### PR TITLE
Bump the critical stack to terraform0.12

### DIFF
--- a/critical/api.wellcomecollection.org/cloudfront.tf
+++ b/critical/api.wellcomecollection.org/cloudfront.tf
@@ -1,7 +1,11 @@
+provider "aws" {
+  alias = "us_east_1"
+}
+
 data "aws_acm_certificate" "api_wc_org" {
   domain   = "${var.cert_domain}.wellcomecollection.org"
   statuses = ["ISSUED"]
-  provider = "aws.us-east-1"
+  provider = aws.us_east_1
 }
 
 locals {
@@ -14,7 +18,7 @@ resource "aws_cloudfront_distribution" "api_root" {
   // root
 
   origin {
-    domain_name = "${var.public_api_bucket_domain_name}"
+    domain_name = var.public_api_bucket_domain_name
     origin_id   = "root"
   }
 
@@ -42,7 +46,7 @@ resource "aws_cloudfront_distribution" "api_root" {
   // catalogue
 
   origin {
-    domain_name = "${local.catalogue_domain_name}"
+    domain_name = local.catalogue_domain_name
     origin_id   = "catalogue_api"
 
     custom_origin_config {
@@ -83,7 +87,7 @@ resource "aws_cloudfront_distribution" "api_root" {
   }
   // storage
   origin {
-    domain_name = "${local.storage_domain_name}"
+    domain_name = local.storage_domain_name
     origin_id   = "storage_api"
 
     custom_origin_config {
@@ -124,7 +128,7 @@ resource "aws_cloudfront_distribution" "api_root" {
   }
   // stacks
   origin {
-    domain_name = "${local.stacks_domain_name}"
+    domain_name = local.stacks_domain_name
     origin_id   = "stacks_api"
 
     custom_origin_config {
@@ -166,7 +170,7 @@ resource "aws_cloudfront_distribution" "api_root" {
 
   // shared config
 
-  comment             = "${var.description}"
+  comment             = var.description
   enabled             = true
   is_ipv6_enabled     = true
   default_root_object = "index.html"
@@ -175,7 +179,7 @@ resource "aws_cloudfront_distribution" "api_root" {
   ]
   price_class = "PriceClass_100"
   viewer_certificate {
-    acm_certificate_arn      = "${data.aws_acm_certificate.api_wc_org.arn}"
+    acm_certificate_arn      = data.aws_acm_certificate.api_wc_org.arn
     minimum_protocol_version = "TLSv1"
     ssl_support_method       = "sni-only"
   }
@@ -186,7 +190,7 @@ resource "aws_cloudfront_distribution" "api_root" {
   }
   logging_config {
     include_cookies = false
-    bucket          = "${var.cf_logging_bucket}"
+    bucket          = var.cf_logging_bucket
     prefix          = "api_root"
   }
 }

--- a/critical/cognito.tf
+++ b/critical/cognito.tf
@@ -1,12 +1,13 @@
 resource "aws_cognito_user_pool" "pool" {
   name = "Wellcome Collection"
 
-  admin_create_user_config = {
+  admin_create_user_config {
     allow_admin_create_user_only = true
   }
 
-  password_policy = {
-    minimum_length = 8
+  password_policy {
+    minimum_length                   = 8
+    temporary_password_validity_days = 7
   }
 }
 
@@ -14,49 +15,47 @@ data "aws_acm_certificate" "auth" {
   domain   = "auth.wellcomecollection.org"
   statuses = ["ISSUED"]
 
-  provider = "aws.us-east-1"
+  provider = aws.us-east-1
 }
 
 resource "aws_cognito_user_pool_domain" "domain" {
   domain          = "auth.wellcomecollection.org"
-  certificate_arn = "${data.aws_acm_certificate.auth.arn}"
-  user_pool_id    = "${aws_cognito_user_pool.pool.id}"
+  certificate_arn = data.aws_acm_certificate.auth.arn
+  user_pool_id    = aws_cognito_user_pool.pool.id
 }
 
 resource "aws_cognito_resource_server" "stacks_api" {
   identifier = "https://api.wellcomecollection.org/stacks/v1"
   name       = "Stacks API V1"
 
-  scope = [
-    {
-      scope_name        = "requests_readwrite"
-      scope_description = "Read and write requests"
-    },
-    {
-      scope_name        = "items_readonly"
-      scope_description = "Read the status of items"
-    },
-  ]
+  scope {
+    scope_name        = "requests_readwrite"
+    scope_description = "Read and write requests"
+  }
 
-  user_pool_id = "${aws_cognito_user_pool.pool.id}"
+  scope {
+    scope_name        = "items_readonly"
+    scope_description = "Read the status of items"
+  }
+
+  user_pool_id = aws_cognito_user_pool.pool.id
 }
 
 resource "aws_cognito_resource_server" "storage_api" {
   identifier = "https://api.wellcomecollection.org/storage/v1"
   name       = "Storage API V1"
 
-  scope = [
-    {
-      scope_name        = "ingests"
-      scope_description = "Read and write ingests"
-    },
-    {
-      scope_name        = "bags"
-      scope_description = "Read bags"
-    },
-  ]
+  scope {
+    scope_name        = "ingests"
+    scope_description = "Read and write ingests"
+  }
 
-  user_pool_id = "${aws_cognito_user_pool.pool.id}"
+  scope {
+    scope_name        = "bags"
+    scope_description = "Read bags"
+  }
+
+  user_pool_id = aws_cognito_user_pool.pool.id
 }
 
 resource "aws_cognito_user_pool_client" "goobi" {
@@ -70,11 +69,13 @@ resource "aws_cognito_user_pool_client" "goobi" {
     "CUSTOM_AUTH_FLOW_ONLY",
   ]
 
-  allowed_oauth_scopes = [
-    "${aws_cognito_resource_server.storage_api.scope_identifiers}",
-    "https://api-stage.wellcomecollection.org/storage/v1/ingests",
-    "https://api-stage.wellcomecollection.org/storage/v1/bags",
-  ]
+  allowed_oauth_scopes = concat(
+    aws_cognito_resource_server.storage_api.scope_identifiers,
+    [
+      "https://api-stage.wellcomecollection.org/storage/v1/ingests",
+      "https://api-stage.wellcomecollection.org/storage/v1/bags",
+    ]
+  )
 
   allowed_oauth_flows_user_pool_client = true
   supported_identity_providers         = ["COGNITO"]
@@ -82,7 +83,7 @@ resource "aws_cognito_user_pool_client" "goobi" {
   generate_secret        = true
   refresh_token_validity = 1
 
-  user_pool_id = "${aws_cognito_user_pool.pool.id}"
+  user_pool_id = aws_cognito_user_pool.pool.id
 }
 
 resource "aws_cognito_user_pool_client" "dds" {
@@ -96,9 +97,7 @@ resource "aws_cognito_user_pool_client" "dds" {
     "CUSTOM_AUTH_FLOW_ONLY",
   ]
 
-  allowed_oauth_scopes = [
-    "${aws_cognito_resource_server.storage_api.scope_identifiers}",
-  ]
+  allowed_oauth_scopes = aws_cognito_resource_server.storage_api.scope_identifiers
 
   allowed_oauth_flows_user_pool_client = true
   supported_identity_providers         = ["COGNITO"]
@@ -106,5 +105,5 @@ resource "aws_cognito_user_pool_client" "dds" {
   generate_secret        = true
   refresh_token_validity = 1
 
-  user_pool_id = "${aws_cognito_user_pool.pool.id}"
+  user_pool_id = aws_cognito_user_pool.pool.id
 }

--- a/critical/config.tf
+++ b/critical/config.tf
@@ -3,5 +3,5 @@ data "aws_ssm_parameter" "admin_cidr_ingress" {
 }
 
 locals {
-  admin_cidr_ingress = "${data.aws_ssm_parameter.admin_cidr_ingress.value}"
+  admin_cidr_ingress = data.aws_ssm_parameter.admin_cidr_ingress.value
 }

--- a/critical/iam.tf
+++ b/critical/iam.tf
@@ -3,11 +3,11 @@
 module "elasticcloud-catalogue" {
   source = "../modules/elasticcloud"
 
-  bucket_name = "${aws_s3_bucket.elasticsearch-snapshots-catalogue.id}"
+  bucket_name = aws_s3_bucket.elasticsearch-snapshots-catalogue.id
   namespace   = "catalogue"
-  pgp_pub_key = "${local.wellcomedigitalplatform_pgp_pub_key}"
+  pgp_pub_key = local.wellcomedigitalplatform_pgp_pub_key
 
   principals = [
-    "${local.aws_platform_principal}"
+    local.aws_platform_principal
   ]
 }

--- a/critical/locals.tf
+++ b/critical/locals.tf
@@ -1,9 +1,9 @@
 locals {
-  account_id                          = "${data.aws_caller_identity.current.account_id}"
+  account_id                          = data.aws_caller_identity.current.account_id
   aws_platform_principal              = "arn:aws:iam::${local.account_id}:root"
-  wellcomedigitalplatform_pgp_pub_key = "${data.template_file.pgp_pub_key.rendered}"
+  wellcomedigitalplatform_pgp_pub_key = data.template_file.pgp_pub_key.rendered
 }
 
 data "template_file" "pgp_pub_key" {
-  template = "${file("${path.module}/wellcomedigitalplatform.pub")}"
+  template = file("${path.module}/wellcomedigitalplatform.pub")
 }

--- a/critical/main.tf
+++ b/critical/main.tf
@@ -1,27 +1,35 @@
 module "api-stage" {
-  source = "api.wellcomecollection.org"
+  source = "./api.wellcomecollection.org"
 
   subdomain   = "api-stage"
   cert_domain = "api"
 
-  public_api_bucket_domain_name = "${aws_s3_bucket.public_api.bucket_domain_name}"
+  public_api_bucket_domain_name = aws_s3_bucket.public_api.bucket_domain_name
 
   description = "Collection APIs staging"
 
-  cf_logging_bucket = "${aws_s3_bucket.api_root_cf_logs.bucket_domain_name}"
+  cf_logging_bucket = aws_s3_bucket.api_root_cf_logs.bucket_domain_name
+
+  providers = {
+    aws.us_east_1 = aws.us-east-1
+  }
 }
 
 module "api" {
-  source = "api.wellcomecollection.org"
+  source = "./api.wellcomecollection.org"
 
   subdomain   = "api"
   cert_domain = "api"
 
-  public_api_bucket_domain_name = "${aws_s3_bucket.public_api.bucket_domain_name}"
+  public_api_bucket_domain_name = aws_s3_bucket.public_api.bucket_domain_name
 
   description = "Collection APIs production"
 
-  cf_logging_bucket = "${aws_s3_bucket.api_root_cf_logs.bucket_domain_name}"
+  cf_logging_bucket = aws_s3_bucket.api_root_cf_logs.bucket_domain_name
+
+  providers = {
+    aws.us_east_1 = aws.us-east-1
+  }
 }
 
 // S3 origin for redirect to developers.wellcomecollection.org
@@ -52,9 +60,9 @@ EOF
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket       = "${aws_s3_bucket.public_api.bucket}"
+  bucket       = aws_s3_bucket.public_api.bucket
   key          = "index.html"
   source       = "${path.module}/s3_objects/index.html"
-  etag         = "${md5(file("${path.module}/s3_objects/index.html"))}"
+  etag         = md5(file("${path.module}/s3_objects/index.html"))
   content_type = "text/html"
 }

--- a/critical/outputs.tf
+++ b/critical/outputs.tf
@@ -1,37 +1,37 @@
 # Cognito
 
 output "cognito_user_pool_arn" {
-  value = "${aws_cognito_user_pool.pool.arn}"
+  value = aws_cognito_user_pool.pool.arn
 }
 
 output "cognito_storage_api_identifier" {
-  value = "${aws_cognito_resource_server.storage_api.identifier}"
+  value = aws_cognito_resource_server.storage_api.identifier
 }
 
 output "cognito_stacks_api_identifier" {
-  value = "${aws_cognito_resource_server.stacks_api.identifier}"
+  value = aws_cognito_resource_server.stacks_api.identifier
 }
 
 # Misc
 
 output "admin_cidr_ingress" {
-  value = "${local.admin_cidr_ingress}"
+  value = local.admin_cidr_ingress
 }
 
 # Elasticcloud
 
 output "elasticcloud_access_id" {
-  value = "${module.elasticcloud-catalogue.elasticcloud_access_id}"
+  value = module.elasticcloud-catalogue.elasticcloud_access_id
 }
 
 output "elasticcloud_access_secret" {
-  value = "${module.elasticcloud-catalogue.elasticcloud_access_secret}"
+  value = module.elasticcloud-catalogue.elasticcloud_access_secret
 }
 
 output "elasticcloud_readonly_role_arn" {
-  value = "${module.elasticcloud-catalogue.elasticcloud_readonly_role_arn}"
+  value = module.elasticcloud-catalogue.elasticcloud_readonly_role_arn
 }
 
 output "elasticcloud_readonly_role_name" {
-  value = "${module.elasticcloud-catalogue.elasticcloud_readonly_role_name}"
+  value = module.elasticcloud-catalogue.elasticcloud_readonly_role_name
 }

--- a/critical/provider.tf
+++ b/critical/provider.tf
@@ -1,6 +1,6 @@
 provider "aws" {
-  region  = "${var.aws_region}"
-  version = "1.46.0"
+  region  = var.aws_region
+  version = "~> 2.7"
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-admin"
@@ -12,7 +12,7 @@ provider "aws" {
 
   region = "us-east-1"
 
-  version = "1.46.0"
+  version = "~> 2.7"
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-admin"

--- a/modules/elasticcloud/main.tf
+++ b/modules/elasticcloud/main.tf
@@ -1,12 +1,12 @@
 # elasticcloud snapshot reader
 
 resource "aws_iam_role" "elasticcloud-snapshot-readonly" {
-  assume_role_policy = "${data.aws_iam_policy_document.assume-elasticcloud-snapshot-readonly.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume-elasticcloud-snapshot-readonly.json
 }
 
 resource "aws_iam_role_policy" "elasticcloud-snapshot-readonly" {
-  policy = "${data.aws_iam_policy_document.elasticcloud-snapshot-readonly.json}"
-  role   = "${aws_iam_role.elasticcloud-snapshot-readonly.id}"
+  policy = data.aws_iam_policy_document.elasticcloud-snapshot-readonly.json
+  role   = aws_iam_role.elasticcloud-snapshot-readonly.id
 }
 
 data "aws_iam_policy_document" "elasticcloud-snapshot-readonly" {
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "elasticcloud-snapshot-readonly" {
       "s3:Get*"
     ]
     resources = [
-      "${data.aws_s3_bucket.elasticcloud-snapshots.arn}",
+      data.aws_s3_bucket.elasticcloud-snapshots.arn,
       "${data.aws_s3_bucket.elasticcloud-snapshots.arn}/*"
     ]
   }
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "assume-elasticcloud-snapshot-readonly" {
   statement {
     actions = ["sts:AssumeRole"]
     principals {
-      identifiers = ["${var.principals}"]
+      identifiers = var.principals
       type        = "AWS"
     }
   }
@@ -39,25 +39,25 @@ resource "aws_iam_user" "elasticcloud" {
 }
 
 resource "aws_iam_access_key" "elasticcloud" {
-  user    = "${aws_iam_user.elasticcloud.name}"
-  pgp_key = "${var.pgp_pub_key}"
+  user    = aws_iam_user.elasticcloud.name
+  pgp_key = var.pgp_pub_key
 }
 
 resource "aws_iam_user_policy" "elasticcloud" {
-  user = "${aws_iam_user.elasticcloud.name}"
+  user = aws_iam_user.elasticcloud.name
 
-  policy = "${data.aws_iam_policy_document.elasticcloud.json}"
+  policy = data.aws_iam_policy_document.elasticcloud.json
 }
 
 data "aws_s3_bucket" "elasticcloud-snapshots" {
-  bucket = "${var.bucket_name}"
+  bucket = var.bucket_name
 }
 
 data "aws_iam_policy_document" "elasticcloud" {
   statement {
     actions = ["s3:*"]
     resources = [
-      "${data.aws_s3_bucket.elasticcloud-snapshots.arn}",
+      data.aws_s3_bucket.elasticcloud-snapshots.arn,
       "${data.aws_s3_bucket.elasticcloud-snapshots.arn}/*"
     ]
   }

--- a/modules/elasticcloud/outputs.tf
+++ b/modules/elasticcloud/outputs.tf
@@ -1,15 +1,15 @@
 output "elasticcloud_access_id" {
-  value = "${aws_iam_access_key.elasticcloud.id}"
+  value = aws_iam_access_key.elasticcloud.id
 }
 
 output "elasticcloud_access_secret" {
-  value = "${aws_iam_access_key.elasticcloud.encrypted_secret}"
+  value = aws_iam_access_key.elasticcloud.encrypted_secret
 }
 
 output "elasticcloud_readonly_role_arn" {
-  value = "${aws_iam_role.elasticcloud-snapshot-readonly.arn}"
+  value = aws_iam_role.elasticcloud-snapshot-readonly.arn
 }
 
 output "elasticcloud_readonly_role_name" {
-  value = "${aws_iam_role.elasticcloud-snapshot-readonly.name}"
+  value = aws_iam_role.elasticcloud-snapshot-readonly.name
 }

--- a/modules/elasticcloud/variables.tf
+++ b/modules/elasticcloud/variables.tf
@@ -2,5 +2,5 @@ variable "namespace" {}
 variable "bucket_name" {}
 variable "pgp_pub_key" {}
 variable "principals" {
-  type = "list"
+  type = list(string)
 }


### PR DESCRIPTION
This gets the stack to plan cleanly with 0.12 (no deprecation warnings or errors).

I haven't applied this because it wants to change the DDS Cognito user pool, and I'm not sure why (or how the existing Terraform could ever have done this):

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_cognito_user_pool_client.dds will be updated in-place
  ~ resource "aws_cognito_user_pool_client" "dds" {
        allowed_oauth_flows                  = [
            "client_credentials",
        ]
        allowed_oauth_flows_user_pool_client = true
      ~ allowed_oauth_scopes                 = [
          - "https://api-stage.wellcomecollection.org/storage/v1/bags",
          - "https://api-stage.wellcomecollection.org/storage/v1/ingests",
            "https://api.wellcomecollection.org/storage/v1/bags",
            "https://api.wellcomecollection.org/storage/v1/ingests",
        ]
        callback_urls                        = []
        client_secret                        = "b8i9i5f6nukgbef5jkbil2fo5hmi84ug67nv9sp6vivvat7vhur"
      ~ explicit_auth_flows                  = [
          - "ALLOW_CUSTOM_AUTH",
          - "ALLOW_REFRESH_TOKEN_AUTH",
          + "CUSTOM_AUTH_FLOW_ONLY",
        ]
        generate_secret                      = true
        id                                   = "71jnbmd926s828gerpu81vt9gm"
        logout_urls                          = []
        name                                 = "DDS"
        read_attributes                      = []
        refresh_token_validity               = 1
        supported_identity_providers         = [
            "COGNITO",
        ]
        user_pool_id                         = "eu-west-1_h3qKmdYyD"
        write_attributes                     = []
    }

  # aws_s3_bucket_object.object will be updated in-place
  ~ resource "aws_s3_bucket_object" "object" {
        acl           = "private"
        bucket        = "wellcomecollection-public-api"
        content_type  = "text/html"
        etag          = "1926c572db8e909135f7cef9d15b558c"
      + force_destroy = false
        id            = "index.html"
        key           = "index.html"
        metadata      = {}
      ~ source        = "/Users/k/workspace/platform/infrastructure/terraform/critical/s3_objects/index.html" -> "./s3_objects/index.html"
        storage_class = "STANDARD"
        tags          = {}
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```

Is it okay to roll change the Cognito user pool this way, or should the Terraform be updated to match?