### PR TITLE
Adds new Route53 management role

### DIFF
--- a/accounts/rolesets.tf
+++ b/accounts/rolesets.tf
@@ -66,7 +66,9 @@ module "super_dev_roleset" {
     module.s3_releases_scala_typesafe.role_arn,
     module.s3_releases_scala_fixtures.role_arn,
 
-    # Route 53 - drupalinfra
+    # Route 53
+    "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update",
+    # DERECATED
     "arn:aws:iam::250790015188:role/wellcomecollection-assume_role_hosted_zone_update",
   ]
 }

--- a/accounts/rolesets.tf
+++ b/accounts/rolesets.tf
@@ -68,7 +68,7 @@ module "super_dev_roleset" {
 
     # Route 53
     "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update",
-    # DERECATED
+    # DEPRECATED
     "arn:aws:iam::250790015188:role/wellcomecollection-assume_role_hosted_zone_update",
   ]
 }


### PR DESCRIPTION
Hosted zone records for wellcomecollection.org are moving to a new account, access to that new account is provisioned here.

Applied and tested.

Part of https://github.com/wellcometrust/wellcome-dns-infra/pull/120