### PR TITLE
Manage the digitisation S3 buckets in Terraform

### DIFF
--- a/accounts/iam_roles.tf
+++ b/accounts/iam_roles.tf
@@ -32,15 +32,23 @@ data "aws_iam_policy_document" "workflow_support" {
     ]
 
     resources = [
+      # Buckets in the digitisation account
       "arn:aws:s3:::wellcomecollection-archivematica-transfer-source",
       "arn:aws:s3:::wellcomecollection-archivematica-transfer-source/*",
       "arn:aws:s3:::wellcomecollection-archivematica-staging-transfer-source",
       "arn:aws:s3:::wellcomecollection-archivematica-staging-transfer-source/*",
+      "arn:aws:s3:::wellcomecollection-client-transfer-pre2020",
+      "arn:aws:s3:::wellcomecollection-client-transfer-pre2020/*",
+      "arn:aws:s3:::wellcomecollection-digitisation-av",
+      "arn:aws:s3:::wellcomecollection-digitisation-av/*",
 
+      # Other buckets
       "arn:aws:s3:::wellcomecollection-client-transfer",
       "arn:aws:s3:::wellcomecollection-client-transfer/*",
       "arn:aws:s3:::wellcomecollection-workflow-upload",
       "arn:aws:s3:::wellcomecollection-workflow-upload/*",
+      "arn:aws:s3:::wellcomecollection-workflow-stage-upload",
+      "arn:aws:s3:::wellcomecollection-workflow-stage-upload/*",
       "arn:aws:s3:::wellcomecollection-editorial-photography",
       "arn:aws:s3:::wellcomecollection-editorial-photography/*",
     ]

--- a/digitisation_infra/locals.tf
+++ b/digitisation_infra/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  workflow_account_id = "299497370133"
+}

--- a/digitisation_infra/provider.tf
+++ b/digitisation_infra/provider.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region  = "eu-west-1"
+  version = "~> 2.7"
+
+  assume_role {
+    role_arn = "arn:aws:iam::404315009621:role/digitisation-admin"
+  }
+}

--- a/digitisation_infra/s3_client_transfer.tf
+++ b/digitisation_infra/s3_client_transfer.tf
@@ -1,0 +1,3 @@
+resource "aws_s3_bucket" "client_transfer" {
+  bucket = "wellcomecollection-client-transfer-pre2020"
+}

--- a/digitisation_infra/s3_client_transfer.tf
+++ b/digitisation_infra/s3_client_transfer.tf
@@ -1,3 +1,30 @@
 resource "aws_s3_bucket" "client_transfer" {
   bucket = "wellcomecollection-client-transfer-pre2020"
 }
+
+resource "aws_s3_bucket_policy" "client_transfer" {
+  bucket = aws_s3_bucket.client_transfer.id
+  policy = data.aws_iam_policy_document.client_transfer_readonly.json
+}
+
+data "aws_iam_policy_document" "client_transfer_readonly" {
+  statement {
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.client_transfer.arn}",
+      "${aws_s3_bucket.client_transfer.arn}/*",
+    ]
+
+    principals {
+      identifiers = [
+        local.workflow_account_id,
+      ]
+
+      type = "AWS"
+    }
+  }
+}

--- a/digitisation_infra/s3_delivery_service.tf
+++ b/digitisation_infra/s3_delivery_service.tf
@@ -1,0 +1,3 @@
+resource "aws_s3_bucket" "delivery_service" {
+  bucket = "wellcomecollection-delivery-service"
+}

--- a/digitisation_infra/s3_digitisation_av.tf
+++ b/digitisation_infra/s3_digitisation_av.tf
@@ -1,0 +1,13 @@
+resource "aws_s3_bucket" "digitisation_av" {
+  bucket = "wellcomecollection-digitisation-av"
+
+  lifecycle_rule {
+    id      = "Transition to Infrequent Access"
+    enabled = true
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+  }
+}

--- a/digitisation_infra/s3_digitisation_av.tf
+++ b/digitisation_infra/s3_digitisation_av.tf
@@ -11,3 +11,31 @@ resource "aws_s3_bucket" "digitisation_av" {
     }
   }
 }
+
+
+resource "aws_s3_bucket_policy" "digitisation_av" {
+  bucket = aws_s3_bucket.digitisation_av.id
+  policy = data.aws_iam_policy_document.digitisation_av_readonly.json
+}
+
+data "aws_iam_policy_document" "digitisation_av_readonly" {
+  statement {
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.digitisation_av.arn}",
+      "${aws_s3_bucket.digitisation_av.arn}/*",
+    ]
+
+    principals {
+      identifiers = [
+        local.workflow_account_id,
+      ]
+
+      type = "AWS"
+    }
+  }
+}

--- a/digitisation_infra/s3_digitisation_transfer.tf
+++ b/digitisation_infra/s3_digitisation_transfer.tf
@@ -1,0 +1,3 @@
+resource "aws_s3_bucket" "digitisation_transfer" {
+  bucket = "wellcomecollection-digitisation-transfer"
+}

--- a/digitisation_infra/terraform.tf
+++ b/digitisation_infra/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "s3" {
+    role_arn = "arn:aws:iam::404315009621:role/digitisation-developer"
+
+    bucket         = "wellcomedigitisation-infra"
+    key            = "terraform/platform-infrastructure/digitisation_infra.tfstate"
+    dynamodb_table = "terraform-locktable"
+    region         = "eu-west-1"
+  }
+}


### PR DESCRIPTION
As far as I can tell, these buckets were being managed by hand. Boo!

This adds:

* Terraform definitions for the existing buckets
* Read permissions for workflow users to get to certain buckets (in particular Harkiran and the A/V buckets)

Closes https://github.com/wellcomecollection/platform/issues/4401