### PR TITLE
Add an explicit document type for the fluentbit container

### DIFF
--- a/containers/fluentbit/extra.conf
+++ b/containers/fluentbit/extra.conf
@@ -13,3 +13,10 @@
     Logstash_Format On
     Logstash_Prefix firelens
     tls             On
+
+    # By default, Fluentbit sends the document type "flb_type".  Elasticsearch
+    # is gradually deprecating multiple types per index, and the index template
+    # for our firelens indexes specifies the type "_doc".
+    #
+    # See https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch#faq-multiple-types
+    Type _doc


### PR DESCRIPTION
This wasn't caught when setting up the logging because we didn't have an index template.

The index templates require that the document type is `_doc` – if it’s possible to change that, it's very well hidden. Easier to lean into the ES way of doing things, and ditch the custom document type.

This change is published and running in the storage staging.