### PR TITLE
Allow identity-ci to manage Lambdas and API gateways

### DIFF
--- a/accounts/identity/iam_identity_ci.tf
+++ b/accounts/identity/iam_identity_ci.tf
@@ -4,6 +4,39 @@ resource "aws_iam_role_policy" "identity_ci" {
 }
 
 data "aws_iam_policy_document" "identity_ci" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "lambda:CreateAlias",
+      "lambda:GetFunction",
+      "lambda:CreateFunction",
+      "lambda:DeleteFunction",
+      "lambda:UpdateFunctionCode",
+      "lambda:GetFunctionConfiguration",
+      "lambda:UpdateFunctionConfiguration",
+      "lambda:AddPermission",
+      "lambda:RemovePermission",
+      "lambda:InvokeFunction"
+    ]
+
+    resources = [
+      "arn:aws:lambda:::function:identity-api-*",
+      "arn:aws:lambda:::function:identity-authorizer-*"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "apigateway:*"
+    ]
+
+    resources = [
+      "arn:aws:apigateway:::/restapis/*/stages",
+      "arn:aws:apigateway:::/restapis/*/stages/*"
+    ]
+  }
 
   statement {
     effect = "Allow"


### PR DESCRIPTION
This is needed so the deployment scripts in buildkite are able to
execute the following steps:

- Create a new version of Lambda Function from S3 reference
- Create a Lambda alias to the new version
- Fetch all resources in the API gateway
  - Update their integrations with the new Lambda.
- Update the API gateway authorizer to point to the new lambda.
- Create a new API gateway deployment.