### PR TITLE
CI for each repo should assume role

### DIFF
--- a/accounts/account.tf
+++ b/accounts/account.tf
@@ -1,3 +1,7 @@
+locals {
+  sbt_releases_bucket_arn = "arn:aws:s3:::releases.mvn-repo.wellcomecollection.org"
+}
+
 # Parent Platform account
 
 module "aws_account" {
@@ -11,6 +15,9 @@ module "aws_account" {
   principals = [
     local.aws_principal,
   ]
+
+  infra_bucket_arn        = "arn:aws:s3:::wellcomecollection-platform-infra"
+  sbt_releases_bucket_arn = local.sbt_releases_bucket_arn
 }
 
 module "account_federation" {
@@ -40,6 +47,9 @@ module "catalogue_account" {
   principals = [
     local.aws_principal
   ]
+
+  infra_bucket_arn        = "arn:aws:s3:::wellcomecollection-catalogue-infra-delta"
+  sbt_releases_bucket_arn = local.sbt_releases_bucket_arn
 }
 
 module "workflow_account" {
@@ -53,6 +63,9 @@ module "workflow_account" {
   principals = [
     local.aws_principal
   ]
+
+  infra_bucket_arn        = "arn:aws:s3:::wellcomecollection-workflow-infra"
+  sbt_releases_bucket_arn = local.sbt_releases_bucket_arn
 }
 
 module "storage_account" {
@@ -66,19 +79,9 @@ module "storage_account" {
   principals = [
     local.aws_principal
   ]
-}
 
-module "digitisation_account" {
-  source = "./modules/account/aws"
-
-  providers = {
-    aws = aws.digitisation
-  }
-
-  prefix = "digitisation"
-  principals = [
-    local.aws_principal
-  ]
+  infra_bucket_arn        = "arn:aws:s3:::wellcomecollection-storage-infra"
+  sbt_releases_bucket_arn = local.sbt_releases_bucket_arn
 }
 
 module "data_account" {
@@ -92,6 +95,9 @@ module "data_account" {
   principals = [
     local.aws_principal
   ]
+
+  infra_bucket_arn        = "arn:aws:s3:::wellcomecollection-datascience-infra"
+  sbt_releases_bucket_arn = local.sbt_releases_bucket_arn
 }
 
 module "reporting_account" {
@@ -105,6 +111,9 @@ module "reporting_account" {
   principals = [
     local.aws_principal
   ]
+
+  infra_bucket_arn        = "arn:aws:s3:::wellcomecollection-reporting-infra"
+  sbt_releases_bucket_arn = local.sbt_releases_bucket_arn
 }
 
 module "experience_account" {
@@ -119,6 +128,24 @@ module "experience_account" {
   principals = [
     local.aws_principal
   ]
+
+  infra_bucket_arn        = "arn:aws:s3:::wellcomecollection-experience-infra"
+  sbt_releases_bucket_arn = local.sbt_releases_bucket_arn
+}
+
+module "digitisation_account" {
+  source = "./modules/account/aws"
+
+  providers = {
+    aws = aws.digitisation
+  }
+
+  prefix = "digitisation"
+  principals = [
+    local.aws_principal
+  ]
+
+  sbt_releases_bucket_arn = local.sbt_releases_bucket_arn
 }
 
 module "digirati_account" {
@@ -133,4 +160,6 @@ module "digirati_account" {
   principals = [
     local.aws_principal
   ]
+
+  sbt_releases_bucket_arn = local.sbt_releases_bucket_arn
 }

--- a/accounts/modules/account/aws/main.tf
+++ b/accounts/modules/account/aws/main.tf
@@ -93,3 +93,22 @@ module "publisher_role_policy" {
   source    = "../../role_policies/publisher"
   role_name = module.publisher_role.name
 }
+
+# CI role
+
+module "ci_role" {
+  source = "../../assumable_role/aws"
+  name   = "${var.prefix}-ci"
+
+  max_session_duration_in_seconds = var.max_session_duration_in_seconds
+
+  principals = var.principals
+}
+
+module "ci_role_policy" {
+  source    = "../../role_policies/ci"
+  role_name = module.ci_role.name
+
+  infra_bucket_arn        = var.infra_bucket_arn
+  sbt_releases_bucket_arn = var.sbt_releases_bucket_arn
+}

--- a/accounts/modules/account/aws/outputs.tf
+++ b/accounts/modules/account/aws/outputs.tf
@@ -21,3 +21,7 @@ output "read_only_role_arn" {
 output "publisher_role_arn" {
   value = module.publisher_role.arn
 }
+
+output "ci_role_arn" {
+  value = module.ci_role.arn
+}

--- a/accounts/modules/account/aws/variables.tf
+++ b/accounts/modules/account/aws/variables.tf
@@ -8,3 +8,11 @@ variable "max_session_duration_in_seconds" {
   # Default is one hour
   default = "3600"
 }
+
+variable "infra_bucket_arn" {
+  type = string
+  default = ""
+}
+variable "sbt_releases_bucket_arn" {
+  type = string
+}

--- a/accounts/modules/role_policies/ci/main.tf
+++ b/accounts/modules/role_policies/ci/main.tf
@@ -1,0 +1,4 @@
+resource "aws_iam_role_policy" "ci_permissions" {
+  role   = var.role_name
+  policy = data.aws_iam_policy_document.ci_permissions.json
+}

--- a/accounts/modules/role_policies/ci/variables.tf
+++ b/accounts/modules/role_policies/ci/variables.tf
@@ -1,0 +1,10 @@
+variable "role_name" {
+  type = string
+}
+variable "sbt_releases_bucket_arn" {
+  type = string
+}
+variable "infra_bucket_arn" {
+  type = string
+  default = ""
+}

--- a/accounts/outputs.tf
+++ b/accounts/outputs.tf
@@ -20,6 +20,24 @@ output "publisher_role_arn" {
   value = module.aws_account.publisher_role_arn
 }
 
+output "platform_read_only_role_arn" {
+  value = module.aws_account.read_only_role_arn
+}
+
+output "ci_role_arn" {
+  value = {
+    platform: module.aws_account.ci_role_arn,
+    workflow: module.workflow_account.ci_role_arn,
+    data: module.data_account.ci_role_arn,
+    catalogue: module.catalogue_account.ci_role_arn,
+    storage: module.storage_account.ci_role_arn,
+    data: module.data_account.ci_role_arn,
+    digirati: module.digirati_account.ci_role_arn,
+    reporting: module.reporting_account.ci_role_arn,
+    digitisation: module.digitisation_account.ci_role_arn,
+  }
+}
+
 output "s3_releases_scala_catalogue_client" {
   value = module.s3_releases_scala_catalogue_client.role_arn
 }

--- a/accounts/rolesets.tf
+++ b/accounts/rolesets.tf
@@ -61,6 +61,16 @@ module "super_dev_roleset" {
     # CI Roles
     module.aws_account.publisher_role_arn,
 
+    module.aws_account.ci_role_arn,
+    module.workflow_account.ci_role_arn,
+    module.data_account.ci_role_arn,
+    module.catalogue_account.ci_role_arn,
+    module.storage_account.ci_role_arn,
+    module.data_account.ci_role_arn,
+    module.digirati_account.ci_role_arn,
+    module.reporting_account.ci_role_arn,
+    module.digitisation_account.ci_role_arn,
+
     aws_iam_role.s3_scala_releases_read.arn,
     module.s3_releases_scala_sierra_client.role_arn,
     module.s3_releases_scala_catalogue_client.role_arn,
@@ -126,6 +136,16 @@ module "dev_roleset" {
 
     # CI Roles
     module.aws_account.publisher_role_arn,
+
+    module.aws_account.ci_role_arn,
+    module.workflow_account.ci_role_arn,
+    module.data_account.ci_role_arn,
+    module.catalogue_account.ci_role_arn,
+    module.storage_account.ci_role_arn,
+    module.data_account.ci_role_arn,
+    module.digirati_account.ci_role_arn,
+    module.reporting_account.ci_role_arn,
+    module.digitisation_account.ci_role_arn,
 
     module.s3_releases_scala_fixtures.role_arn,
     module.s3_releases_scala_json.role_arn,

--- a/builds/terraform/locals.tf
+++ b/builds/terraform/locals.tf
@@ -5,5 +5,6 @@ locals {
 
   lambda_error_alarm_arn = data.terraform_remote_state.shared_infra.outputs.lambda_error_alarm_arn
 
-  platform_read_only_role = "arn:aws:iam::${local.platform_account_id}:role/platform-read_only"
+  platform_read_only_role_arn = data.terraform_remote_state.accounts.outputs.platform_read_only_role_arn
+  ci_role_arn                 = data.terraform_remote_state.accounts.outputs.ci_role_arn
 }

--- a/builds/terraform/main.tf
+++ b/builds/terraform/main.tf
@@ -10,7 +10,10 @@ module "catalogue_repo" {
     aws_sns_topic.lambda_pushes.arn,
   ]
 
-  platform_read_only_role = local.platform_read_only_role
+  assumable_ci_roles = [
+    local.platform_read_only_role_arn,
+    local.ci_role_arn["catalogue"]
+  ]
 
   providers = {
     aws    = aws.platform
@@ -30,7 +33,10 @@ module "storage_repo" {
     aws_sns_topic.lambda_pushes.arn,
   ]
 
-  platform_read_only_role = local.platform_read_only_role
+  assumable_ci_roles = [
+    local.platform_read_only_role_arn,
+    local.ci_role_arn["storage"]
+  ]
 
   providers = {
     aws    = aws.storage
@@ -50,7 +56,10 @@ module "stacks_service_repo" {
     aws_sns_topic.lambda_pushes.arn,
   ]
 
-  platform_read_only_role = local.platform_read_only_role
+  assumable_ci_roles = [
+    local.platform_read_only_role_arn,
+    local.ci_role_arn["catalogue"]
+  ]
 
   providers = {
     aws    = aws.catalogue
@@ -70,7 +79,10 @@ module "archivematica_infrastructure_repo" {
     aws_sns_topic.lambda_pushes.arn,
   ]
 
-  platform_read_only_role = local.platform_read_only_role
+  assumable_ci_roles = [
+    local.platform_read_only_role_arn,
+    local.ci_role_arn["workflow"]
+  ]
 
   providers = {
     aws    = aws.workflow
@@ -90,7 +102,10 @@ module "loris_infrastructure_repo" {
     aws_sns_topic.lambda_pushes.arn,
   ]
 
-  platform_read_only_role = local.platform_read_only_role
+  assumable_ci_roles = [
+    local.platform_read_only_role_arn,
+    local.ci_role_arn["platform"]
+  ]
 
   providers = {
     aws    = aws.platform
@@ -113,7 +128,10 @@ module "scala_libs" {
 
   bucket_arn = aws_s3_bucket.releases.arn
 
-  platform_read_only_role = local.platform_read_only_role
+  assumable_ci_roles = [
+    local.platform_read_only_role_arn,
+    local.ci_role_arn["platform"]
+  ]
 
   providers = {
     aws    = aws.platform
@@ -129,7 +147,10 @@ module "scala_json" {
   "json"]
   bucket_arn = aws_s3_bucket.releases.arn
 
-  platform_read_only_role = local.platform_read_only_role
+  assumable_ci_roles = [
+    local.platform_read_only_role_arn,
+    local.ci_role_arn["platform"]
+  ]
 
   providers = {
     aws    = aws.platform
@@ -145,7 +166,10 @@ module "scala_storage" {
   "storage"]
   bucket_arn = aws_s3_bucket.releases.arn
 
-  platform_read_only_role = local.platform_read_only_role
+  assumable_ci_roles = [
+    local.platform_read_only_role_arn,
+    local.ci_role_arn["platform"]
+  ]
 
   providers = {
     aws    = aws.platform
@@ -161,7 +185,10 @@ module "scala_monitoring" {
   "monitoring"]
   bucket_arn = aws_s3_bucket.releases.arn
 
-  platform_read_only_role = local.platform_read_only_role
+  assumable_ci_roles = [
+    local.platform_read_only_role_arn,
+    local.ci_role_arn["platform"]
+  ]
 
   providers = {
     aws    = aws.platform
@@ -177,7 +204,10 @@ module "scala_messaging" {
   "messaging"]
   bucket_arn = aws_s3_bucket.releases.arn
 
-  platform_read_only_role = local.platform_read_only_role
+  assumable_ci_roles = [
+    local.platform_read_only_role_arn,
+    local.ci_role_arn["platform"]
+  ]
 
   providers = {
     aws    = aws.platform
@@ -193,7 +223,10 @@ module "scala_fixtures" {
   "fixtures"]
   bucket_arn = aws_s3_bucket.releases.arn
 
-  platform_read_only_role = local.platform_read_only_role
+  assumable_ci_roles = [
+    local.platform_read_only_role_arn,
+    local.ci_role_arn["platform"]
+  ]
 
   providers = {
     aws    = aws.platform
@@ -210,7 +243,10 @@ module "scala_typesafe" {
   repo_name  = "wellcome-typesafe-app"
   bucket_arn = aws_s3_bucket.releases.arn
 
-  platform_read_only_role = local.platform_read_only_role
+  assumable_ci_roles = [
+    local.platform_read_only_role_arn,
+    local.ci_role_arn["platform"]
+  ]
 
   providers = {
     aws    = aws.platform
@@ -228,7 +264,10 @@ module "scala_sierra" {
 
   bucket_arn = aws_s3_bucket.releases.arn
 
-  platform_read_only_role = local.platform_read_only_role
+  assumable_ci_roles = [
+    local.platform_read_only_role_arn,
+    local.ci_role_arn["platform"]
+  ]
 
   providers = {
     aws    = aws.platform

--- a/builds/terraform/platform/variables.tf
+++ b/builds/terraform/platform/variables.tf
@@ -1,8 +1,9 @@
 variable "repo_name" {}
 variable "infra_bucket_arn" {}
 variable "sbt_releases_bucket_arn" {}
-variable "platform_read_only_role" {}
-
+variable "assumable_ci_roles" {
+  type = list(string)
+}
 variable "publish_topics" {
   type = list(string)
 }

--- a/builds/terraform/scala_library/iam_policy_document.tf
+++ b/builds/terraform/scala_library/iam_policy_document.tf
@@ -1,7 +1,7 @@
 data "aws_iam_policy_document" "travis_permissions" {
   statement {
     actions   = ["sts:AssumeRole"]
-    resources = [var.platform_read_only_role]
+    resources = var.assumable_ci_roles
   }
 
   dynamic "statement" {

--- a/builds/terraform/scala_library/variables.tf
+++ b/builds/terraform/scala_library/variables.tf
@@ -17,4 +17,6 @@ variable "lib_names" {
   type = list(string)
 }
 
-variable "platform_read_only_role" {}
+variable "assumable_ci_roles" {
+  type = list(string)
+}

--- a/builds/terraform/terraform.tf
+++ b/builds/terraform/terraform.tf
@@ -22,3 +22,15 @@ data "terraform_remote_state" "shared_infra" {
     region = "eu-west-1"
   }
 }
+
+data "terraform_remote_state" "accounts" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/platform-infrastructure/accounts.tfstate"
+    region = "eu-west-1"
+  }
+}


### PR DESCRIPTION
Instead of a fixed identity, CI should assume role allowing developers to mimic exactly the permissions and process of CI with regard to AWS permissions.