### PR TITLE
Add an IAM users for accessing MIRO images

### DIFF
--- a/assets/iam_users.tf
+++ b/assets/iam_users.tf
@@ -1,0 +1,39 @@
+# This user was created for the cataloguers to view the MIRO images kept
+# in wellcomecollection-assets-workingstorage.  They use the access credentials
+# to set up a "site" in FileZilla Pro, and browse the images there.
+resource "aws_iam_user" "cataloguers_wellcome_images" {
+  name = "cataloguers_wellcome_images"
+
+  tags = local.default_tags
+}
+
+resource "aws_iam_access_key" "cataloguers_wellcome_images" {
+  user    = aws_iam_user.cataloguers_wellcome_images.name
+}
+
+data "aws_iam_policy_document" "allow_miro_access" {
+  statement {
+    actions = [
+      "s3:List*",
+    ]
+
+    resources = [
+      aws_s3_bucket.working_storage.arn,
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:Get*",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.working_storage.arn}/miro/*",
+    ]
+  }
+}
+
+resource "aws_iam_user_policy" "cataloguers_wellcome_images" {
+  user   = aws_iam_user.cataloguers_wellcome_images.name
+  policy = data.aws_iam_policy_document.allow_miro_access.json
+}

--- a/assets/iam_users.tf
+++ b/assets/iam_users.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "allow_miro_access" {
     ]
 
     resources = [
-      aws_s3_bucket.working_storage.arn,
+      "*",
     ]
   }
 

--- a/assets/provider.tf
+++ b/assets/provider.tf
@@ -1,0 +1,14 @@
+locals {
+  default_tags = {
+    TerraformConfigurationURL = "https://github.com/wellcomecollection/platform-infrastructure/tree/master/assets"
+  }
+}
+
+provider "aws" {
+  region  = var.aws_region
+  version = "~> 2.7"
+
+  assume_role {
+    role_arn = "arn:aws:iam::760097843905:role/platform-admin"
+  }
+}

--- a/assets/s3_workingstorage.tf
+++ b/assets/s3_workingstorage.tf
@@ -33,6 +33,8 @@ resource "aws_s3_bucket" "working_storage" {
 
     enabled = true
   }
+
+  tags = local.default_tags
 }
 
 resource "aws_s3_bucket_policy" "working_storage" {
@@ -44,7 +46,6 @@ locals {
   digitisation_account_id = "404315009621"
   workflow_account_id     = "299497370133"
 }
-
 
 data "aws_iam_policy_document" "working_storage" {
 

--- a/assets/terraform.tf
+++ b/assets/terraform.tf
@@ -10,12 +10,3 @@ terraform {
     region         = "eu-west-1"
   }
 }
-
-provider "aws" {
-  region  = var.aws_region
-  version = "~> 2.7"
-
-  assume_role {
-    role_arn = "arn:aws:iam::760097843905:role/platform-admin"
-  }
-}


### PR DESCRIPTION
I've sent the access/secret key pair to the cataloguers to set up as a site in FileZilla Pro.

Closes https://github.com/wellcomecollection/platform/issues/4567