### PR TITLE
Add own account as principal for assumed roles

### DIFF
--- a/accounts/account.tf
+++ b/accounts/account.tf
@@ -13,7 +13,7 @@ module "aws_account" {
   prefix = "platform"
 
   principals = [
-    local.aws_principal,
+    local.account_principals["platform"],
   ]
 
   infra_bucket_arn        = "arn:aws:s3:::wellcomecollection-platform-infra"
@@ -45,7 +45,8 @@ module "catalogue_account" {
 
   prefix = "catalogue"
   principals = [
-    local.aws_principal
+    local.account_principals["platform"],
+    local.account_principals["catalogue"],
   ]
 
   infra_bucket_arn        = "arn:aws:s3:::wellcomecollection-catalogue-infra-delta"
@@ -61,7 +62,8 @@ module "workflow_account" {
 
   prefix = "workflow"
   principals = [
-    local.aws_principal
+    local.account_principals["platform"],
+    local.account_principals["workflow"],
   ]
 
   infra_bucket_arn        = "arn:aws:s3:::wellcomecollection-workflow-infra"
@@ -77,7 +79,8 @@ module "storage_account" {
 
   prefix = "storage"
   principals = [
-    local.aws_principal
+    local.account_principals["platform"],
+    local.account_principals["storage"],
   ]
 
   infra_bucket_arn        = "arn:aws:s3:::wellcomecollection-storage-infra"
@@ -93,7 +96,8 @@ module "data_account" {
 
   prefix = "data"
   principals = [
-    local.aws_principal
+    local.account_principals["platform"],
+    local.account_principals["data"],
   ]
 
   infra_bucket_arn        = "arn:aws:s3:::wellcomecollection-datascience-infra"
@@ -109,7 +113,8 @@ module "reporting_account" {
 
   prefix = "reporting"
   principals = [
-    local.aws_principal
+    local.account_principals["platform"],
+    local.account_principals["reporting"],
   ]
 
   infra_bucket_arn        = "arn:aws:s3:::wellcomecollection-reporting-infra"
@@ -126,7 +131,8 @@ module "experience_account" {
   prefix = "experience"
 
   principals = [
-    local.aws_principal
+    local.account_principals["platform"],
+    local.account_principals["experience"],
   ]
 
   infra_bucket_arn        = "arn:aws:s3:::wellcomecollection-experience-infra"
@@ -142,7 +148,8 @@ module "digitisation_account" {
 
   prefix = "digitisation"
   principals = [
-    local.aws_principal
+    local.account_principals["platform"],
+    local.account_principals["digitisation"],
   ]
 
   sbt_releases_bucket_arn = local.sbt_releases_bucket_arn
@@ -158,7 +165,8 @@ module "digirati_account" {
   prefix = "digirati"
 
   principals = [
-    local.aws_principal
+    local.account_principals["platform"],
+    local.account_principals["digirati"],
   ]
 
   sbt_releases_bucket_arn = local.sbt_releases_bucket_arn

--- a/accounts/terraform.tf
+++ b/accounts/terraform.tf
@@ -88,4 +88,17 @@ locals {
 
   account_id    = data.aws_caller_identity.current.account_id
   aws_principal = "arn:aws:iam::${local.account_id}:root"
+
+  account_ids = {
+    platform     = local.account_id
+    storage      = "975596993436"
+    experience   = "130871440101"
+    data         = "964279923020"
+    reporting    = "269807742353"
+    digitisation = "404315009621"
+    workflow     = "299497370133"
+    digirati     = "653428163053"
+  }
+
+  account_principals = {for key, value in local.account_ids: key => "arn:aws:iam::${value}:root"}
 }

--- a/accounts/terraform.tf
+++ b/accounts/terraform.tf
@@ -97,6 +97,7 @@ locals {
     reporting    = "269807742353"
     digitisation = "404315009621"
     workflow     = "299497370133"
+    catalogue    = "756629837203"
     digirati     = "653428163053"
   }
 


### PR DESCRIPTION
Allows users within an account to assume roles created in accounts (will allow CI users to assume in same account roles).