### PR TITLE
Manage our ACM certificates in Terraform

### DIFF
--- a/cloudfront/api.wc.org/cert.tf
+++ b/cloudfront/api.wc.org/cert.tf
@@ -1,0 +1,16 @@
+module "cert" {
+  source = "../modules/certificate"
+
+  domain_name = "api.wellcomecollection.org"
+
+  subject_alternative_names = [
+    "api-stage.wellcomecollection.org",
+  ]
+
+  ttl = 60
+
+  providers = {
+    aws     = aws.us_east_1
+    aws.dns = aws.dns
+  }
+}

--- a/cloudfront/api.wc.org/data.tf
+++ b/cloudfront/api.wc.org/data.tf
@@ -1,5 +1,0 @@
-data "aws_acm_certificate" "api_wc_org" {
-  domain   = "api.wellcomecollection.org"
-  statuses = ["ISSUED"]
-  provider = aws.us_east_1
-}

--- a/cloudfront/api.wc.org/main.tf
+++ b/cloudfront/api.wc.org/main.tf
@@ -2,12 +2,12 @@ module "wellcomecollection-prod" {
   source = "./cloudfront_distro"
 
   environment         = "prod"
-  acm_certificate_arn = data.aws_acm_certificate.api_wc_org.arn
+  acm_certificate_arn = module.cert.arn
 }
 
 module "wellcomecollection-stage" {
   source = "./cloudfront_distro"
 
   environment         = "stage"
-  acm_certificate_arn = data.aws_acm_certificate.api_wc_org.arn
+  acm_certificate_arn = module.cert.arn
 }

--- a/cloudfront/api.wc.org/provider.tf
+++ b/cloudfront/api.wc.org/provider.tf
@@ -15,3 +15,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
   }
 }
+
+provider "aws" {
+  region = "eu-west-1"
+  alias  = "dns"
+
+  assume_role {
+    role_arn = "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update"
+  }
+}

--- a/cloudfront/iiif.wc.org/terraform/cert.tf
+++ b/cloudfront/iiif.wc.org/terraform/cert.tf
@@ -1,0 +1,16 @@
+module "cert" {
+  source = "../../modules/certificate"
+
+  domain_name = "iiif.wellcomecollection.org"
+
+  subject_alternative_names = [
+    "iiif-test.wellcomecollection.org",
+    "iiif-prod.wellcomecollection.org",
+    "iiif-stage.wellcomecollection.org",
+  ]
+
+  providers = {
+    aws     = aws.us_east_1
+    aws.dns = aws.dns
+  }
+}

--- a/cloudfront/iiif.wc.org/terraform/data.tf
+++ b/cloudfront/iiif.wc.org/terraform/data.tf
@@ -1,5 +1,0 @@
-data "aws_acm_certificate" "iiif_wc_org" {
-  domain   = "iiif.wellcomecollection.org"
-  statuses = ["ISSUED"]
-  provider = aws.us_east_1
-}

--- a/cloudfront/iiif.wc.org/terraform/main.tf
+++ b/cloudfront/iiif.wc.org/terraform/main.tf
@@ -2,14 +2,14 @@ module "iiif-prod" {
   source = "./cloudfront_distro"
 
   environment         = "prod"
-  acm_certificate_arn = data.aws_acm_certificate.iiif_wc_org.arn
+  acm_certificate_arn = module.cert.arn
 }
 
 module "iiif-stage" {
   source = "./cloudfront_distro"
 
   environment         = "stage"
-  acm_certificate_arn = data.aws_acm_certificate.iiif_wc_org.arn
+  acm_certificate_arn = module.cert.arn
 
   dlcs_lambda_associations = [
     {
@@ -27,5 +27,5 @@ module "iiif-test" {
   source = "./cloudfront_distro"
 
   environment         = "test"
-  acm_certificate_arn = data.aws_acm_certificate.iiif_wc_org.arn
+  acm_certificate_arn = module.cert.arn
 }

--- a/cloudfront/iiif.wc.org/terraform/provider.tf
+++ b/cloudfront/iiif.wc.org/terraform/provider.tf
@@ -15,3 +15,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
   }
 }
+
+provider "aws" {
+  region = "eu-west-1"
+  alias  = "dns"
+
+  assume_role {
+    role_arn = "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update"
+  }
+}

--- a/cloudfront/logging.wc.org/cert.tf
+++ b/cloudfront/logging.wc.org/cert.tf
@@ -1,0 +1,16 @@
+module "cert" {
+  source = "../modules/certificate"
+
+  domain_name = "logging.wellcomecollection.org"
+
+  subject_alternative_names = [
+    "*.logging.wellcomecollection.org"
+  ]
+
+  ttl = 30
+
+  providers = {
+    aws     = aws.us_east_1
+    aws.dns = aws.dns
+  }
+}

--- a/cloudfront/logging.wc.org/data.tf
+++ b/cloudfront/logging.wc.org/data.tf
@@ -1,5 +1,0 @@
-data "aws_acm_certificate" "logging_wc_org" {
-  domain   = "logging.wellcomecollection.org"
-  statuses = ["ISSUED"]
-  provider = aws.us_east_1
-}

--- a/cloudfront/logging.wc.org/main.tf
+++ b/cloudfront/logging.wc.org/main.tf
@@ -5,5 +5,5 @@ module "kibana-logging" {
   comment = "Kibana (logging)"
 
   origin_domain_name  = "393eaa6b8f93443c851fc957cccdd5cb.eu-west-1.aws.found.io"
-  acm_certificate_arn = data.aws_acm_certificate.logging_wc_org.arn
+  acm_certificate_arn = module.cert.arn
 }

--- a/cloudfront/logging.wc.org/provider.tf
+++ b/cloudfront/logging.wc.org/provider.tf
@@ -15,3 +15,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
   }
 }
+
+provider "aws" {
+  region = "eu-west-1"
+  alias  = "dns"
+
+  assume_role {
+    role_arn = "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update"
+  }
+}

--- a/cloudfront/modules/certificate/main.tf
+++ b/cloudfront/modules/certificate/main.tf
@@ -1,0 +1,44 @@
+resource "aws_acm_certificate" "cert" {
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  subject_alternative_names = var.subject_alternative_names
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "aws_route53_zone" "zone" {
+  provider = aws.dns
+
+  name = "wellcomecollection.org."
+}
+
+resource "aws_route53_record" "cert_validation" {
+  provider = aws.dns
+
+  # This is based on an example from the Terraform docs
+  # See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation#dns-validation-with-route-53
+  for_each = {
+    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  name    = each.value.name
+  type    = each.value.type
+  records = [each.value.record]
+
+  zone_id = data.aws_route53_zone.zone.id
+
+  ttl = var.ttl
+}
+
+resource "aws_acm_certificate_validation" "validation" {
+  certificate_arn = aws_acm_certificate.cert.arn
+
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}

--- a/cloudfront/modules/certificate/outputs.tf
+++ b/cloudfront/modules/certificate/outputs.tf
@@ -1,0 +1,3 @@
+output "arn" {
+  value = aws_acm_certificate.cert.arn
+}

--- a/cloudfront/modules/certificate/provider.tf
+++ b/cloudfront/modules/certificate/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  alias = "dns"
+}

--- a/cloudfront/modules/certificate/variables.tf
+++ b/cloudfront/modules/certificate/variables.tf
@@ -1,0 +1,13 @@
+variable "domain_name" {
+  type = string
+}
+
+variable "subject_alternative_names" {
+  type    = list(string)
+  default = []
+}
+
+variable "ttl" {
+  type    = number
+  default = 300
+}

--- a/cloudfront/reporting.wc.org/cert.tf
+++ b/cloudfront/reporting.wc.org/cert.tf
@@ -1,0 +1,12 @@
+module "cert" {
+  source = "../modules/certificate"
+
+  domain_name = "reporting.wellcomecollection.org"
+
+  ttl = 60
+
+  providers = {
+    aws     = aws.us_east_1
+    aws.dns = aws.dns
+  }
+}

--- a/cloudfront/reporting.wc.org/data.tf
+++ b/cloudfront/reporting.wc.org/data.tf
@@ -1,5 +1,0 @@
-data "aws_acm_certificate" "reporting_wc_org" {
-  domain   = "reporting.wellcomecollection.org"
-  statuses = ["ISSUED"]
-  provider = aws.us_east_1
-}

--- a/cloudfront/reporting.wc.org/main.tf
+++ b/cloudfront/reporting.wc.org/main.tf
@@ -5,5 +5,5 @@ module "kibana-reporting" {
   comment = "Kibana (reporting)"
 
   origin_domain_name  = "c783b93d8b0b4b11900b5793cb2a1865.eu-west-1.aws.found.io"
-  acm_certificate_arn = data.aws_acm_certificate.reporting_wc_org.arn
+  acm_certificate_arn = module.cert.arn
 }

--- a/cloudfront/reporting.wc.org/provider.tf
+++ b/cloudfront/reporting.wc.org/provider.tf
@@ -15,3 +15,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
   }
 }
+
+provider "aws" {
+  region = "eu-west-1"
+  alias  = "dns"
+
+  assume_role {
+    role_arn = "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update"
+  }
+}

--- a/cloudfront/roadmap.wc.org/cert.tf
+++ b/cloudfront/roadmap.wc.org/cert.tf
@@ -1,0 +1,10 @@
+module "cert" {
+  source = "../modules/certificate"
+
+  domain_name = "roadmap.wellcomecollection.org"
+
+  providers = {
+    aws     = aws.us_east_1
+    aws.dns = aws.dns
+  }
+}

--- a/cloudfront/roadmap.wc.org/data.tf
+++ b/cloudfront/roadmap.wc.org/data.tf
@@ -1,5 +1,0 @@
-data "aws_acm_certificate" "roadmap_wc_org" {
-  domain   = "roadmap.wellcomecollection.org"
-  statuses = ["ISSUED"]
-  provider = aws.us_east_1
-}

--- a/cloudfront/roadmap.wc.org/main.tf
+++ b/cloudfront/roadmap.wc.org/main.tf
@@ -4,5 +4,5 @@ module "productboard-wellcomecollection" {
   alias   = "roadmap.wellcomecollection.org"
   comment = "productboard (roadmap)"
 
-  acm_certificate_arn = data.aws_acm_certificate.roadmap_wc_org.arn
+  acm_certificate_arn = module.cert.arn
 }

--- a/cloudfront/roadmap.wc.org/provider.tf
+++ b/cloudfront/roadmap.wc.org/provider.tf
@@ -15,3 +15,12 @@ provider "aws" {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
   }
 }
+
+provider "aws" {
+  region = "eu-west-1"
+  alias  = "dns"
+
+  assume_role {
+    role_arn = "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update"
+  }
+}


### PR DESCRIPTION
Follows #102

We used to create ACM certificates and the associated DNS validation records in the console, because we didn't have access to the right roles in the DNS account to manage them programatically. That's no longer the case; this module moves the certificates used by our CloudFront distributions to be managed by Terraform.

I didn't do monitoring.wc.org or auth.wc.org because the stacks that use those certificates have fallen quite far behind, and need a bit of work before we can plan/apply in them with current versions of Terraform.