### PR TITLE
Adds lambda@edge redirects for Loris -> DLCS change

### DIFF
--- a/cloudfront/.gitignore
+++ b/cloudfront/.gitignore
@@ -1,0 +1,1 @@
+edge-lambda/*.zip

--- a/cloudfront/.terraform.lock.hcl
+++ b/cloudfront/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.0.0"
+  hashes = [
+    "h1:eOUi4EO4QTgPuz+gmD8xy2LTTxNfyc9txyc9PDARth8=",
+    "zh:1c3300a6686481ed0b3ce456949805b5c55f901b77108543046f12118a102914",
+    "zh:2d44bcc8a5ea3f2c2ff54ca4c4b273cdc3500ad8bb6929eec6722bb9d10a9714",
+    "zh:4be17c4e06a74ca30a3c9e88446e453ad16c493b2ddef872a6580dbfe618a1b4",
+    "zh:50c216a6c672b51d67ece37ce69c121acbcd5c8d24b899e876c61bc09989f69f",
+    "zh:90d6ad51fecab8d2f086aab9ed45020f1a9d3627dbc95edda11af8e3f87082d9",
+    "zh:d147427135330b4940a85a0f552e2c1f83a0d1ccdcc82c36a2d311b7f85dbd38",
+    "zh:dd4b8c0b113e37fd83ceab0f8a203ccfa39caaca5551c70a94fa61e900902932",
+    "zh:e30ef64a2ed0c2a6e8d1e29b8da8b05b4a303e256478a4b410af81c81cbcbc23",
+    "zh:e5a81379810d3e1f380b7145d0ecee4a69ab4e80184f77b66cd4411b86aca6a8",
+    "zh:f9a0a2a72721e7e047e83053173b3a68a7d53e2a22719cc2d9234dbee46c466c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "2.70.0"
+  constraints = "~> 2.7"
+  hashes = [
+    "h1:mM6eIaG1Gcrk47TveViXBO9YjY6nDaGukbED2bdo8Mk=",
+    "zh:01a5f351146434b418f9ff8d8cc956ddc801110f1cc8b139e01be2ff8c544605",
+    "zh:1ec08abbaf09e3e0547511d48f77a1e2c89face2d55886b23f643011c76cb247",
+    "zh:606d134fef7c1357c9d155aadbee6826bc22bc0115b6291d483bc1444291c3e1",
+    "zh:67e31a71a5ecbbc96a1a6708c9cc300bbfe921c322320cdbb95b9002026387e1",
+    "zh:75aa59ae6f0834ed7142c81569182a658e4c22724a34db5d10f7545857d8db0c",
+    "zh:76880f29fca7a0a3ff1caef31d245af2fb12a40709d67262e099bc22d039a51d",
+    "zh:aaeaf97ffc1f76714e68bc0242c7407484c783d604584c04ad0b267b6812b6dc",
+    "zh:ae1f88d19cc85b2e9b6ef71994134d55ef7830fd02f1f3c58c0b3f2b90e8b337",
+    "zh:b155bdda487461e7b3d6e3a8d5ce5c887a047e4d983512e81e2c8266009f2a1f",
+    "zh:ba394a7c391a26c4a91da63ad680e83bde0bc1ecc0a0856e26e9d62a4e77c408",
+    "zh:e243c9d91feb0979638f28eb26f89ebadc179c57a2bd299b5729fb52bd1902f2",
+    "zh:f6c05e20d9a3fba76ca5f47206dde35e5b43b6821c6cbf57186164ce27ba9f15",
+  ]
+}

--- a/cloudfront/edge-lambda/dlcs_path_rewrite.js
+++ b/cloudfront/edge-lambda/dlcs_path_rewrite.js
@@ -2,8 +2,9 @@
 
 // lambda@edge Origin Request trigger to remove the first path element
 
-exports.request = (event, context) => {
+exports.request = (event, context, callback) => {
     const request = event.Records[0].cf.request;           // extract the request object
-    request.uri = request.uri.replace(/^\/[^\/]+\//,'/');  // modify the URI
+    request.uri = request.uri.replace("/image/","/");      // remove leading /image/ from iiif URL
+    request.uri = request.uri.replace(".jpg/","/");        // remove any non path terminating .jpg from iiif URL
     return callback(null, request);                        // return control to CloudFront
 };

--- a/cloudfront/edge-lambda/dlcs_path_rewrite.js
+++ b/cloudfront/edge-lambda/dlcs_path_rewrite.js
@@ -1,0 +1,9 @@
+'use strict';
+
+// lambda@edge Origin Request trigger to remove the first path element
+
+exports.request = (event, context) => {
+    const request = event.Records[0].cf.request;           // extract the request object
+    request.uri = request.uri.replace(/^\/[^\/]+\//,'/');  // modify the URI
+    return callback(null, request);                        // return control to CloudFront
+};

--- a/cloudfront/iiif/main.tf
+++ b/cloudfront/iiif/main.tf
@@ -80,6 +80,24 @@ resource "aws_cloudfront_distribution" "iiif" {
     }
   }
 
+  origin {
+    domain_name = local.dlcs_domain
+    origin_id   = "dlcs_space_8"
+    origin_path = "/iiif-img/wellcome/8"
+
+    custom_origin_config {
+      origin_protocol_policy = "match-viewer"
+      origin_ssl_protocols = [
+        "TLSv1",
+        "TLSv1.1",
+        "TLSv1.2",
+      ]
+
+      http_port  = 80
+      https_port = 443
+    }
+  }
+
   enabled         = true
   is_ipv6_enabled = true
   comment         = "IIIF APIs (${var.environment})"
@@ -108,29 +126,7 @@ resource "aws_cloudfront_distribution" "iiif" {
     path_pattern     = "image/V00*"
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = "loris"
-
-    forwarded_values {
-      query_string = true
-      headers      = []
-
-      cookies {
-        forward = "none"
-      }
-    }
-
-    min_ttl     = 604800
-    default_ttl = 86400
-    max_ttl     = 31536000
-
-    viewer_protocol_policy = "redirect-to-https"
-  }
-
-  ordered_cache_behavior {
-    path_pattern     = "image/L00*"
-    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
-    cached_methods   = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = "loris"
+    target_origin_id = var.miro_sourced_images_target
 
     forwarded_values {
       query_string = true
@@ -145,7 +141,37 @@ resource "aws_cloudfront_distribution" "iiif" {
       for_each = var.dlcs_lambda_associations
       content {
         event_type = lambda_function_association.value["event_type"]
-        lambda_arn = lambda_function_association.value["lambda_function_association"]
+        lambda_arn = lambda_function_association.value["lambda_arn"]
+      }
+    }
+
+    min_ttl     = 604800
+    default_ttl = 86400
+    max_ttl     = 31536000
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "image/L00*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = var.miro_sourced_images_target
+
+    forwarded_values {
+      query_string = true
+      headers      = []
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    dynamic "lambda_function_association" {
+      for_each = var.dlcs_lambda_associations
+      content {
+        event_type = lambda_function_association.value["event_type"]
+        lambda_arn = lambda_function_association.value["lambda_arn"]
       }
     }
 
@@ -160,7 +186,7 @@ resource "aws_cloudfront_distribution" "iiif" {
     path_pattern     = "image/M00*"
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = "loris"
+    target_origin_id = var.miro_sourced_images_target
 
     forwarded_values {
       query_string = true
@@ -168,6 +194,14 @@ resource "aws_cloudfront_distribution" "iiif" {
 
       cookies {
         forward = "none"
+      }
+    }
+
+    dynamic "lambda_function_association" {
+      for_each = var.dlcs_lambda_associations
+      content {
+        event_type = lambda_function_association.value["event_type"]
+        lambda_arn = lambda_function_association.value["lambda_arn"]
       }
     }
 
@@ -182,7 +216,7 @@ resource "aws_cloudfront_distribution" "iiif" {
     path_pattern     = "image/B00*"
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = "loris"
+    target_origin_id = var.miro_sourced_images_target
 
     forwarded_values {
       query_string = true
@@ -190,6 +224,14 @@ resource "aws_cloudfront_distribution" "iiif" {
 
       cookies {
         forward = "none"
+      }
+    }
+
+    dynamic "lambda_function_association" {
+      for_each = var.dlcs_lambda_associations
+      content {
+        event_type = lambda_function_association.value["event_type"]
+        lambda_arn = lambda_function_association.value["lambda_arn"]
       }
     }
 
@@ -204,7 +246,7 @@ resource "aws_cloudfront_distribution" "iiif" {
     path_pattern     = "image/N00*"
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = "loris"
+    target_origin_id = var.miro_sourced_images_target
 
     forwarded_values {
       query_string = true
@@ -212,6 +254,14 @@ resource "aws_cloudfront_distribution" "iiif" {
 
       cookies {
         forward = "none"
+      }
+    }
+
+    dynamic "lambda_function_association" {
+      for_each = var.dlcs_lambda_associations
+      content {
+        event_type = lambda_function_association.value["event_type"]
+        lambda_arn = lambda_function_association.value["lambda_arn"]
       }
     }
 
@@ -226,7 +276,7 @@ resource "aws_cloudfront_distribution" "iiif" {
     path_pattern     = "image/A00*"
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = "loris"
+    target_origin_id = var.miro_sourced_images_target
 
     forwarded_values {
       query_string = true
@@ -234,6 +284,14 @@ resource "aws_cloudfront_distribution" "iiif" {
 
       cookies {
         forward = "none"
+      }
+    }
+
+    dynamic "lambda_function_association" {
+      for_each = var.dlcs_lambda_associations
+      content {
+        event_type = lambda_function_association.value["event_type"]
+        lambda_arn = lambda_function_association.value["lambda_arn"]
       }
     }
 
@@ -248,7 +306,7 @@ resource "aws_cloudfront_distribution" "iiif" {
     path_pattern     = "image/W00*"
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = "loris"
+    target_origin_id = var.miro_sourced_images_target
 
     forwarded_values {
       query_string = true
@@ -256,6 +314,14 @@ resource "aws_cloudfront_distribution" "iiif" {
 
       cookies {
         forward = "none"
+      }
+    }
+
+    dynamic "lambda_function_association" {
+      for_each = var.dlcs_lambda_associations
+      content {
+        event_type = lambda_function_association.value["event_type"]
+        lambda_arn = lambda_function_association.value["lambda_arn"]
       }
     }
 
@@ -270,7 +336,7 @@ resource "aws_cloudfront_distribution" "iiif" {
     path_pattern     = "image/S00*"
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = "loris"
+    target_origin_id = var.miro_sourced_images_target
 
     forwarded_values {
       query_string = true
@@ -278,6 +344,14 @@ resource "aws_cloudfront_distribution" "iiif" {
 
       cookies {
         forward = "none"
+      }
+    }
+
+    dynamic "lambda_function_association" {
+      for_each = var.dlcs_lambda_associations
+      content {
+        event_type = lambda_function_association.value["event_type"]
+        lambda_arn = lambda_function_association.value["lambda_arn"]
       }
     }
 

--- a/cloudfront/iiif/main.tf
+++ b/cloudfront/iiif/main.tf
@@ -141,6 +141,14 @@ resource "aws_cloudfront_distribution" "iiif" {
       }
     }
 
+    dynamic "lambda_function_association" {
+      for_each = var.dlcs_lambda_associations
+      content {
+        event_type = lambda_function_association.value["event_type"]
+        lambda_arn = lambda_function_association.value["lambda_function_association"]
+      }
+    }
+
     min_ttl     = 604800
     default_ttl = 86400
     max_ttl     = 31536000

--- a/cloudfront/iiif/variables.tf
+++ b/cloudfront/iiif/variables.tf
@@ -5,3 +5,12 @@ variable "environment" {
 variable "acm_certificate_arn" {
   type = string
 }
+
+variable "dlcs_lambda_associations" {
+  default = []
+
+  type = list(object({
+    event_type = string
+    lambda_arn = string
+  }))
+}

--- a/cloudfront/iiif/variables.tf
+++ b/cloudfront/iiif/variables.tf
@@ -14,3 +14,7 @@ variable "dlcs_lambda_associations" {
     lambda_arn = string
   }))
 }
+
+variable "miro_sourced_images_target" {
+  default = "loris"
+}

--- a/cloudfront/lambdas.tf
+++ b/cloudfront/lambdas.tf
@@ -1,0 +1,38 @@
+resource "aws_lambda_function" "dlcs_path_rewrite" {
+  provider = aws.us_east_1
+
+  function_name = "cf_edge_dlcs_path_rewrite"
+  role          = aws_iam_role.edge_lambda_role.arn
+  runtime       = "nodejs12.x"
+  handler       = "dlcs_path_rewite.request"
+  filename      = "${path.module}/edge-lambda/dlcs_path_rewrite.zip"
+  publish       = true
+}
+
+data "archive_file" "dlcs_path_rewite" {
+  type        = "zip"
+  source_file = "${path.module}/edge-lambda/dlcs_path_rewrite.js"
+  output_path = "${path.module}/edge-lambda/dlcs_path_rewrite.zip"
+}
+
+resource "aws_iam_role" "edge_lambda_role" {
+  provider = aws.us_east_1
+
+  name_prefix        = "edge_lambda"
+  assume_role_policy = data.aws_iam_policy_document.lambda.json
+}
+
+data "aws_iam_policy_document" "lambda" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+
+      identifiers = [
+        "lambda.amazonaws.com",
+        "edgelambda.amazonaws.com",
+      ]
+    }
+  }
+}

--- a/cloudfront/lambdas.tf
+++ b/cloudfront/lambdas.tf
@@ -4,9 +4,11 @@ resource "aws_lambda_function" "dlcs_path_rewrite" {
   function_name = "cf_edge_dlcs_path_rewrite"
   role          = aws_iam_role.edge_lambda_role.arn
   runtime       = "nodejs12.x"
-  handler       = "dlcs_path_rewite.request"
+  handler       = "dlcs_path_rewrite.request"
   filename      = "${path.module}/edge-lambda/dlcs_path_rewrite.zip"
   publish       = true
+
+  source_code_hash = data.archive_file.dlcs_path_rewite.output_base64sha256
 }
 
 data "archive_file" "dlcs_path_rewite" {
@@ -20,6 +22,11 @@ resource "aws_iam_role" "edge_lambda_role" {
 
   name_prefix        = "edge_lambda"
   assume_role_policy = data.aws_iam_policy_document.lambda.json
+}
+
+resource "aws_iam_role_policy_attachment" "basic_execution_role" {
+  role       = aws_iam_role.edge_lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
 data "aws_iam_policy_document" "lambda" {

--- a/cloudfront/locals.tf
+++ b/cloudfront/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  dlcs_path_rewrite_arn        = aws_lambda_function.dlcs_path_rewrite.arn
+  dlcs_path_rewrite_latest     = aws_lambda_function.dlcs_path_rewrite.version
+  dlcs_path_rewrite_arn_latest = "${local.dlcs_path_rewrite_arn}:${local.dlcs_path_rewrite_latest}"
+  dlcs_path_rewrite_arn_stage  = local.dlcs_path_rewrite_arn_latest
+  dlcs_path_rewrite_arn_prod   = ""
+}

--- a/cloudfront/main.tf
+++ b/cloudfront/main.tf
@@ -10,6 +10,17 @@ module "iiif-stage" {
 
   environment         = "stage"
   acm_certificate_arn = data.aws_acm_certificate.iiif_wc_org.arn
+
+  dlcs_lambda_associations = [
+    {
+      event_type = "origin-request"
+      lambda_arn = local.dlcs_path_rewrite_arn_latest
+    }
+  ]
+
+  # Temporary variable to differentiate prod/stage cache behaviour
+  # Defaults to "loris" where unspecified
+  miro_sourced_images_target = "dlcs_space_8"
 }
 
 module "iiif-test" {

--- a/cloudfront/outputs.tf
+++ b/cloudfront/outputs.tf
@@ -1,0 +1,3 @@
+output "dlcs_path_rewrite_arn_latest" {
+  value = local.dlcs_path_rewrite_arn_latest
+}

--- a/cloudfront/provider.tf
+++ b/cloudfront/provider.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region  = "eu-west-1"
+  region = "eu-west-1"
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
@@ -9,7 +9,7 @@ provider "aws" {
 provider "aws" {
   alias = "us_east_1"
 
-  region  = "us-east-1"
+  region = "us-east-1"
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"

--- a/cloudfront/provider.tf
+++ b/cloudfront/provider.tf
@@ -1,6 +1,5 @@
 provider "aws" {
   region  = "eu-west-1"
-  version = "~> 2.7"
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
@@ -11,7 +10,6 @@ provider "aws" {
   alias = "us_east_1"
 
   region  = "us-east-1"
-  version = "~> 2.7"
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"


### PR DESCRIPTION
This change will redirect a set of Miro images in the staging environment to the new DLCS space where images are being registered as part of the miro migration work.

This PR intends to demonstrate a practical approach in code for moving staging/prod over from Loris to DLCS in a piecemeal fashion in order to ensure that this approach is viable and that all images are available. 

TODO:
- [x] Associate lambda with stage `ordered_cache_behaviour` for `"image/L00*"`
- [x] Associate lambda with all miro `ordered_cache_behaviour` image sets in stage.

Part of https://github.com/wellcomecollection/platform/issues/4883