### PR TITLE
Add CloudFront distros for IIIF APIs

### DIFF
--- a/cloudfront/iiif/main.tf
+++ b/cloudfront/iiif/main.tf
@@ -1,7 +1,7 @@
 locals {
   subdomain_modifier = var.environment == "prod" ? "" : "-${var.environment}"
 
-  distro_alias = "iiif${local.subdomain_modifier}.wellcomecollection.org"
+  distro_alias = "iiif-${var.environment}.wellcomecollection.org"
 
   dds_domain   = "dds${local.subdomain_modifier}.dlcs.io"
   iiif_domain  = "iiif${local.subdomain_modifier}.dlcs.io"

--- a/cloudfront/iiif/main.tf
+++ b/cloudfront/iiif/main.tf
@@ -1,0 +1,439 @@
+locals {
+  subdomain_modifier = var.environment == "prod" ? "" : "-${var.environment}"
+
+  distro_alias = "iiif${local.subdomain_modifier}.wellcomecollection.org"
+
+  dds_domain   = "dds${local.subdomain_modifier}.dlcs.io"
+  iiif_domain  = "iiif${local.subdomain_modifier}.dlcs.io"
+  loris_domain = "iiif-origin.wellcomecollection.org"
+  dlcs_domain  = "dlcs.io"
+}
+
+resource "aws_cloudfront_distribution" "iiif" {
+  aliases = [
+    local.distro_alias
+  ]
+
+  origin {
+    domain_name = local.dds_domain
+    origin_id   = "dds"
+
+    custom_origin_config {
+      origin_protocol_policy = "match-viewer"
+      origin_ssl_protocols = ["TLSv1"]
+
+      http_port = 80
+      https_port = 443
+    }
+  }
+
+  origin {
+    domain_name = local.dlcs_domain
+    origin_id   = "dlcs"
+
+    custom_origin_config {
+      origin_protocol_policy = "match-viewer"
+      origin_ssl_protocols = ["TLSv1"]
+
+      http_port = 80
+      https_port = 443
+    }
+  }
+
+  origin {
+    domain_name = local.loris_domain
+    origin_id   = "loris"
+
+    custom_origin_config {
+      origin_protocol_policy = "match-viewer"
+      origin_ssl_protocols = ["TLSv1"]
+
+      http_port = 80
+      https_port = 443
+    }
+  }
+
+  origin {
+    domain_name = local.iiif_domain
+    origin_id   = "iiif"
+
+    custom_origin_config {
+      origin_protocol_policy = "match-viewer"
+      origin_ssl_protocols = ["TLSv1"]
+
+      http_port = 80
+      https_port = 443
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "IIIF APIs (${var.environment})"
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "dlcs"
+
+    forwarded_values {
+      query_string = true
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 3600
+    max_ttl     = 86400
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "image/V00*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "loris"
+
+    forwarded_values {
+      query_string = true
+      headers = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "image/L00*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "loris"
+
+    forwarded_values {
+      query_string = true
+      headers = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "image/M00*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "loris"
+
+    forwarded_values {
+      query_string = true
+      headers = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "image/B00*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "loris"
+
+    forwarded_values {
+      query_string = true
+      headers = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "image/N00*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "loris"
+
+    forwarded_values {
+      query_string = true
+      headers = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "image/A00*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "loris"
+
+    forwarded_values {
+      query_string = true
+      headers = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "image/W00*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "loris"
+
+    forwarded_values {
+      query_string = true
+      headers = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "image/S00*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "loris"
+
+    forwarded_values {
+      query_string = true
+      headers = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "thumbs/*.*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "dlcs"
+
+    forwarded_values {
+      query_string = true
+      headers = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "thumbs/b*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "iiif"
+
+    forwarded_values {
+      query_string = true
+      headers = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "image/*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "dlcs"
+
+    forwarded_values {
+      query_string = true
+      headers = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "av/*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "dlcs"
+
+    forwarded_values {
+      query_string = true
+      headers = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "pdf/*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "dlcs"
+
+    forwarded_values {
+      query_string = true
+      headers = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "dash/*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "dds"
+
+    forwarded_values {
+      query_string = true
+      headers = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "text/v1*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "iiif"
+
+    forwarded_values {
+      query_string = true
+      headers = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  price_class = "PriceClass_100"
+
+  tags = {
+    Managed = "terraform"
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = var.acm_certificate_arn
+    ssl_support_method = "sni-only"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+}

--- a/cloudfront/iiif/variables.tf
+++ b/cloudfront/iiif/variables.tf
@@ -1,0 +1,6 @@
+variable "environment" {
+  type = string
+}
+variable "acm_certificate_arn" {
+  type = string
+}

--- a/cloudfront/main.tf
+++ b/cloudfront/main.tf
@@ -1,0 +1,24 @@
+module "iiif-prod" {
+  source = "./iiif"
+
+  environment = "prod"
+  acm_certificate_arn = local.acm_cert_arn
+}
+
+module "iiif-stage" {
+  source = "./iiif"
+
+  environment = "stage"
+  acm_certificate_arn = local.acm_cert_arn
+}
+
+module "iiif-test" {
+  source = "./iiif"
+
+  environment = "test"
+  acm_certificate_arn = local.acm_cert_arn
+}
+
+locals {
+  acm_cert_arn = "arn:aws:acm:us-east-1:760097843905:certificate/04bb4447-b501-453a-804e-411d3f660a74"
+}

--- a/cloudfront/main.tf
+++ b/cloudfront/main.tf
@@ -20,5 +20,5 @@ module "iiif-test" {
 }
 
 locals {
-  acm_cert_arn = "arn:aws:acm:us-east-1:760097843905:certificate/04bb4447-b501-453a-804e-411d3f660a74"
+  acm_cert_arn = "arn:aws:acm:us-east-1:760097843905:certificate/1a749ce8-ebd3-4342-accb-37f692fc8e52"
 }

--- a/cloudfront/provider.tf
+++ b/cloudfront/provider.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region  = "eu-west-1"
+  version = "2.35.0"
+
+  assume_role {
+    role_arn = "arn:aws:iam::760097843905:role/platform-admin"
+  }
+}

--- a/cloudfront/terraform.tf
+++ b/cloudfront/terraform.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 0.9"
+
+  backend "s3" {
+    bucket         = "wellcomecollection-platform-infra"
+    key            = "terraform/platform-infrastructure/cloudfront.tfstate"
+    dynamodb_table = "terraform-locktable"
+
+    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    region   = "eu-west-1"
+  }
+}


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/4603

When this is released the following Loris specific CloudFront distro can be removed (along with the cert it uses, and that cert can then be definitively referenced in terraform here).

https://github.com/wellcomecollection/loris-infrastructure/blob/master/terraform/cloudfront.tf