### PR TITLE
Remove the last of the re-exported VPCs from the critical/back_end stack

### DIFF
--- a/critical/back_end/outputs.tf
+++ b/critical/back_end/outputs.tf
@@ -127,20 +127,6 @@ output "catalogue_vpc_delta_id" {
   value = local.catalogue_vpcs["catalogue_vpc_delta_id"]
 }
 
-# Data Science VPC
-
-output "datascience_vpc_private_subnets" {
-  value = local.datascience_vpcs["datascience_vpc_private_subnets"]
-}
-
-output "datascience_vpc_public_subnets" {
-  value = local.datascience_vpcs["datascience_vpc_public_subnets"]
-}
-
-output "datascience_vpc_id" {
-  value = local.datascience_vpcs["datascience_vpc_id"]
-}
-
 # Catalogue VPC
 
 output "catalogue_vpc_private_subnets" {

--- a/critical/back_end/outputs.tf
+++ b/critical/back_end/outputs.tf
@@ -113,34 +113,6 @@ output "inference_calm_reindex_topic_name" {
   value = module.inference_calm_reindex_topic.name
 }
 
-# Catalogue VPC
-
-output "catalogue_vpc_delta_private_subnets" {
-  value = local.catalogue_vpcs["catalogue_vpc_delta_private_subnets"]
-}
-
-output "catalogue_vpc_delta_public_subnets" {
-  value = local.catalogue_vpcs["catalogue_vpc_delta_public_subnets"]
-}
-
-output "catalogue_vpc_delta_id" {
-  value = local.catalogue_vpcs["catalogue_vpc_delta_id"]
-}
-
-# Catalogue VPC
-
-output "catalogue_vpc_private_subnets" {
-  value = local.catalogue_vpcs["catalogue_vpc_private_subnets"]
-}
-
-output "catalogue_vpc_public_subnets" {
-  value = local.catalogue_vpcs["catalogue_vpc_public_subnets"]
-}
-
-output "catalogue_vpc_id" {
-  value = local.catalogue_vpcs["catalogue_vpc_id"]
-}
-
 # Cloud health roles
 
 output "cloudhealth_catalogue_role_arn" {

--- a/critical/back_end/terraform.tf
+++ b/critical/back_end/terraform.tf
@@ -23,19 +23,6 @@ data "terraform_remote_state" "accounts_catalogue" {
   }
 }
 
-data "terraform_remote_state" "accounts_data" {
-  backend = "s3"
-
-  config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
-
-    bucket = "wellcomecollection-platform-infra"
-    key    = "terraform/platform-infrastructure/accounts/data.tfstate"
-    region = "eu-west-1"
-  }
-}
-
 locals {
-  catalogue_vpcs   = data.terraform_remote_state.accounts_catalogue.outputs
-  datascience_vpcs = data.terraform_remote_state.accounts_data.outputs
+  catalogue_vpcs = data.terraform_remote_state.accounts_catalogue.outputs
 }

--- a/critical/back_end/terraform.tf
+++ b/critical/back_end/terraform.tf
@@ -10,19 +10,3 @@ terraform {
     region         = "eu-west-1"
   }
 }
-
-data "terraform_remote_state" "accounts_catalogue" {
-  backend = "s3"
-
-  config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
-
-    bucket = "wellcomecollection-platform-infra"
-    key    = "terraform/platform-infrastructure/accounts/catalogue.tfstate"
-    region = "eu-west-1"
-  }
-}
-
-locals {
-  catalogue_vpcs = data.terraform_remote_state.accounts_catalogue.outputs
-}


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/platform/issues/4802

Waiting for https://github.com/wellcomecollection/catalogue/pull/893