### PR TITLE
Add a non-default VPC for the experience account

### DIFF
--- a/shared/vpcs.tf
+++ b/shared/vpcs.tf
@@ -20,13 +20,14 @@ module "catalogue_vpc_delta" {
   cidrsubnet_newbits_private = "2"
 }
 
-# Used by:
-# - Storage service
-
 locals {
   storage_cidr_block_vpc     = "172.30.0.0/16"
   storage_cidr_block_public  = "172.30.0.0/17"
   storage_cidr_block_private = "172.30.128.0/17"
+
+  monitoring_cidr_block_vpc     = "172.28.0.0/16"
+  monitoring_cidr_block_public  = "172.28.0.0/17"
+  monitoring_cidr_block_private = "172.28.128.0/17"
 
   datascience_cidr_block_vpc     = "172.17.0.0/16"
   datascience_cidr_block_public  = "172.17.0.0/17"
@@ -35,6 +36,10 @@ locals {
   catalogue_cidr_block_vpc     = "172.18.0.0/16"
   catalogue_cidr_block_public  = "172.18.0.0/17"
   catalogue_cidr_block_private = "172.18.128.0/17"
+
+  experience_cidr_block_vpc     = "172.19.0.0/16"
+  experience_cidr_block_public  = "172.19.0.0/17"
+  experience_cidr_block_private = "172.19.128.0/17"
 }
 
 module "storage_vpc" {
@@ -66,14 +71,14 @@ module "monitoring_vpc_delta" {
 
   name = "monitoring-172-28-0-0-16"
 
-  cidr_block_vpc = "172.28.0.0/16"
+  cidr_block_vpc = local.monitoring_cidr_block_vpc
 
   public_az_count           = "3"
-  cidr_block_public         = "172.28.0.0/17"
+  cidr_block_public         = local.monitoring_cidr_block_public
   cidrsubnet_newbits_public = "2"
 
   private_az_count           = "3"
-  cidr_block_private         = "172.28.128.0/17"
+  cidr_block_private         = local.monitoring_cidr_block_private
   cidrsubnet_newbits_private = "2"
 }
 
@@ -122,5 +127,28 @@ module "catalogue_vpc" {
 
   providers = {
     aws = aws.catalogue
+  }
+}
+
+# Used by:
+# - wellcomecollection.org
+
+module "experience_vpc" {
+  source = "./modules/public-private-igw"
+
+  name = "experience-172-19-0-0-16"
+
+  cidr_block_vpc = local.experience_cidr_block_vpc
+
+  public_az_count           = "3"
+  cidr_block_public         = local.experience_cidr_block_public
+  cidrsubnet_newbits_public = "2"
+
+  private_az_count           = "3"
+  cidr_block_private         = local.experience_cidr_block_private
+  cidrsubnet_newbits_private = "2"
+
+  providers = {
+    aws = aws.experience
   }
 }


### PR DESCRIPTION
The experience AWS account is using the default VPC which is [not recommended](https://lmgtfy.com/?q=aws+why+not+use+default+vpc).

