### PR TITLE
Adds SES verification and DKIM records for Identity project

### DIFF
--- a/dns/locals.tf
+++ b/dns/locals.tf
@@ -7,7 +7,7 @@ locals {
   // want to allow the outputs from that stack to set those details here in order
   // to more tightly control of wellcomecollection.org records in this stack.
   identity_ses_txt_records = data.terraform_remote_state.identity.outputs.wellcomecollection_org_ses_vertification_token[["records"]]
-  identity_dkim_cname = data.terraform_remote_state.identity.outputs.wellcomecollection_org_ses_dkim_tokens
+  identity_dkim_cname      = data.terraform_remote_state.identity.outputs.wellcomecollection_org_ses_dkim_tokens
   identity_ses_dkim_records = toset([
     for record in local.identity_dkim_cname : split(".", record["name"])[0]
   ])

--- a/dns/locals.tf
+++ b/dns/locals.tf
@@ -1,4 +1,14 @@
 
 locals {
   identity_zone_name_servers = data.terraform_remote_state.identity.outputs.identity_zone_name_servers
+
+  // The outputs from the identity stack contain enough information to construct
+  // the whole record (including type, and name) which is useful _but_ we don't
+  // want to allow the outputs from that stack to set those details here in order
+  // to more tightly control of wellcomecollection.org records in this stack.
+  identity_ses_txt_records = data.terraform_remote_state.identity.outputs.wellcomecollection_org_ses_vertification_token[["records"]]
+  identity_dkim_cname = data.terraform_remote_state.identity.outputs.wellcomecollection_org_ses_dkim_tokens
+  identity_ses_dkim_records = toset([
+    for record in local.identity_dkim_cname : split(".", record["name"])[0]
+  ])
 }

--- a/dns/main.tf
+++ b/dns/main.tf
@@ -70,7 +70,7 @@ resource "aws_route53_record" "identity-ses-txt" {
   name    = "_amazonses.${data.aws_route53_zone.weco_zone.name}"
   type    = "TXT"
   ttl     = "300"
-  records = [local.identity_ses_txt_verification_record_value]
+  records = local.identity_ses_txt_records
 
   provider = aws.dns
 }

--- a/dns/main.tf
+++ b/dns/main.tf
@@ -64,3 +64,25 @@ resource "aws_route53_record" "identity-ns" {
 
   provider = aws.dns
 }
+
+resource "aws_route53_record" "identity-ses-txt" {
+  zone_id = data.aws_route53_zone.weco_zone.id
+  name    = "_amazonses.${data.aws_route53_zone.weco_zone.name}"
+  type    = "TXT"
+  ttl     = "300"
+  records = [local.identity_ses_txt_verification_record_value]
+
+  provider = aws.dns
+}
+
+resource "aws_route53_record" "identity-ses-dkim-cname" {
+  for_each = local.identity_ses_dkim_records
+
+  zone_id = data.aws_route53_zone.weco_zone.id
+  name    = "${each.value}._domainkey.${data.aws_route53_zone.weco_zone.name}"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["${each.value}.dkim.amazonses.com"]
+
+  provider = aws.dns
+}


### PR DESCRIPTION
Verifies SES as capable of using `wellcomecollection.org` to send e-mail. 

See https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail to understand what's going on with the DKIM records!