### PR TITLE
Add permission to get to the Miro bucket for cataloguers_wellcome_images and workflow-support

### DIFF
--- a/accounts/workflow/iam_workflow_support.tf
+++ b/accounts/workflow/iam_workflow_support.tf
@@ -113,6 +113,7 @@ data "aws_iam_policy_document" "workflow_support" {
 
     resources = [
       "arn:aws:s3:::wellcomecollection-storage/digitised/*",
+      "arn:aws:s3:::wellcomecollection-storage/miro/*",
       "arn:aws:s3:::wellcomecollection-storage-staging/digitised/*",
     ]
   }

--- a/assets/iam_users.tf
+++ b/assets/iam_users.tf
@@ -29,6 +29,7 @@ data "aws_iam_policy_document" "allow_miro_access" {
 
     resources = [
       "${aws_s3_bucket.working_storage.arn}/miro/*",
+      "arn:aws:s3:::wellcomecollection-storage/miro/*",
     ]
   }
 }


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5077