### PR TITLE
Add some lifecycle rules to the platform-infra bucket

### DIFF
--- a/critical/back_end/s3_platform_infra.tf
+++ b/critical/back_end/s3_platform_infra.tf
@@ -21,16 +21,6 @@ resource "aws_s3_bucket" "platform_infra" {
       storage_class = "STANDARD_IA"
     }
 
-    noncurrent_version_transition {
-      days          = 30
-      storage_class = "STANDARD_IA"
-    }
-
-    noncurrent_version_transition {
-      days          = 60
-      storage_class = "GLACIER"
-    }
-
     noncurrent_version_expiration {
       days = 90
     }

--- a/critical/back_end/s3_platform_infra.tf
+++ b/critical/back_end/s3_platform_infra.tf
@@ -12,6 +12,30 @@ resource "aws_s3_bucket" "platform_infra" {
     }
   }
 
+  lifecycle_rule {
+    id      = "expire_old_versions"
+    enabled = true
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    noncurrent_version_transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    noncurrent_version_transition {
+      days          = 60
+      storage_class = "GLACIER"
+    }
+
+    noncurrent_version_expiration {
+      days = 90
+    }
+  }
+
   lifecycle {
     prevent_destroy = true
   }


### PR DESCRIPTION
We shouldn't be keeping everything that goes in this bucket indefinitely. This is particularly driven by https://github.com/wellcomecollection/platform/issues/5025, which will start adding 1GB+ snapshots of the Sierra data to this bucket, and we don't need to keep multiple copies of that.

Because this is a potentially destructive change, I'm not going to apply it until it's reviewed.