### PR TITLE
Rescoping API Gateway permissions for Identity CI user

### DIFF
--- a/accounts/identity/iam_identity_ci.tf
+++ b/accounts/identity/iam_identity_ci.tf
@@ -32,8 +32,7 @@ data "aws_iam_policy_document" "identity_ci" {
     ]
 
     resources = [
-      "arn:aws:apigateway:eu-west-1::/restapis/*/stages",
-      "arn:aws:apigateway:eu-west-1::/restapis/*/stages/*"
+      "arn:aws:apigateway:eu-west-1::*"
     ]
   }
 


### PR DESCRIPTION
The current ARN for the API Gateway IAM permissions for the Identity CI user target the `/stages` resources only. This is incorrect, wider scope is required. This change widens that scope to all API Gateway resources.