### PR TITLE
Don't re-export VPCs through critical/back_end

### DIFF
--- a/builds/terraform/locals.tf
+++ b/builds/terraform/locals.tf
@@ -1,18 +1,16 @@
 locals {
-  infra_bucket_arn = data.terraform_remote_state.shared_infra.outputs.infra_bucket_arn
+  infra_bucket_arn = local.shared_infra["infra_bucket_arn"]
+  infra_bucket_id  = local.shared_infra["infra_bucket"]
 
-  infra_bucket_id = data.terraform_remote_state.shared_infra.outputs.infra_bucket
-
-  lambda_error_alarm_arn = data.terraform_remote_state.shared_infra.outputs.lambda_error_alarm_arn
+  lambda_error_alarm_arn = local.shared_infra["lambda_error_alarm_arn"]
 
   non_critical_slack_webhook = data.aws_ssm_parameter.non_critical_slack_webhook.value
 
-  platform_read_only_role_arn = data.terraform_remote_state.accounts.outputs.platform_read_only_role_arn
-
-  account_ci_role_arn_map = data.terraform_remote_state.accounts.outputs.ci_role_arn
+  platform_read_only_role_arn = local.platform_accounts["platform_read_only_role_arn"]
+  account_ci_role_arn_map     = local.platform_accounts["ci_role_arn"]
 
   ci_agent_role_name = "ci-agent"
 
-  ci_vpc_id = data.terraform_remote_state.critical_back_end.outputs.ci_vpc_id
-  ci_vpc_private_subnets = data.terraform_remote_state.critical_back_end.outputs.ci_vpc_private_subnets
+  ci_vpc_id              = local.platform_vpcs["ci_vpc_id"]
+  ci_vpc_private_subnets = local.platform_vpcs["ci_vpc_private_subnets"]
 }

--- a/builds/terraform/terraform.tf
+++ b/builds/terraform/terraform.tf
@@ -23,11 +23,11 @@ data "terraform_remote_state" "shared_infra" {
   }
 }
 
-data "terraform_remote_state" "accounts" {
+data "terraform_remote_state" "accounts_platform" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
 
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/platform-infrastructure/accounts/platform.tfstate"
@@ -35,14 +35,9 @@ data "terraform_remote_state" "accounts" {
   }
 }
 
-data "terraform_remote_state" "critical_back_end" {
-  backend = "s3"
+locals {
+  shared_infra = data.terraform_remote_state.shared_infra.outputs
 
-  config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
-
-    bucket         = "wellcomecollection-platform-infra"
-    key            = "terraform/platform-infrastructure/shared.tfstate"
-    region         = "eu-west-1"
-  }
+  platform_accounts = data.terraform_remote_state.accounts_platform.outputs
+  platform_vpcs     = data.terraform_remote_state.accounts_platform.outputs
 }

--- a/critical/back_end/outputs.tf
+++ b/critical/back_end/outputs.tf
@@ -215,20 +215,6 @@ output "digirati_vpc_id" {
   value = local.digirati_vpcs["digirati_vpc_id"]
 }
 
-# Developer VPC
-
-output "developer_vpc_private_subnets" {
-  value = local.platform_vpcs["developer_vpc_private_subnets"]
-}
-
-output "developer_vpc_public_subnets" {
-  value = local.platform_vpcs["developer_vpc_public_subnets"]
-}
-
-output "developer_vpc_id" {
-  value = local.platform_vpcs["developer_vpc_id"]
-}
-
 # Cloud health roles
 
 output "cloudhealth_catalogue_role_arn" {

--- a/critical/back_end/outputs.tf
+++ b/critical/back_end/outputs.tf
@@ -141,20 +141,6 @@ output "storage_vpc_id" {
   value = local.storage_vpcs["storage_vpc_id"]
 }
 
-# Monitoring VPC
-
-output "monitoring_vpc_delta_private_subnets" {
-  value = local.platform_vpcs["monitoring_vpc_delta_private_subnets"]
-}
-
-output "monitoring_vpc_delta_public_subnets" {
-  value = local.platform_vpcs["monitoring_vpc_delta_public_subnets"]
-}
-
-output "monitoring_vpc_delta_id" {
-  value = local.platform_vpcs["monitoring_vpc_delta_id"]
-}
-
 # Data Science VPC
 
 output "datascience_vpc_private_subnets" {

--- a/critical/back_end/outputs.tf
+++ b/critical/back_end/outputs.tf
@@ -229,20 +229,6 @@ output "developer_vpc_id" {
   value = local.platform_vpcs["developer_vpc_id"]
 }
 
-# CI VPC
-
-output "ci_vpc_private_subnets" {
-  value = local.platform_vpcs["ci_vpc_private_subnets"]
-}
-
-output "ci_vpc_public_subnets" {
-  value = local.platform_vpcs["ci_vpc_public_subnets"]
-}
-
-output "ci_vpc_id" {
-  value = local.platform_vpcs["ci_vpc_id"]
-}
-
 # Cloud health roles
 
 output "cloudhealth_catalogue_role_arn" {

--- a/critical/back_end/terraform.tf
+++ b/critical/back_end/terraform.tf
@@ -59,18 +59,6 @@ data "terraform_remote_state" "accounts_experience" {
   }
 }
 
-data "terraform_remote_state" "accounts_platform" {
-  backend = "s3"
-
-  config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
-
-    bucket = "wellcomecollection-platform-infra"
-    key    = "terraform/platform-infrastructure/accounts/platform.tfstate"
-    region = "eu-west-1"
-  }
-}
-
 data "terraform_remote_state" "accounts_storage" {
   backend = "s3"
 
@@ -88,6 +76,5 @@ locals {
   datascience_vpcs = data.terraform_remote_state.accounts_data.outputs
   digirati_vpcs    = data.terraform_remote_state.accounts_digirati.outputs
   experience_vpcs  = data.terraform_remote_state.accounts_experience.outputs
-  platform_vpcs    = data.terraform_remote_state.accounts_platform.outputs
   storage_vpcs     = data.terraform_remote_state.accounts_storage.outputs
 }

--- a/monitoring/terraform/locals.tf
+++ b/monitoring/terraform/locals.tf
@@ -1,17 +1,17 @@
 locals {
-  gateway_server_error_alarm_arn = data.terraform_remote_state.shared_infra.outputs.gateway_server_error_alarm_arn
-  lambda_error_alarm_arn         = data.terraform_remote_state.shared_infra.outputs.lambda_error_alarm_arn
-  dlq_alarm_arn                  = data.terraform_remote_state.shared_infra.outputs.dlq_alarm_arn
+  gateway_server_error_alarm_arn = local.shared_infra["gateway_server_error_alarm_arn"]
+  lambda_error_alarm_arn         = local.shared_infra["lambda_error_alarm_arn"]
+  dlq_alarm_arn                  = local.shared_infra["dlq_alarm_arn"]
 
   admin_cidr_ingress = data.terraform_remote_state.infra_critical.outputs.admin_cidr_ingress
 
-  bucket_alb_logs_id = data.terraform_remote_state.shared_infra.outputs.bucket_alb_logs_id
+  bucket_alb_logs_id = local.shared_infra["bucket_alb_logs_id"]
 
   cloudfront_errors_topic_arn = data.terraform_remote_state.loris.outputs.cloudfront_errors_topic_arn
 
   namespace = "monitoring"
 
-  vpc_id          = data.terraform_remote_state.shared_infra.outputs.monitoring_vpc_delta_id
-  private_subnets = data.terraform_remote_state.shared_infra.outputs.monitoring_vpc_delta_private_subnets
-  public_subnets  = data.terraform_remote_state.shared_infra.outputs.monitoring_vpc_delta_public_subnets
+  vpc_id          = local.platform_vpcs["monitoring_vpc_delta_id"]
+  private_subnets = local.platform_vpcs["monitoring_vpc_delta_private_subnets"]
+  public_subnets  = local.platform_vpcs["monitoring_vpc_delta_public_subnets"]
 }

--- a/monitoring/terraform/terraform.tf
+++ b/monitoring/terraform/terraform.tf
@@ -34,9 +34,26 @@ data "terraform_remote_state" "shared_infra" {
     role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
 
     bucket = "wellcomecollection-platform-infra"
-    key    = "terraform/platform-infrastructure/shared.tfstate"
+    key    = "terraform/platform-infrastructure/accounts/shared.tfstate"
     region = "eu-west-1"
   }
+}
+
+data "terraform_remote_state" "accounts_platform" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/platform-infrastructure/accounts/platform.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+locals {
+  shared_infra  = data.terraform_remote_state.shared_infra.outputs
+  platform_vpcs = data.terraform_remote_state.accounts_platform.outputs
 }
 
 data "terraform_remote_state" "infra_critical" {


### PR DESCRIPTION
Another part of https://github.com/wellcomecollection/platform/issues/4802

I set up the `critical/back_end` stack to re-export any VPC outputs it already had, to avoid breaking any other Terraform stacks, but it would be better if consumers loaded the VPC info directly from `accounts/<name>`.

(Among other things, it means they'll always get the latest value. If you get it from `critical/back_end`, it might be stale if somebody has changed things in `accounts/<name>` but not re-applied in `critical/back_end`.)

This patch updates the configurations in platform-infrastructure to use the new Terraform state.