### PR TITLE
Adding 'lambda:GetPolicy' permission to 'identity-ci' IAM user

### DIFF
--- a/accounts/identity/iam_identity_ci.tf
+++ b/accounts/identity/iam_identity_ci.tf
@@ -15,6 +15,7 @@ data "aws_iam_policy_document" "identity_ci" {
       "lambda:GetAlias",
       "lambda:GetFunction",
       "lambda:GetFunctionConfiguration",
+      "lambda:GetPolicy",
       "lambda:InvokeFunction",
       "lambda:RemovePermission",
       "lambda:UpdateAlias",


### PR DESCRIPTION
Required to allow the CI / CD process to determine if the respective IAM policy already exists.