### PR TITLE
Adding Lambda 'GetAlias' to Identity CI

### DIFF
--- a/accounts/identity/iam_identity_ci.tf
+++ b/accounts/identity/iam_identity_ci.tf
@@ -17,6 +17,7 @@ data "aws_iam_policy_document" "identity_ci" {
       "lambda:GetFunctionConfiguration",
       "lambda:InvokeFunction",
       "lambda:RemovePermission",
+      "lambda:UpdateAlias",
       "lambda:UpdateFunctionCode",
       "lambda:UpdateFunctionConfiguration",
     ]

--- a/accounts/identity/iam_identity_ci.tf
+++ b/accounts/identity/iam_identity_ci.tf
@@ -12,6 +12,7 @@ data "aws_iam_policy_document" "identity_ci" {
       "lambda:CreateAlias",
       "lambda:CreateFunction",
       "lambda:DeleteFunction",
+      "lambda:GetAlias",
       "lambda:GetFunction",
       "lambda:GetFunctionConfiguration",
       "lambda:InvokeFunction",


### PR DESCRIPTION
In order to complete the Buildkite deployment pipeline, the Identity CI user must be able to determine if a Lambda alias already exists.