### PR TITLE
Remove a CloudWatch event rule that isn't used anywhere

### DIFF
--- a/critical/back_end/cloudwatch_event_rules.tf
+++ b/critical/back_end/cloudwatch_event_rules.tf
@@ -1,5 +1,0 @@
-resource "aws_cloudwatch_event_rule" "every_minute" {
-  name                = "every_minute_lambdas"
-  description         = "Fires every minute"
-  schedule_expression = "rate(1 minute)"
-}


### PR DESCRIPTION
I _thought_ I'd done this already, but apparently not.