### PR TITLE
Add NS records for account.wellcomecollection.org

### DIFF
--- a/dns/locals.tf
+++ b/dns/locals.tf
@@ -1,6 +1,7 @@
 
 locals {
   identity_zone_name_servers = data.terraform_remote_state.identity.outputs.identity_zone_name_servers
+  account_zone_name_servers = data.terraform_remote_state.identity.outputs.account_zone_name_servers
 
   // The outputs from the identity stack contain enough information to construct
   // the whole record (including type, and name) which is useful _but_ we don't

--- a/dns/main.tf
+++ b/dns/main.tf
@@ -65,6 +65,20 @@ resource "aws_route53_record" "identity-ns" {
   provider = aws.dns
 }
 
+resource "aws_route53_zone" "account" {
+  name = "account.${data.aws_route53_zone.weco_zone.name}"
+}
+
+resource "aws_route53_record" "account-ns" {
+  zone_id = data.aws_route53_zone.weco_zone.id
+  name    = "account.${data.aws_route53_zone.weco_zone.name}"
+  type    = "NS"
+  ttl     = "300"
+  records = local.account_zone_name_servers
+
+  provider = aws.dns
+}
+
 resource "aws_route53_record" "identity-ses-txt" {
   zone_id = data.aws_route53_zone.weco_zone.id
   name    = "_amazonses.${data.aws_route53_zone.weco_zone.name}"

--- a/dns/main.tf
+++ b/dns/main.tf
@@ -51,20 +51,6 @@ module "www" {
 # Delegates access to the identity account hosted zone
 # See: https://github.com/wellcomecollection/identity
 
-resource "aws_route53_zone" "identity" {
-  name = "identity.${data.aws_route53_zone.weco_zone.name}"
-}
-
-resource "aws_route53_record" "identity-ns" {
-  zone_id = data.aws_route53_zone.weco_zone.id
-  name    = "identity.${data.aws_route53_zone.weco_zone.name}"
-  type    = "NS"
-  ttl     = "300"
-  records = local.identity_zone_name_servers
-
-  provider = aws.dns
-}
-
 resource "aws_route53_zone" "account" {
   name = "account.${data.aws_route53_zone.weco_zone.name}"
 }


### PR DESCRIPTION
We'll use `account.wellcomecollection.org` rather than `identity.wellcomecollection.org`.

This PR adds the NS records for `accounts`.

Note: This change is applied.