### PR TITLE
Add a script for cleaning up unused Parameter Store entries

### DIFF
--- a/scripts/migrations/2020-10-cleanup_parameter_store.py
+++ b/scripts/migrations/2020-10-cleanup_parameter_store.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+"""
+Part of https://github.com/wellcomecollection/platform/issues/4846
+
+At one point we used Parameter Store to record "releases" -- that is, the tag of
+the Docker image that should be deployed in ECS.
+
+We no longer use Parameter Store.  This script deletes entries from Parameter Store,
+and records their final value (in case they need to be restored).
+"""
+
+import datetime
+import json
+
+import boto3
+import termcolor
+
+
+ssm_client = boto3.client("ssm")
+
+
+def get_parameter_store_entries():
+    """
+    Get all the entries in Parameter Store for an account.
+
+    It returns a 2-tuple: metadata about the parameter from DescribeParameters,
+    and the current value of the parameter from GetParameters.
+    """
+    paginator = ssm_client.get_paginator("describe_parameters")
+
+    for page in paginator.paginate():
+
+        # The DescribeParameters call tells us what parameters exist, but it
+        # doesn't tell us what their values are.  We need to make a separate
+        # GetParameters call to fetch those.
+        resp = ssm_client.get_parameters(
+            Names=[param["Name"] for param in page["Parameters"]]
+        )
+
+        parameter_values = {
+            param["Name"]: param
+            for param in resp["Parameters"]
+        }
+
+        for param_meta in page["Parameters"]:
+            yield param_meta, parameter_values[param_meta["Name"]]
+
+
+def delete_parameter_store_entry(param_meta, param_value):
+    """
+    Deletes an entry from Parameter Store, and records it to JSON.
+    """
+    try:
+        deleted_params = json.load(open("2020-10-deleted_parameters.json"))
+    except FileNotFoundError:
+        deleted_params = []
+
+    parameter_record = {
+        "description": param_meta.get("Description"),
+        "last_modified": param_meta["LastModifiedDate"].isoformat(),
+        "deleted_at": datetime.datetime.now().isoformat(),
+        "name": param_meta["Name"],
+        "arn": param_value["ARN"],
+        "value": param_value["Value"],
+    }
+
+    # Print the parameter first, so if we screw up saving it to JSON, we've
+    # still got all the critical info.
+    print(termcolor.colored(f"Deleting {param_meta['Name']}:", 'red'))
+    print(json.dumps(parameter_record))
+
+    ssm_client.delete_parameter(Name=param_meta["Name"])
+
+    deleted_params.append(parameter_record)
+
+    with open("2020-10-deleted_parameters.json", "w") as outfile:
+        outfile.write(json.dumps(deleted_params, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    for param_meta, param_value in get_parameter_store_entries():
+        if (
+            "/images/" not in param_meta["Name"] and
+            not param_meta["Name"].startswith("/releases/")
+        ):
+            continue
+
+        # A couple of hard-coded exceptions for services that still use SSM.
+        if param_meta["Name"] in {
+            "/loris/images/latest/loris",
+            "/platform/images/latest/nginx_loris",
+        }:
+            continue
+
+        delete_parameter_store_entry(param_meta=param_meta, param_value=param_value)

--- a/scripts/migrations/2020-10-cleanup_parameter_store.py
+++ b/scripts/migrations/2020-10-cleanup_parameter_store.py
@@ -37,10 +37,7 @@ def get_parameter_store_entries():
             Names=[param["Name"] for param in page["Parameters"]]
         )
 
-        parameter_values = {
-            param["Name"]: param
-            for param in resp["Parameters"]
-        }
+        parameter_values = {param["Name"]: param for param in resp["Parameters"]}
 
         for param_meta in page["Parameters"]:
             yield param_meta, parameter_values[param_meta["Name"]]
@@ -66,7 +63,7 @@ def delete_parameter_store_entry(param_meta, param_value):
 
     # Print the parameter first, so if we screw up saving it to JSON, we've
     # still got all the critical info.
-    print(termcolor.colored(f"Deleting {param_meta['Name']}:", 'red'))
+    print(termcolor.colored(f"Deleting {param_meta['Name']}:", "red"))
     print(json.dumps(parameter_record))
 
     ssm_client.delete_parameter(Name=param_meta["Name"])
@@ -79,9 +76,8 @@ def delete_parameter_store_entry(param_meta, param_value):
 
 if __name__ == "__main__":
     for param_meta, param_value in get_parameter_store_entries():
-        if (
-            "/images/" not in param_meta["Name"] and
-            not param_meta["Name"].startswith("/releases/")
+        if "/images/" not in param_meta["Name"] and not param_meta["Name"].startswith(
+            "/releases/"
         ):
             continue
 

--- a/scripts/migrations/2020-10-deleted_parameters.json
+++ b/scripts/migrations/2020-10-deleted_parameters.json
@@ -1,0 +1,1250 @@
+[
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/nginx/images/latest/nginx",
+    "deleted_at": "2020-10-15T08:00:34.388891",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-11-19T15:29:20.569000+00:00",
+    "name": "/nginx/images/latest/nginx",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx:95821b39e1683a0a7098cd67d82bc690415c1d5a"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/latest/bag_register",
+    "deleted_at": "2020-10-15T08:00:55.363970",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-24T08:25:38.340000+01:00",
+    "name": "/storage/images/latest/bag_register",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_register:ref.ea19a75c75850f0d5732c2ecd2c4ba5f8b10348b"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/latest/bag_indexer",
+    "deleted_at": "2020-10-15T08:01:03.369721",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-24T08:40:57.784000+01:00",
+    "name": "/storage/images/latest/bag_indexer",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_indexer:ref.ea19a75c75850f0d5732c2ecd2c4ba5f8b10348b"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/latest/bag_tagger",
+    "deleted_at": "2020-10-15T08:01:03.969856",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-24T08:26:04.151000+01:00",
+    "name": "/storage/images/latest/bag_tagger",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_tagger:ref.ea19a75c75850f0d5732c2ecd2c4ba5f8b10348b"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/latest/bags_api",
+    "deleted_at": "2020-10-15T08:01:04.100843",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-24T08:25:40.545000+01:00",
+    "name": "/storage/images/latest/bags_api",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bags_api:ref.ea19a75c75850f0d5732c2ecd2c4ba5f8b10348b"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/latest/ingests",
+    "deleted_at": "2020-10-15T08:01:04.395698",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2020-05-14T12:41:18.322000+01:00",
+    "name": "/storage/images/latest/ingests",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingests:f001af9afce8579ea3908928ade32802344afd7f"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/latest/ingests_api",
+    "deleted_at": "2020-10-15T08:01:04.505239",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-24T08:40:34.289000+01:00",
+    "name": "/storage/images/latest/ingests_api",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingests_api:ref.ea19a75c75850f0d5732c2ecd2c4ba5f8b10348b"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/latest/ingests_indexer",
+    "deleted_at": "2020-10-15T08:01:04.602459",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-24T08:40:21.338000+01:00",
+    "name": "/storage/images/latest/ingests_indexer",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingests_indexer:ref.ea19a75c75850f0d5732c2ecd2c4ba5f8b10348b"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/latest/ingests_worker",
+    "deleted_at": "2020-10-15T08:01:04.789004",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-24T08:39:37.474000+01:00",
+    "name": "/storage/images/latest/ingests_worker",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingests_worker:ref.ea19a75c75850f0d5732c2ecd2c4ba5f8b10348b"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/latest/manifest_fixer",
+    "deleted_at": "2020-10-15T08:01:04.900044",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2020-05-27T14:41:25.918000+01:00",
+    "name": "/storage/images/latest/manifest_fixer",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/manifest_fixer:91977a7c48d8b9af97e883dd4c5b7f2213ab5b55"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/latest/notifier",
+    "deleted_at": "2020-10-15T08:01:05.015027",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-24T08:46:48.485000+01:00",
+    "name": "/storage/images/latest/notifier",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/notifier:ref.ea19a75c75850f0d5732c2ecd2c4ba5f8b10348b"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/latest/bag_replicator",
+    "deleted_at": "2020-10-15T08:01:05.444857",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-24T08:25:37.881000+01:00",
+    "name": "/storage/images/latest/bag_replicator",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_replicator:ref.ea19a75c75850f0d5732c2ecd2c4ba5f8b10348b"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/latest/bag_root_finder",
+    "deleted_at": "2020-10-15T08:01:05.962819",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-24T08:24:53.373000+01:00",
+    "name": "/storage/images/latest/bag_root_finder",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_root_finder:ref.ea19a75c75850f0d5732c2ecd2c4ba5f8b10348b"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/latest/bag_tracker",
+    "deleted_at": "2020-10-15T08:01:06.075409",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-24T08:32:01.860000+01:00",
+    "name": "/storage/images/latest/bag_tracker",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_tracker:ref.ea19a75c75850f0d5732c2ecd2c4ba5f8b10348b"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/latest/bag_unpacker",
+    "deleted_at": "2020-10-15T08:01:06.179136",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-24T08:32:33.621000+01:00",
+    "name": "/storage/images/latest/bag_unpacker",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_unpacker:ref.ea19a75c75850f0d5732c2ecd2c4ba5f8b10348b"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/latest/bag_verifier",
+    "deleted_at": "2020-10-15T08:01:06.492311",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-24T08:33:23.365000+01:00",
+    "name": "/storage/images/latest/bag_verifier",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_verifier:ref.ea19a75c75850f0d5732c2ecd2c4ba5f8b10348b"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/latest/bag_versioner",
+    "deleted_at": "2020-10-15T08:01:06.608658",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-24T08:32:45.104000+01:00",
+    "name": "/storage/images/latest/bag_versioner",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_versioner:ref.ea19a75c75850f0d5732c2ecd2c4ba5f8b10348b"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/latest/ingests_tracker",
+    "deleted_at": "2020-10-15T08:01:06.716032",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-24T08:40:36.911000+01:00",
+    "name": "/storage/images/latest/ingests_tracker",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingests_tracker:ref.ea19a75c75850f0d5732c2ecd2c4ba5f8b10348b"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/latest/replica_aggregator",
+    "deleted_at": "2020-10-15T08:01:06.887374",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-24T08:33:37.708000+01:00",
+    "name": "/storage/images/latest/replica_aggregator",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/replica_aggregator:ref.ea19a75c75850f0d5732c2ecd2c4ba5f8b10348b"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/prod/bag_versioner",
+    "deleted_at": "2020-10-15T08:01:07.540846",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:11:02.599000+01:00",
+    "name": "/storage/images/prod/bag_versioner",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_versioner:ref.2c10f5590f41e1dffd6da923a84829c9314e0eb8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/prod/bag_register",
+    "deleted_at": "2020-10-15T08:01:23.017887",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:11:01.675000+01:00",
+    "name": "/storage/images/prod/bag_register",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_register:ref.2c10f5590f41e1dffd6da923a84829c9314e0eb8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/prod/bag_root_finder",
+    "deleted_at": "2020-10-15T08:01:23.283211",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:11:01.195000+01:00",
+    "name": "/storage/images/prod/bag_root_finder",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_root_finder:ref.2c10f5590f41e1dffd6da923a84829c9314e0eb8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/prod/bag_unpacker",
+    "deleted_at": "2020-10-15T08:01:23.376463",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:10:59.030000+01:00",
+    "name": "/storage/images/prod/bag_unpacker",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_unpacker:ref.2c10f5590f41e1dffd6da923a84829c9314e0eb8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/prod/ingests",
+    "deleted_at": "2020-10-15T08:01:23.480034",
+    "description": null,
+    "last_modified": "2020-07-06T13:52:19.637000+01:00",
+    "name": "/storage/images/prod/ingests",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingests:f001af9afce8579ea3908928ade32802344afd7f"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/prod/ingests_tracker",
+    "deleted_at": "2020-10-15T08:01:23.570374",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:11:00.294000+01:00",
+    "name": "/storage/images/prod/ingests_tracker",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingests_tracker:ref.2c10f5590f41e1dffd6da923a84829c9314e0eb8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/prod/ingests_worker",
+    "deleted_at": "2020-10-15T08:01:23.771398",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:11:08.607000+01:00",
+    "name": "/storage/images/prod/ingests_worker",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingests_worker:ref.2c10f5590f41e1dffd6da923a84829c9314e0eb8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/prod/manifest_fixer",
+    "deleted_at": "2020-10-15T08:01:23.890585",
+    "description": null,
+    "last_modified": "2020-07-06T13:52:19.187000+01:00",
+    "name": "/storage/images/prod/manifest_fixer",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/manifest_fixer:91977a7c48d8b9af97e883dd4c5b7f2213ab5b55"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/prod/notifier",
+    "deleted_at": "2020-10-15T08:01:24.013004",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:11:07.163000+01:00",
+    "name": "/storage/images/prod/notifier",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/notifier:ref.2c10f5590f41e1dffd6da923a84829c9314e0eb8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/prod/replica_aggregator",
+    "deleted_at": "2020-10-15T08:01:24.319312",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:11:02.145000+01:00",
+    "name": "/storage/images/prod/replica_aggregator",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/replica_aggregator:ref.2c10f5590f41e1dffd6da923a84829c9314e0eb8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/prod/bag_indexer",
+    "deleted_at": "2020-10-15T08:01:24.717138",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:11:00.735000+01:00",
+    "name": "/storage/images/prod/bag_indexer",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_indexer:ref.2c10f5590f41e1dffd6da923a84829c9314e0eb8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/prod/bag_replicator",
+    "deleted_at": "2020-10-15T08:01:24.856752",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:11:08.955000+01:00",
+    "name": "/storage/images/prod/bag_replicator",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_replicator:ref.2c10f5590f41e1dffd6da923a84829c9314e0eb8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/prod/bag_tagger",
+    "deleted_at": "2020-10-15T08:01:25.025960",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:11:08.170000+01:00",
+    "name": "/storage/images/prod/bag_tagger",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_tagger:ref.2c10f5590f41e1dffd6da923a84829c9314e0eb8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/prod/bag_tracker",
+    "deleted_at": "2020-10-15T08:01:25.147901",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:11:06.692000+01:00",
+    "name": "/storage/images/prod/bag_tracker",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_tracker:ref.2c10f5590f41e1dffd6da923a84829c9314e0eb8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/prod/bag_verifier",
+    "deleted_at": "2020-10-15T08:01:25.467268",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:11:05.956000+01:00",
+    "name": "/storage/images/prod/bag_verifier",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_verifier:ref.2c10f5590f41e1dffd6da923a84829c9314e0eb8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/prod/bags_api",
+    "deleted_at": "2020-10-15T08:01:25.761385",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:11:04.064000+01:00",
+    "name": "/storage/images/prod/bags_api",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bags_api:ref.2c10f5590f41e1dffd6da923a84829c9314e0eb8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/prod/ingests_api",
+    "deleted_at": "2020-10-15T08:01:25.929601",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:11:03.617000+01:00",
+    "name": "/storage/images/prod/ingests_api",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingests_api:ref.2c10f5590f41e1dffd6da923a84829c9314e0eb8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/prod/ingests_indexer",
+    "deleted_at": "2020-10-15T08:01:26.024691",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:11:03.118000+01:00",
+    "name": "/storage/images/prod/ingests_indexer",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingests_indexer:ref.2c10f5590f41e1dffd6da923a84829c9314e0eb8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/stage/bag_unpacker",
+    "deleted_at": "2020-10-15T08:01:26.144885",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T07:18:58.067000+01:00",
+    "name": "/storage/images/stage/bag_unpacker",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_unpacker:ref.006baf38d4d68797140324c5a6453ae45779163c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/stage/notifier",
+    "deleted_at": "2020-10-15T08:01:26.425923",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T07:19:03.746000+01:00",
+    "name": "/storage/images/stage/notifier",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/notifier:ref.006baf38d4d68797140324c5a6453ae45779163c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/stage/bag_root_finder",
+    "deleted_at": "2020-10-15T08:01:26.814937",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T07:18:59.594000+01:00",
+    "name": "/storage/images/stage/bag_root_finder",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_root_finder:ref.006baf38d4d68797140324c5a6453ae45779163c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/stage/bag_tagger",
+    "deleted_at": "2020-10-15T08:01:26.960734",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T07:19:04.056000+01:00",
+    "name": "/storage/images/stage/bag_tagger",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_tagger:ref.006baf38d4d68797140324c5a6453ae45779163c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/stage/bag_verifier",
+    "deleted_at": "2020-10-15T08:01:27.060971",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T07:19:02.753000+01:00",
+    "name": "/storage/images/stage/bag_verifier",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_verifier:ref.006baf38d4d68797140324c5a6453ae45779163c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/stage/bag_versioner",
+    "deleted_at": "2020-10-15T08:01:27.184441",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T07:19:00.976000+01:00",
+    "name": "/storage/images/stage/bag_versioner",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_versioner:ref.006baf38d4d68797140324c5a6453ae45779163c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/stage/ingests_api",
+    "deleted_at": "2020-10-15T08:01:27.471434",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T07:19:01.928000+01:00",
+    "name": "/storage/images/stage/ingests_api",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingests_api:ref.006baf38d4d68797140324c5a6453ae45779163c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/stage/ingests_indexer",
+    "deleted_at": "2020-10-15T08:01:27.709034",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T07:19:01.442000+01:00",
+    "name": "/storage/images/stage/ingests_indexer",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingests_indexer:ref.006baf38d4d68797140324c5a6453ae45779163c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/stage/ingests_tracker",
+    "deleted_at": "2020-10-15T08:01:27.856607",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T07:18:58.704000+01:00",
+    "name": "/storage/images/stage/ingests_tracker",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingests_tracker:ref.006baf38d4d68797140324c5a6453ae45779163c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/stage/ingests_worker",
+    "deleted_at": "2020-10-15T08:01:28.058009",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T07:19:04.456000+01:00",
+    "name": "/storage/images/stage/ingests_worker",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingests_worker:ref.006baf38d4d68797140324c5a6453ae45779163c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/stage/manifest_fixer",
+    "deleted_at": "2020-10-15T08:01:28.187639",
+    "description": null,
+    "last_modified": "2020-07-14T15:26:17.337000+01:00",
+    "name": "/storage/images/stage/manifest_fixer",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/manifest_fixer:91977a7c48d8b9af97e883dd4c5b7f2213ab5b55"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/stage/replica_aggregator",
+    "deleted_at": "2020-10-15T08:01:28.512273",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T07:19:00.518000+01:00",
+    "name": "/storage/images/stage/replica_aggregator",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/replica_aggregator:ref.006baf38d4d68797140324c5a6453ae45779163c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/stage/bag_indexer",
+    "deleted_at": "2020-10-15T08:01:29.984634",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T07:18:59.198000+01:00",
+    "name": "/storage/images/stage/bag_indexer",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_indexer:ref.006baf38d4d68797140324c5a6453ae45779163c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/stage/bag_register",
+    "deleted_at": "2020-10-15T08:01:30.187187",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T07:19:00.083000+01:00",
+    "name": "/storage/images/stage/bag_register",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_register:ref.006baf38d4d68797140324c5a6453ae45779163c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/stage/bag_replicator",
+    "deleted_at": "2020-10-15T08:01:30.298824",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T07:19:04.896000+01:00",
+    "name": "/storage/images/stage/bag_replicator",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_replicator:ref.006baf38d4d68797140324c5a6453ae45779163c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/stage/bag_tracker",
+    "deleted_at": "2020-10-15T08:01:30.608912",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T07:19:03.432000+01:00",
+    "name": "/storage/images/stage/bag_tracker",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bag_tracker:ref.006baf38d4d68797140324c5a6453ae45779163c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/stage/bags_api",
+    "deleted_at": "2020-10-15T08:01:30.762594",
+    "description": "Docker image URL; auto-managed by /Users/alexwlchan/repos/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T07:19:02.259000+01:00",
+    "name": "/storage/images/stage/bags_api",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/bags_api:ref.006baf38d4d68797140324c5a6453ae45779163c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:975596993436:parameter/storage/images/stage/ingests",
+    "deleted_at": "2020-10-15T08:01:31.001502",
+    "description": null,
+    "last_modified": "2020-07-14T15:26:18.013000+01:00",
+    "name": "/storage/images/stage/ingests",
+    "value": "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingests:f001af9afce8579ea3908928ade32802344afd7f"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/api/images/latest/api",
+    "deleted_at": "2020-10-15T08:03:10.250065",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-11-18T10:27:41.165000+00:00",
+    "name": "/api/images/latest/api",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:1e3efab086f8772ed995bd3a046b7dd458e100c2"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/api/images/latest/goobi_reader",
+    "deleted_at": "2020-10-15T08:03:10.613909",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-11-15T10:20:11.301000+00:00",
+    "name": "/api/images/latest/goobi_reader",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/goobi_reader:ed252661a9df51446651e0002fd0356835e0275d"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/api/images/latest/update_api_docs",
+    "deleted_at": "2020-10-15T08:03:10.827827",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-11-18T10:43:07.221000+00:00",
+    "name": "/api/images/latest/update_api_docs",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/update_api_docs:1e3efab086f8772ed995bd3a046b7dd458e100c2"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/calm_adapter/images/latest/calm_adapter",
+    "deleted_at": "2020-10-15T08:03:10.981296",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:25:33.323000+01:00",
+    "name": "/calm_adapter/images/latest/calm_adapter",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/calm_adapter:ref.fd4539bbcba323bf1dc09ae962e2573adcc686bd"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/calm_adapter/images/prod/calm_adapter",
+    "deleted_at": "2020-10-15T08:03:11.268082",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-17T12:20:19.790000+01:00",
+    "name": "/calm_adapter/images/prod/calm_adapter",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/calm_adapter:ref.5751ca15e35cf2283da8104bcf5021d578e50435"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_api/images/latest/api",
+    "deleted_at": "2020-10-15T08:03:11.887381",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T11:27:09.051000+01:00",
+    "name": "/catalogue_api/images/latest/api",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:ref.42d7545fadb0bef7f6c4121f9d73ed5745f7435c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_api/images/latest/nginx_api-gw",
+    "deleted_at": "2020-10-15T08:03:11.984426",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-11-12T17:32:47.186000+00:00",
+    "name": "/catalogue_api/images/latest/nginx_api-gw",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_api-gw:bad0dbfa548874938d16496e313b05adb71268b7"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_api/images/latest/snapshot_generator",
+    "deleted_at": "2020-10-15T08:03:12.078652",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T11:35:33.876000+01:00",
+    "name": "/catalogue_api/images/latest/snapshot_generator",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/snapshot_generator:ref.42d7545fadb0bef7f6c4121f9d73ed5745f7435c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_api/images/latest/update_api_docs",
+    "deleted_at": "2020-10-15T08:03:12.564960",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-23T11:32:04.857000+01:00",
+    "name": "/catalogue_api/images/latest/update_api_docs",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/update_api_docs:ref.42d7545fadb0bef7f6c4121f9d73ed5745f7435c"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_api/images/prod/api",
+    "deleted_at": "2020-10-15T08:03:12.737471",
+    "description": null,
+    "last_modified": "2020-07-02T15:43:11.060000+01:00",
+    "name": "/catalogue_api/images/prod/api",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:860f1a72def8a20a6aafc4c09f993263fd9c128f"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_api/images/prod/nginx_api-gw",
+    "deleted_at": "2020-10-15T08:03:12.832754",
+    "description": null,
+    "last_modified": "2020-07-02T15:43:11.166000+01:00",
+    "name": "/catalogue_api/images/prod/nginx_api-gw",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_api-gw:bad0dbfa548874938d16496e313b05adb71268b7"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_api/images/prod/snapshot_generator",
+    "deleted_at": "2020-10-15T08:03:12.974689",
+    "description": null,
+    "last_modified": "2020-07-02T15:43:10.970000+01:00",
+    "name": "/catalogue_api/images/prod/snapshot_generator",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/snapshot_generator:bfd6ffff39edd4468d69018bf79ef4abc64bf348"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_api/images/prod/update_api_docs",
+    "deleted_at": "2020-10-15T08:03:13.091453",
+    "description": null,
+    "last_modified": "2020-07-02T15:43:11.260000+01:00",
+    "name": "/catalogue_api/images/prod/update_api_docs",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/update_api_docs:c3cfc661e0ddd5308df7ddf34525fd4232666650"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_api/images/staging/api",
+    "deleted_at": "2020-10-15T08:03:13.365472",
+    "description": null,
+    "last_modified": "2020-07-28T15:15:13.812000+01:00",
+    "name": "/catalogue_api/images/staging/api",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:ref.3415581245f2698aa80d770ea9ec4d274d5967d8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_api/images/staging/nginx_api-gw",
+    "deleted_at": "2020-10-15T08:03:13.758462",
+    "description": null,
+    "last_modified": "2020-07-02T12:42:59.822000+01:00",
+    "name": "/catalogue_api/images/staging/nginx_api-gw",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_api-gw:bad0dbfa548874938d16496e313b05adb71268b7"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_api/images/staging/snapshot_generator",
+    "deleted_at": "2020-10-15T08:03:13.942101",
+    "description": null,
+    "last_modified": "2020-07-02T12:42:59.594000+01:00",
+    "name": "/catalogue_api/images/staging/snapshot_generator",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/snapshot_generator:bfd6ffff39edd4468d69018bf79ef4abc64bf348"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_api/images/staging/update_api_docs",
+    "deleted_at": "2020-10-15T08:03:14.038430",
+    "description": null,
+    "last_modified": "2020-07-02T12:42:59.919000+01:00",
+    "name": "/catalogue_api/images/staging/update_api_docs",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/update_api_docs:860f1a72def8a20a6aafc4c09f993263fd9c128f"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_api/images/test/api",
+    "deleted_at": "2020-10-15T08:03:14.149177",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-12-09T10:20:27.348000+00:00",
+    "name": "/catalogue_api/images/test/api",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:5051e1c0e66799d88e40094f780a71b5b9dc8e79"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/alice/transformer_sierra",
+    "deleted_at": "2020-10-15T08:03:14.714219",
+    "description": null,
+    "last_modified": "2020-06-16T17:18:13.663000+01:00",
+    "name": "/catalogue_pipeline/images/alice/transformer_sierra",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/transformer_sierra:871aac2494ff5d5545b8ff3b8eca0889caa080d9"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/latest/ingestor",
+    "deleted_at": "2020-10-15T08:03:14.912188",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2020-03-20T22:08:51.943000+00:00",
+    "name": "/catalogue_pipeline/images/latest/ingestor",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingestor:5c55c2662201c24aebd7aaa09b81c91f51b777cb"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/latest/ingestor_images",
+    "deleted_at": "2020-10-15T08:03:15.060975",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T17:17:46.161000+01:00",
+    "name": "/catalogue_pipeline/images/latest/ingestor_images",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingestor_images:ref.84a3af0cfe3511b11970c1d0baefdc9a7db88075"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/latest/ingestor_works",
+    "deleted_at": "2020-10-15T08:03:15.194378",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T17:19:26.177000+01:00",
+    "name": "/catalogue_pipeline/images/latest/ingestor_works",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingestor_works:ref.84a3af0cfe3511b11970c1d0baefdc9a7db88075"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/latest/transformer_mets",
+    "deleted_at": "2020-10-15T08:03:15.462194",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T12:56:39.752000+01:00",
+    "name": "/catalogue_pipeline/images/latest/transformer_mets",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/transformer_mets:ref.fd4539bbcba323bf1dc09ae962e2573adcc686bd"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/latest/feature_inferrer",
+    "deleted_at": "2020-10-15T08:03:16.084327",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T12:56:39.162000+01:00",
+    "name": "/catalogue_pipeline/images/latest/feature_inferrer",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/feature_inferrer:ref.1fe8c0cf070da461723a9b10e0fc69ad1a6cce03"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/latest/feature_training",
+    "deleted_at": "2020-10-15T08:03:16.191654",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2020-06-19T11:51:26.372000+01:00",
+    "name": "/catalogue_pipeline/images/latest/feature_training",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/feature_training:02965d30dc83465e92bfefd703659fa9304137b8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/latest/inference_manager",
+    "deleted_at": "2020-10-15T08:03:16.289687",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T12:56:42.669000+01:00",
+    "name": "/catalogue_pipeline/images/latest/inference_manager",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/inference_manager:ref.fd4539bbcba323bf1dc09ae962e2573adcc686bd"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/latest/matcher",
+    "deleted_at": "2020-10-15T08:03:16.607741",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T12:56:42.091000+01:00",
+    "name": "/catalogue_pipeline/images/latest/matcher",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/matcher:ref.fd4539bbcba323bf1dc09ae962e2573adcc686bd"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/latest/merger",
+    "deleted_at": "2020-10-15T08:03:16.770357",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T12:56:42.877000+01:00",
+    "name": "/catalogue_pipeline/images/latest/merger",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/merger:ref.fd4539bbcba323bf1dc09ae962e2573adcc686bd"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/latest/mets_adapter",
+    "deleted_at": "2020-10-15T08:03:16.981154",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-10T12:50:18.248000+01:00",
+    "name": "/catalogue_pipeline/images/latest/mets_adapter",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/mets_adapter:f8c5a5ad1e566a6607575e30723d92415a188b35"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/latest/recorder",
+    "deleted_at": "2020-10-15T08:03:17.152560",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T12:56:40.526000+01:00",
+    "name": "/catalogue_pipeline/images/latest/recorder",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/recorder:ref.fd4539bbcba323bf1dc09ae962e2573adcc686bd"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/latest/transformer_calm",
+    "deleted_at": "2020-10-15T08:03:17.318332",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T12:56:42.387000+01:00",
+    "name": "/catalogue_pipeline/images/latest/transformer_calm",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/transformer_calm:ref.fd4539bbcba323bf1dc09ae962e2573adcc686bd"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/latest/transformer_miro",
+    "deleted_at": "2020-10-15T08:03:17.563795",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T12:56:40.818000+01:00",
+    "name": "/catalogue_pipeline/images/latest/transformer_miro",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/transformer_miro:ref.fd4539bbcba323bf1dc09ae962e2573adcc686bd"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/latest/transformer_sierra",
+    "deleted_at": "2020-10-15T08:03:17.804406",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T12:56:41.451000+01:00",
+    "name": "/catalogue_pipeline/images/latest/transformer_sierra",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/transformer_sierra:ref.fd4539bbcba323bf1dc09ae962e2573adcc686bd"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/latest/id_minter",
+    "deleted_at": "2020-10-15T08:03:18.294222",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T12:56:40.080000+01:00",
+    "name": "/catalogue_pipeline/images/latest/id_minter",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/id_minter:ref.fd4539bbcba323bf1dc09ae962e2573adcc686bd"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/prod/feature_inferrer",
+    "deleted_at": "2020-10-15T08:03:19.791081",
+    "description": null,
+    "last_modified": "2020-07-02T11:43:10.616000+01:00",
+    "name": "/catalogue_pipeline/images/prod/feature_inferrer",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/feature_inferrer:74e47d1e62f45b66b7a377eb6850c4c21f2f6c6b"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/prod/id_minter",
+    "deleted_at": "2020-10-15T08:03:19.899128",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:20:36.336000+01:00",
+    "name": "/catalogue_pipeline/images/prod/id_minter",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/id_minter:ref.5751ca15e35cf2283da8104bcf5021d578e50435"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/prod/inference_manager",
+    "deleted_at": "2020-10-15T08:03:20.071286",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:20:39.539000+01:00",
+    "name": "/catalogue_pipeline/images/prod/inference_manager",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/inference_manager:ref.5751ca15e35cf2283da8104bcf5021d578e50435"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/prod/ingestor",
+    "deleted_at": "2020-10-15T08:03:20.294503",
+    "description": null,
+    "last_modified": "2020-07-02T11:43:11.448000+01:00",
+    "name": "/catalogue_pipeline/images/prod/ingestor",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingestor:5c55c2662201c24aebd7aaa09b81c91f51b777cb"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/prod/ingestor_images",
+    "deleted_at": "2020-10-15T08:03:20.449037",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:20:38.406000+01:00",
+    "name": "/catalogue_pipeline/images/prod/ingestor_images",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingestor_images:ref.5751ca15e35cf2283da8104bcf5021d578e50435"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/prod/ingestor_works",
+    "deleted_at": "2020-10-15T08:03:20.718167",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:20:37.607000+01:00",
+    "name": "/catalogue_pipeline/images/prod/ingestor_works",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingestor_works:ref.5751ca15e35cf2283da8104bcf5021d578e50435"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/prod/merger",
+    "deleted_at": "2020-10-15T08:03:22.044549",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:20:40.106000+01:00",
+    "name": "/catalogue_pipeline/images/prod/merger",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/merger:ref.5751ca15e35cf2283da8104bcf5021d578e50435"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/prod/recorder",
+    "deleted_at": "2020-10-15T08:03:22.178382",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:20:36.764000+01:00",
+    "name": "/catalogue_pipeline/images/prod/recorder",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/recorder:ref.5751ca15e35cf2283da8104bcf5021d578e50435"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/prod/transformer_calm",
+    "deleted_at": "2020-10-15T08:03:22.370381",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:20:39.117000+01:00",
+    "name": "/catalogue_pipeline/images/prod/transformer_calm",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/transformer_calm:ref.5751ca15e35cf2283da8104bcf5021d578e50435"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/prod/feature_training",
+    "deleted_at": "2020-10-15T08:03:23.996436",
+    "description": null,
+    "last_modified": "2020-07-02T11:43:11.151000+01:00",
+    "name": "/catalogue_pipeline/images/prod/feature_training",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/feature_training:02965d30dc83465e92bfefd703659fa9304137b8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/prod/matcher",
+    "deleted_at": "2020-10-15T08:03:24.263974",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:20:38.784000+01:00",
+    "name": "/catalogue_pipeline/images/prod/matcher",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/matcher:ref.5751ca15e35cf2283da8104bcf5021d578e50435"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/prod/transformer_mets",
+    "deleted_at": "2020-10-15T08:03:24.507257",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:20:35.623000+01:00",
+    "name": "/catalogue_pipeline/images/prod/transformer_mets",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/transformer_mets:ref.5751ca15e35cf2283da8104bcf5021d578e50435"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/prod/transformer_miro",
+    "deleted_at": "2020-10-15T08:03:24.609885",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:20:37.122000+01:00",
+    "name": "/catalogue_pipeline/images/prod/transformer_miro",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/transformer_miro:ref.5751ca15e35cf2283da8104bcf5021d578e50435"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/prod/transformer_sierra",
+    "deleted_at": "2020-10-15T08:03:24.906165",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:20:38.029000+01:00",
+    "name": "/catalogue_pipeline/images/prod/transformer_sierra",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/transformer_sierra:ref.5751ca15e35cf2283da8104bcf5021d578e50435"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/stage/feature_training",
+    "deleted_at": "2020-10-15T08:03:25.024758",
+    "description": null,
+    "last_modified": "2020-07-10T11:59:53.678000+01:00",
+    "name": "/catalogue_pipeline/images/stage/feature_training",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/feature_training:02965d30dc83465e92bfefd703659fa9304137b8"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/stage/inference_manager",
+    "deleted_at": "2020-10-15T08:03:25.121513",
+    "description": null,
+    "last_modified": "2020-07-10T11:59:53.967000+01:00",
+    "name": "/catalogue_pipeline/images/stage/inference_manager",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/inference_manager:bfd6ffff39edd4468d69018bf79ef4abc64bf348"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/stage/transformer_calm",
+    "deleted_at": "2020-10-15T08:03:25.307342",
+    "description": null,
+    "last_modified": "2020-07-10T11:59:53.622000+01:00",
+    "name": "/catalogue_pipeline/images/stage/transformer_calm",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/transformer_calm:bfd6ffff39edd4468d69018bf79ef4abc64bf348"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/stage/transformer_mets",
+    "deleted_at": "2020-10-15T08:03:25.530403",
+    "description": null,
+    "last_modified": "2020-07-10T11:59:53.728000+01:00",
+    "name": "/catalogue_pipeline/images/stage/transformer_mets",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/transformer_mets:bfd6ffff39edd4468d69018bf79ef4abc64bf348"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/stage/transformer_sierra",
+    "deleted_at": "2020-10-15T08:03:25.708702",
+    "description": null,
+    "last_modified": "2020-07-10T11:59:53.426000+01:00",
+    "name": "/catalogue_pipeline/images/stage/transformer_sierra",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/transformer_sierra:f8c5a5ad1e566a6607575e30723d92415a188b35"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/stage/feature_inferrer",
+    "deleted_at": "2020-10-15T08:03:26.347148",
+    "description": null,
+    "last_modified": "2020-07-10T11:59:53.234000+01:00",
+    "name": "/catalogue_pipeline/images/stage/feature_inferrer",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/feature_inferrer:74e47d1e62f45b66b7a377eb6850c4c21f2f6c6b"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/stage/id_minter",
+    "deleted_at": "2020-10-15T08:03:26.528268",
+    "description": null,
+    "last_modified": "2020-07-10T11:59:53.288000+01:00",
+    "name": "/catalogue_pipeline/images/stage/id_minter",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/id_minter:bfd6ffff39edd4468d69018bf79ef4abc64bf348"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/stage/ingestor",
+    "deleted_at": "2020-10-15T08:03:26.690380",
+    "description": null,
+    "last_modified": "2020-07-10T11:59:53.915000+01:00",
+    "name": "/catalogue_pipeline/images/stage/ingestor",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingestor:5c55c2662201c24aebd7aaa09b81c91f51b777cb"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/stage/ingestor_images",
+    "deleted_at": "2020-10-15T08:03:26.996927",
+    "description": null,
+    "last_modified": "2020-07-10T11:59:53.508000+01:00",
+    "name": "/catalogue_pipeline/images/stage/ingestor_images",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingestor_images:860f1a72def8a20a6aafc4c09f993263fd9c128f"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/stage/ingestor_works",
+    "deleted_at": "2020-10-15T08:03:27.282141",
+    "description": null,
+    "last_modified": "2020-07-10T11:59:53.866000+01:00",
+    "name": "/catalogue_pipeline/images/stage/ingestor_works",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingestor_works:860f1a72def8a20a6aafc4c09f993263fd9c128f"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/stage/matcher",
+    "deleted_at": "2020-10-15T08:03:27.430797",
+    "description": null,
+    "last_modified": "2020-07-10T11:59:53.567000+01:00",
+    "name": "/catalogue_pipeline/images/stage/matcher",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/matcher:bfd6ffff39edd4468d69018bf79ef4abc64bf348"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/stage/merger",
+    "deleted_at": "2020-10-15T08:03:28.045730",
+    "description": null,
+    "last_modified": "2020-07-10T11:59:54.019000+01:00",
+    "name": "/catalogue_pipeline/images/stage/merger",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/merger:bfd6ffff39edd4468d69018bf79ef4abc64bf348"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/stage/recorder",
+    "deleted_at": "2020-10-15T08:03:28.193205",
+    "description": null,
+    "last_modified": "2020-07-10T11:59:53.370000+01:00",
+    "name": "/catalogue_pipeline/images/stage/recorder",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/recorder:bfd6ffff39edd4468d69018bf79ef4abc64bf348"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/stage/transformer_miro",
+    "deleted_at": "2020-10-15T08:03:28.290659",
+    "description": null,
+    "last_modified": "2020-07-10T11:59:53.811000+01:00",
+    "name": "/catalogue_pipeline/images/stage/transformer_miro",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/transformer_miro:bfd6ffff39edd4468d69018bf79ef4abc64bf348"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_pipeline/images/staging/transformer_calm",
+    "deleted_at": "2020-10-15T08:03:28.450948",
+    "description": null,
+    "last_modified": "2020-03-24T08:34:15.064000+00:00",
+    "name": "/catalogue_pipeline/images/staging/transformer_calm",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/transformer_calm:5c55c2662201c24aebd7aaa09b81c91f51b777cb"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/goobi_adapter/images/latest/goobi_reader",
+    "deleted_at": "2020-10-15T08:03:29.096316",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-02-11T17:20:11.039000+00:00",
+    "name": "/goobi_adapter/images/latest/goobi_reader",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/goobi_reader:db223ddd9411467ad2f2f9dfcdb653dceb2ff9a0"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/loris/images/latest/loris",
+    "deleted_at": "2020-10-15T08:03:29.503904",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2020-06-02T09:57:41.164000+01:00",
+    "name": "/loris/images/latest/loris",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/loris:e11656ac2282a1929fcfcb9e85c41ce6b0cc19f1"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/loris/images/latest/nginx_loris-delta",
+    "deleted_at": "2020-10-15T08:03:29.760047",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-02-08T12:29:28.848000+00:00",
+    "name": "/loris/images/latest/nginx_loris-delta",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_loris-delta:75d238df8d09848d8148425173587ed271d9b8d9"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/mets_adapter/images/latest/mets_adapter",
+    "deleted_at": "2020-10-15T08:03:29.901401",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:25:06.345000+01:00",
+    "name": "/mets_adapter/images/latest/mets_adapter",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/mets_adapter:ref.fd4539bbcba323bf1dc09ae962e2573adcc686bd"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/mets_adapter/images/prod/mets_adapter",
+    "deleted_at": "2020-10-15T08:03:30.163981",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-17T13:29:05.237000+01:00",
+    "name": "/mets_adapter/images/prod/mets_adapter",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/mets_adapter:ref.497d00e293faa0c64201dad090dec2271d72c74a"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/mets_adapter/images/stage/mets_adapter",
+    "deleted_at": "2020-10-15T08:03:31.196191",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-14T12:36:00.930000+01:00",
+    "name": "/mets_adapter/images/stage/mets_adapter",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/mets_adapter:ref.ff7aa2c5067ebdf713938f42fe08184a0e0b2d52"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/nginx/images/latest/nginx_loris",
+    "deleted_at": "2020-10-15T08:03:31.341143",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2020-03-09T09:36:50.813000+00:00",
+    "name": "/nginx/images/latest/nginx_loris",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_loris:8d740072b5d2cbff454622f8ccf99ed360534e95"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/platform/images/latest/nginx_apigw",
+    "deleted_at": "2020-10-15T08:03:31.461937",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2020-04-28T12:01:24.432000+01:00",
+    "name": "/platform/images/latest/nginx_apigw",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_apigw:28e3e1b1cd4e8ad69ff44f28757eedff9c99a661"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/platform/images/latest/nginx_loris",
+    "deleted_at": "2020-10-15T08:03:31.588017",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2020-06-01T14:25:40.690000+01:00",
+    "name": "/platform/images/latest/nginx_loris",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_loris:2af34d4ec18472323a77207ba69d17b0b224fcae"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/platform/images/latest/fluentbit",
+    "deleted_at": "2020-10-15T08:03:32.456237",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2020-04-29T11:08:33.595000+01:00",
+    "name": "/platform/images/latest/fluentbit",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/fluentbit:2ccd2c68f38aa77a8ac1a32fe3ea54bbbd397a38"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/platform/images/latest/nginx_experience",
+    "deleted_at": "2020-10-15T08:03:32.633420",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2020-04-28T12:01:32.525000+01:00",
+    "name": "/platform/images/latest/nginx_experience",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_experience:28e3e1b1cd4e8ad69ff44f28757eedff9c99a661"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/platform/images/latest/nginx_grafana",
+    "deleted_at": "2020-10-15T08:03:32.787281",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2020-04-28T12:01:43.959000+01:00",
+    "name": "/platform/images/latest/nginx_grafana",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_grafana:28e3e1b1cd4e8ad69ff44f28757eedff9c99a661"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/reindexer/images/latest/reindex_worker",
+    "deleted_at": "2020-10-15T08:03:32.887687",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T09:58:44.797000+01:00",
+    "name": "/reindexer/images/latest/reindex_worker",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/reindex_worker:ref.fd4539bbcba323bf1dc09ae962e2573adcc686bd"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/reindexer/images/prod/reindex_worker",
+    "deleted_at": "2020-10-15T08:03:33.289320",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T09:35:46.448000+01:00",
+    "name": "/reindexer/images/prod/reindex_worker",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/reindex_worker:ref.a32d946b8de10eafef6bf887373c240dca178922"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/requests/images/latest/requests_api",
+    "deleted_at": "2020-10-15T08:03:35.026585",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-10-25T16:21:56.862000+01:00",
+    "name": "/requests/images/latest/requests_api",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/requests_api:d4fb6cc08b9559bbcd0e1c78ad0f0966d458d3d3"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/requests/images/latest/status_api",
+    "deleted_at": "2020-10-15T08:03:35.140954",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-10-18T10:31:02.162000+01:00",
+    "name": "/requests/images/latest/status_api",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/status_api:acefecad19bbcb438abec7cd459a27f154620aad"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/sierra_adapter/images/latest/sierra_bib_merger",
+    "deleted_at": "2020-10-15T08:03:35.384330",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:18:17.804000+01:00",
+    "name": "/sierra_adapter/images/latest/sierra_bib_merger",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/sierra_bib_merger:ref.fd4539bbcba323bf1dc09ae962e2573adcc686bd"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/sierra_adapter/images/latest/sierra_item_merger",
+    "deleted_at": "2020-10-15T08:03:35.603600",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:17:38.570000+01:00",
+    "name": "/sierra_adapter/images/latest/sierra_item_merger",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/sierra_item_merger:ref.fd4539bbcba323bf1dc09ae962e2573adcc686bd"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/sierra_adapter/images/latest/sierra_items_to_dynamo",
+    "deleted_at": "2020-10-15T08:03:35.795995",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:23:04.808000+01:00",
+    "name": "/sierra_adapter/images/latest/sierra_items_to_dynamo",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/sierra_items_to_dynamo:ref.fd4539bbcba323bf1dc09ae962e2573adcc686bd"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/sierra_adapter/images/latest/sierra_reader",
+    "deleted_at": "2020-10-15T08:03:35.994202",
+    "description": "Docker image URL; auto-managed by /weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-22T10:17:10.888000+01:00",
+    "name": "/sierra_adapter/images/latest/sierra_reader",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/sierra_reader:ref.fd4539bbcba323bf1dc09ae962e2573adcc686bd"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/sierra_adapter/images/latest/snapshot_generator",
+    "deleted_at": "2020-10-15T08:03:36.163471",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-11-18T10:44:23.513000+00:00",
+    "name": "/sierra_adapter/images/latest/snapshot_generator",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/snapshot_generator:1e3efab086f8772ed995bd3a046b7dd458e100c2"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/sierra_adapter/images/prod/sierra_bib_merger",
+    "deleted_at": "2020-10-15T08:03:36.442935",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-20T10:33:37.211000+01:00",
+    "name": "/sierra_adapter/images/prod/sierra_bib_merger",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/sierra_bib_merger:ref.5751ca15e35cf2283da8104bcf5021d578e50435"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/sierra_adapter/images/prod/sierra_items_to_dynamo",
+    "deleted_at": "2020-10-15T08:03:37.510182",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-20T10:33:36.282000+01:00",
+    "name": "/sierra_adapter/images/prod/sierra_items_to_dynamo",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/sierra_items_to_dynamo:ref.5751ca15e35cf2283da8104bcf5021d578e50435"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/sierra_adapter/images/prod/sierra_reader",
+    "deleted_at": "2020-10-15T08:03:38.555089",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-20T10:33:34.784000+01:00",
+    "name": "/sierra_adapter/images/prod/sierra_reader",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/sierra_reader:ref.5751ca15e35cf2283da8104bcf5021d578e50435"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/sierra_adapter/images/prod/sierra_item_merger",
+    "deleted_at": "2020-10-15T08:03:38.922516",
+    "description": "Docker image URL; auto-managed by /Users/robertkenny/workspace/weco-deploy/src/deploy/parameter_store.py",
+    "last_modified": "2020-07-20T10:33:36.758000+01:00",
+    "name": "/sierra_adapter/images/prod/sierra_item_merger",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/sierra_item_merger:ref.5751ca15e35cf2283da8104bcf5021d578e50435"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/releases/goobi_adapter/latest/goobi_reader",
+    "deleted_at": "2020-10-15T08:08:14.180797",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-02-11T16:51:40.530000+00:00",
+    "name": "/releases/goobi_adapter/latest/goobi_reader",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/goobi_reader:18810b70b158580de8e7e7a50b03bade3c11978f"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/releases/loris/latest/loris",
+    "deleted_at": "2020-10-15T08:08:14.541169",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2020-02-07T13:44:59.802000+00:00",
+    "name": "/releases/loris/latest/loris",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/loris:bd11fef5f08ac9c31b6f098a8179f292132cf6c3"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/releases/nginx/latest/nginx_apigw",
+    "deleted_at": "2020-10-15T08:08:14.785413",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2020-02-11T12:10:58.930000+00:00",
+    "name": "/releases/nginx/latest/nginx_apigw",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_apigw:101888832d5f0f339a335a4a6228c62809d84369"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/releases/nginx/latest/nginx_grafana",
+    "deleted_at": "2020-10-15T08:08:14.927041",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2020-02-11T12:11:17.740000+00:00",
+    "name": "/releases/nginx/latest/nginx_grafana",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_grafana:101888832d5f0f339a335a4a6228c62809d84369"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/releases/nginx/latest/nginx_loris",
+    "deleted_at": "2020-10-15T08:08:15.196724",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2020-02-11T12:11:08.322000+00:00",
+    "name": "/releases/nginx/latest/nginx_loris",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_loris:101888832d5f0f339a335a4a6228c62809d84369"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/releases/pipeline/latest/id_minter",
+    "deleted_at": "2020-10-15T08:08:15.354266",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-02-12T07:54:00.639000+00:00",
+    "name": "/releases/pipeline/latest/id_minter",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/id_minter:a78bd33181faf00031e1af2555e52a9a34401b74"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/releases/pipeline/latest/ingestor",
+    "deleted_at": "2020-10-15T08:08:15.590783",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-02-12T07:59:43.247000+00:00",
+    "name": "/releases/pipeline/latest/ingestor",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ingestor:a78bd33181faf00031e1af2555e52a9a34401b74"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/releases/pipeline/latest/matcher",
+    "deleted_at": "2020-10-15T08:08:15.825401",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-02-12T08:10:01.097000+00:00",
+    "name": "/releases/pipeline/latest/matcher",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/matcher:a78bd33181faf00031e1af2555e52a9a34401b74"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/releases/pipeline/latest/merger",
+    "deleted_at": "2020-10-15T08:08:15.983284",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-02-12T08:12:40.178000+00:00",
+    "name": "/releases/pipeline/latest/merger",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/merger:a78bd33181faf00031e1af2555e52a9a34401b74"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/releases/pipeline/latest/recorder",
+    "deleted_at": "2020-10-15T08:08:16.216043",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-02-12T08:12:52.919000+00:00",
+    "name": "/releases/pipeline/latest/recorder",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/recorder:a78bd33181faf00031e1af2555e52a9a34401b74"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/releases/pipeline/transformer/latest/transformer_miro",
+    "deleted_at": "2020-10-15T08:08:16.718370",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-02-12T08:08:07.349000+00:00",
+    "name": "/releases/pipeline/transformer/latest/transformer_miro",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/transformer_miro:a78bd33181faf00031e1af2555e52a9a34401b74"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/releases/pipeline/transformer/latest/transformer_sierra",
+    "deleted_at": "2020-10-15T08:08:16.816043",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-02-12T08:12:28.466000+00:00",
+    "name": "/releases/pipeline/transformer/latest/transformer_sierra",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/transformer_sierra:a78bd33181faf00031e1af2555e52a9a34401b74"
+  },
+  {
+    "arn": "arn:aws:ssm:eu-west-1:760097843905:parameter/releases/reindexer/latest/reindex_worker",
+    "deleted_at": "2020-10-15T08:08:17.025993",
+    "description": "Docker image URL; auto-managed by /builds/publish_service_to_aws.py",
+    "last_modified": "2019-02-11T16:51:40.667000+00:00",
+    "name": "/releases/reindexer/latest/reindex_worker",
+    "value": "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/reindex_worker:18810b70b158580de8e7e7a50b03bade3c11978f"
+  }
+]


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/4846

We still have some services not using weco-deploy (Loris, bits of Archivematica, the stacks service), but this clears out a lot of them. Already run and results recorded; PR just for visibility.