### PR TITLE
Don't re-export the storage VPCs through the critical/back_end stack

### DIFF
--- a/critical/back_end/outputs.tf
+++ b/critical/back_end/outputs.tf
@@ -127,20 +127,6 @@ output "catalogue_vpc_delta_id" {
   value = local.catalogue_vpcs["catalogue_vpc_delta_id"]
 }
 
-# Storage VPC
-
-output "storage_vpc_private_subnets" {
-  value = local.storage_vpcs["storage_vpc_private_subnets"]
-}
-
-output "storage_vpc_public_subnets" {
-  value = local.storage_vpcs["storage_vpc_public_subnets"]
-}
-
-output "storage_vpc_id" {
-  value = local.storage_vpcs["storage_vpc_id"]
-}
-
 # Data Science VPC
 
 output "datascience_vpc_private_subnets" {

--- a/critical/back_end/terraform.tf
+++ b/critical/back_end/terraform.tf
@@ -35,20 +35,7 @@ data "terraform_remote_state" "accounts_data" {
   }
 }
 
-data "terraform_remote_state" "accounts_storage" {
-  backend = "s3"
-
-  config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
-
-    bucket = "wellcomecollection-platform-infra"
-    key    = "terraform/platform-infrastructure/accounts/storage.tfstate"
-    region = "eu-west-1"
-  }
-}
-
 locals {
   catalogue_vpcs   = data.terraform_remote_state.accounts_catalogue.outputs
   datascience_vpcs = data.terraform_remote_state.accounts_data.outputs
-  storage_vpcs     = data.terraform_remote_state.accounts_storage.outputs
 }


### PR DESCRIPTION
Part of wellcomecollection/platform#4802

Relies on https://github.com/wellcomecollection/storage-service/pull/749