### PR TITLE
Add some VPC endpoints for connecting to ECR

### DIFF
--- a/accounts/modules/account/federated/outputs.tf
+++ b/accounts/modules/account/federated/outputs.tf
@@ -1,21 +1,21 @@
 output "principal" {
-  value = "${local.principal}"
+  value = local.principal
 }
 
 output "list_roles_user_id" {
-  value = "${module.list_roles_user.user_id}"
+  value = module.list_roles_user.user_id
 }
 
 output "list_roles_user_secret" {
-  value = "${module.list_roles_user.user_secret}"
+  value = module.list_roles_user.user_secret
 }
 
 output "list_roles_name" {
-  value = "${module.list_roles_user.name}"
+  value = module.list_roles_user.name
 }
 
 output "list_roles_arn" {
-  value = "${module.list_roles_user.arn}"
+  value = module.list_roles_user.arn
 }
 
 variable "saml_xml" {}

--- a/accounts/modules/assumable_role/aws/variables.tf
+++ b/accounts/modules/assumable_role/aws/variables.tf
@@ -1,7 +1,7 @@
 variable "name" {}
 
 variable "principals" {
-  type = list
+  type = list(any)
 }
 
 variable "max_session_duration_in_seconds" {

--- a/accounts/modules/assumable_role/federated/outputs.tf
+++ b/accounts/modules/assumable_role/federated/outputs.tf
@@ -1,7 +1,7 @@
 output "arn" {
-  value = "${aws_iam_role.role.arn}"
+  value = aws_iam_role.role.arn
 }
 
 output "name" {
-  value = "${aws_iam_role.role.name}"
+  value = aws_iam_role.role.name
 }

--- a/accounts/modules/interface_endpoint/main.tf
+++ b/accounts/modules/interface_endpoint/main.tf
@@ -1,0 +1,40 @@
+variable "service" {}
+variable "vpc_id" {}
+
+variable "security_group_ids" {
+  type = list(string)
+}
+
+variable "subnet_ids" {
+  type = list(string)
+}
+
+data "aws_vpc" "selected" {
+  id = var.vpc_id
+}
+
+locals {
+  vpc_name  = lookup(data.aws_vpc.selected.tags, "name", var.vpc_id)
+  vpc_label = split(",", local.vpc_name)[0]
+}
+
+data "aws_vpc_endpoint_service" "service" {
+  service = var.service
+}
+
+resource "aws_vpc_endpoint" "endpoint" {
+  vpc_id            = var.vpc_id
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = var.security_group_ids
+
+  subnet_ids = var.subnet_ids
+
+  service_name = data.aws_vpc_endpoint_service.service.service_name
+
+  private_dns_enabled = true
+
+  tags = {
+    Name = "${local.vpc_label}-${var.service}"
+  }
+}

--- a/accounts/modules/interface_endpoint/main.tf
+++ b/accounts/modules/interface_endpoint/main.tf
@@ -14,8 +14,8 @@ data "aws_vpc" "selected" {
 }
 
 locals {
-  vpc_name  = lookup(data.aws_vpc.selected.tags, "name", var.vpc_id)
-  vpc_label = split(",", local.vpc_name)[0]
+  vpc_name  = lookup(data.aws_vpc.selected.tags, "Name", var.vpc_id)
+  vpc_label = split("-", local.vpc_name)[0]
 }
 
 data "aws_vpc_endpoint_service" "service" {
@@ -35,6 +35,6 @@ resource "aws_vpc_endpoint" "endpoint" {
   private_dns_enabled = true
 
   tags = {
-    Name = "${local.vpc_label}-${var.service}"
+    Name = "${local.vpc_label}-${var.service}-vpc_endpoint"
   }
 }

--- a/accounts/modules/users/list_roles_user/outputs.tf
+++ b/accounts/modules/users/list_roles_user/outputs.tf
@@ -1,9 +1,9 @@
 output "user_id" {
-  value = "${aws_iam_access_key.access_key.id}"
+  value = aws_iam_access_key.access_key.id
 }
 
 output "user_secret" {
-  value = "${aws_iam_access_key.access_key.encrypted_secret}"
+  value = aws_iam_access_key.access_key.encrypted_secret
 }
 
 output "name" {
@@ -11,5 +11,5 @@ output "name" {
 }
 
 output "arn" {
-  value = "${aws_iam_user.user.arn}"
+  value = aws_iam_user.user.arn
 }

--- a/accounts/modules/vpc/public-private-igw/gateway_endpoint/main.tf
+++ b/accounts/modules/vpc/public-private-igw/gateway_endpoint/main.tf
@@ -2,9 +2,22 @@ data "aws_vpc_endpoint_service" "service" {
   service = var.service
 }
 
+data "aws_vpc" "selected" {
+  id = var.vpc_id
+}
+
+locals {
+  vpc_name  = lookup(data.aws_vpc.selected.tags, "Name", var.vpc_id)
+  vpc_label = split("-", local.vpc_name)[0]
+}
+
 resource "aws_vpc_endpoint" "endpoint" {
   vpc_id       = var.vpc_id
   service_name = data.aws_vpc_endpoint_service.service.service_name
-  route_table_ids = [
-  var.route_table_id]
+
+  route_table_ids = [var.route_table_id]
+
+  tags = {
+    Name = "${local.vpc_label}-${var.service}-vpc_endpoint"
+  }
 }

--- a/builds/terraform/.terraform.lock.hcl
+++ b/builds/terraform/.terraform.lock.hcl
@@ -2,8 +2,7 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "2.47.0"
-  constraints = "~> 2.47.0"
+  version = "2.47.0"
   hashes = [
     "h1:3qUZ+SZqdtlxCd4Luyz+MqHclZvnigwrY8LyKvIvq4U=",
   ]

--- a/builds/terraform/vpc.tf
+++ b/builds/terraform/vpc.tf
@@ -1,0 +1,27 @@
+module "ecr_dkr_vpc_endpoint" {
+  source = "../../accounts/modules/interface_endpoint"
+
+  service = "ecr.dkr"
+  vpc_id  = local.ci_vpc_id
+
+  security_group_ids = [
+    # buildkite-elastic
+    "sg-0b5a4d52331945b7e",
+  ]
+
+  subnet_ids = local.ci_vpc_private_subnets
+}
+
+module "ecr_api_vpc_endpoint" {
+  source = "../../accounts/modules/interface_endpoint"
+
+  service = "ecr.api"
+  vpc_id  = local.ci_vpc_id
+
+  security_group_ids = [
+    # buildkite-elastic
+    "sg-0b5a4d52331945b7e",
+  ]
+
+  subnet_ids = local.ci_vpc_private_subnets
+}


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/4920 and https://github.com/wellcomecollection/platform/issues/4926

We spend ~$300/mo on NAT Gateway in the CI VPC, when almost everything it does is talking within AWS. We should be able to make this cost less spiky.

Also add the Name tags to as many endpoints as can be done from this repo, both for ease of working in the console and cost allocation purposes.