### PR TITLE
Update dlcs auth, file, pdf + thumbs paths to use lambda

### DIFF
--- a/cloudfront/iiif.wellcomecollection.org/edge-lambda/src/dlcs_path_rewrite.test.ts
+++ b/cloudfront/iiif.wellcomecollection.org/edge-lambda/src/dlcs_path_rewrite.test.ts
@@ -85,6 +85,34 @@ const rewrite_tests = (): Array<ExpectedRewrite> => {
       in: '/av/b16756654_0055-0000-4202-0000-0-0000-0000-0.mpg/full/full/max/max/0/default.webm#identity',
       out: '/b16756654_0055-0000-4202-0000-0-0000-0000-0.mpg/full/full/max/max/0/default.webm#identity'
     },
+    // DLCS Thumbs paths
+    {
+      in: '/thumbs/2/5/b29348109_0002_0074.jp2/full/!200,200/0/default.jpg',
+      out: '/2/5/b29348109_0002_0074.jp2/full/!200,200/0/default.jpg'
+    },
+    {
+      in: '/thumbs/2/5/b29348109_0002_0074.jp2/info.json',
+      out: '/2/5/b29348109_0002_0074.jp2/info.json'
+    },
+    {
+      in: '/thumbs/2/5/b29348109_0002_0074.jp2',
+      out: '/2/5/b29348109_0002_0074.jp2'
+    },
+    // DLCS PDF paths
+    {
+      in: '/pdf/b18031511',
+      out: '/b18031511'
+    },
+    // DLCS File paths
+    {
+      in: '/file/b21320962_National%20primary%20science%20survey.pdf',
+      out: '/b21320962_National%20primary%20science%20survey.pdf'
+    },
+    // DLCS auth paths
+    {
+      in: '/auth/fromcas?token=xyz',
+      out: '/fromcas?token=xyz'
+    }
   ]
 }
 

--- a/cloudfront/iiif.wellcomecollection.org/edge-lambda/src/dlcs_path_rewrite.ts
+++ b/cloudfront/iiif.wellcomecollection.org/edge-lambda/src/dlcs_path_rewrite.ts
@@ -10,6 +10,10 @@ export const request: CloudFrontRequestHandler = (event, context, callback) => {
     const oldWellcomeImagesUri: RegExp = /^\/image\/[ABLNMSVW]00.+(?:\.jpg)\/.+/
     const dlcsImagesUri: RegExp = /^\/image\/.+/
     const dlcsAVUri: RegExp = /^\/av\/.+/
+    const dlcsThumbsUri: RegExp = /^\/thumbs\/.+/
+    const dlcsPdfUri: RegExp = /^\/pdf\/.+/
+    const dlcsFileUri: RegExp = /^\/file\/.+/
+    const dlcsAuthUri: RegExp = /^\/auth\/.+/
 
     const rewriteRequestUri: (uri: string) => string = (uri: string) => {
         if(uri.match(oldWellcomeImagesUri)) {
@@ -25,6 +29,18 @@ export const request: CloudFrontRequestHandler = (event, context, callback) => {
         } else if(uri.match(dlcsAVUri)) {
             return uri
                 .replace('/av', '')
+        } else if(uri.match(dlcsThumbsUri)) {
+            return uri
+                .replace('/thumbs', '')
+        } else if(uri.match(dlcsPdfUri)) {
+            return uri
+                .replace('/pdf', '')
+        } else if(uri.match(dlcsFileUri)) {
+            return uri
+                .replace('/file', '')
+        } else if(uri.match(dlcsAuthUri)) {
+            return uri
+                .replace('/auth', '')
         } else {
             return uri
         }

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
@@ -160,7 +160,7 @@ locals {
           lambda_arn = local.dlcs_path_rewrite_arn_stage
         }
       ]
-      
+
       min_ttl     = 0
       default_ttl = 24 * 60 * 60
       max_ttl     = 365 * 24 * 60 * 60
@@ -217,7 +217,7 @@ locals {
           lambda_arn = local.dlcs_path_rewrite_arn_prod
         }
       ]
-      
+
       min_ttl     = 0
       default_ttl = 24 * 60 * 60
       max_ttl     = 365 * 24 * 60 * 60
@@ -236,7 +236,7 @@ locals {
           lambda_arn = local.dlcs_path_rewrite_arn_stage
         }
       ]
-      
+
       min_ttl     = 0
       default_ttl = 24 * 60 * 60
       max_ttl     = 365 * 24 * 60 * 60

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
@@ -117,23 +117,50 @@ locals {
 
   thumbs_behaviours = [
     {
-      path_pattern     = "thumbs/b*"
+      path_pattern     = "thumb/*"
       target_origin_id = "iiif"
       headers          = ["*"]
-      cookies          = "all"
+      cookies          = "none"
       lambdas          = []
 
       min_ttl     = 0
       default_ttl = 24 * 60 * 60
       max_ttl     = 365 * 24 * 60 * 60
-    },
+    }
+  ]
+
+  dlcs_thumbs_behaviours_prod = [
     {
-      path_pattern     = "thumbs/*.*"
+      path_pattern     = "thumbs/*"
       target_origin_id = "dlcs_thumbs"
       headers          = []
-      cookies          = "all"
-      lambdas          = []
+      cookies          = "none"
+      lambdas = [
+        {
+          event_type = "origin-request"
+          lambda_arn = local.dlcs_path_rewrite_arn_prod
+        }
+      ]
 
+      min_ttl     = 0
+      default_ttl = 24 * 60 * 60
+      max_ttl     = 365 * 24 * 60 * 60
+    }
+  ]
+
+  dlcs_thumbs_behaviours_stage = [
+    {
+      path_pattern     = "thumbs/*"
+      target_origin_id = "dlcs_thumbs"
+      headers          = []
+      cookies          = "none"
+      lambdas = [
+        {
+          event_type = "origin-request"
+          lambda_arn = local.dlcs_path_rewrite_arn_stage
+        }
+      ]
+      
       min_ttl     = 0
       default_ttl = 24 * 60 * 60
       max_ttl     = 365 * 24 * 60 * 60
@@ -178,27 +205,56 @@ locals {
     },
   ]
 
-  pdf_behaviours = [
+  pdf_behaviours_prod = [
     {
       path_pattern     = "pdf/*"
       target_origin_id = "dlcs_pdf"
       headers          = []
       cookies          = "all"
-      lambdas          = []
-
+      lambdas = [
+        {
+          event_type = "origin-request"
+          lambda_arn = local.dlcs_path_rewrite_arn_prod
+        }
+      ]
+      
       min_ttl     = 0
       default_ttl = 24 * 60 * 60
       max_ttl     = 365 * 24 * 60 * 60
     },
   ]
 
-  file_behaviours = [
+  pdf_behaviours_stage = [
+    {
+      path_pattern     = "pdf/*"
+      target_origin_id = "dlcs_pdf"
+      headers          = []
+      cookies          = "all"
+      lambdas = [
+        {
+          event_type = "origin-request"
+          lambda_arn = local.dlcs_path_rewrite_arn_stage
+        }
+      ]
+      
+      min_ttl     = 0
+      default_ttl = 24 * 60 * 60
+      max_ttl     = 365 * 24 * 60 * 60
+    },
+  ]
+
+  file_behaviours_prod = [
     {
       path_pattern     = "file/*"
       target_origin_id = "dlcs_file"
       headers          = []
       cookies          = "all"
-      lambdas          = []
+      lambdas = [
+        {
+          event_type = "origin-request"
+          lambda_arn = local.dlcs_path_rewrite_arn_prod
+        }
+      ]
 
       min_ttl     = 0
       default_ttl = 24 * 60 * 60
@@ -206,13 +262,56 @@ locals {
     },
   ]
 
-  auth_behaviours = [
+  file_behaviours_stage = [
+    {
+      path_pattern     = "file/*"
+      target_origin_id = "dlcs_file"
+      headers          = []
+      cookies          = "all"
+      lambdas = [
+        {
+          event_type = "origin-request"
+          lambda_arn = local.dlcs_path_rewrite_arn_stage
+        }
+      ]
+
+      min_ttl     = 0
+      default_ttl = 24 * 60 * 60
+      max_ttl     = 365 * 24 * 60 * 60
+    },
+  ]
+
+  auth_behaviours_prod = [
     {
       path_pattern     = "auth/*"
-      target_origin_id = "dlcs"
+      target_origin_id = "dlcs_auth"
       headers          = ["Authorization"]
       cookies          = "all"
-      lambdas          = []
+      lambdas = [
+        {
+          event_type = "origin-request"
+          lambda_arn = local.dlcs_path_rewrite_arn_prod
+        }
+      ]
+
+      min_ttl     = 0
+      default_ttl = 24 * 60 * 60
+      max_ttl     = 365 * 24 * 60 * 60
+    },
+  ]
+
+  auth_behaviours_stage = [
+    {
+      path_pattern     = "auth/*"
+      target_origin_id = "dlcs_auth"
+      headers          = ["Authorization"]
+      cookies          = "all"
+      lambdas = [
+        {
+          event_type = "origin-request"
+          lambda_arn = local.dlcs_path_rewrite_arn_stage
+        }
+      ]
 
       min_ttl     = 0
       default_ttl = 24 * 60 * 60
@@ -263,13 +362,16 @@ locals {
   ]
 
   prod_behaviours = concat(
+    // TODO: Remove this fallback line when Loris is decommissioned
+    // local.wellcome_images_loris_behaviours,
     local.wellcome_images_dlcs_behaviours_prod,
     local.dlcs_images_behaviours_prod,
     local.thumbs_behaviours,
+    local.dlcs_thumbs_behaviours_prod,
     local.av_behaviours_prod,
-    local.pdf_behaviours,
-    local.file_behaviours,
-    local.auth_behaviours,
+    local.pdf_behaviours_prod,
+    local.file_behaviours_prod,
+    local.auth_behaviours_prod,
     local.dash_behaviours,
     local.text_behaviours,
     local.pdf_cover_behaviours,
@@ -279,10 +381,11 @@ locals {
     local.wellcome_images_dlcs_behaviours_stage,
     local.dlcs_images_behaviours_stage,
     local.thumbs_behaviours,
+    local.dlcs_thumbs_behaviours_stage,
     local.av_behaviours_stage,
-    local.pdf_behaviours,
-    local.file_behaviours,
-    local.auth_behaviours,
+    local.pdf_behaviours_stage,
+    local.file_behaviours_stage,
+    local.auth_behaviours_stage,
     local.dash_behaviours,
     local.text_behaviours,
     local.pdf_cover_behaviours,
@@ -292,10 +395,11 @@ locals {
     local.wellcome_images_dlcs_behaviours_stage,
     local.dlcs_images_behaviours_stage,
     local.thumbs_behaviours,
+    local.dlcs_thumbs_behaviours_stage,
     local.av_behaviours_stage,
-    local.pdf_behaviours,
-    local.file_behaviours,
-    local.auth_behaviours,
+    local.pdf_behaviours_stage,
+    local.file_behaviours_stage,
+    local.auth_behaviours_stage,
     local.dash_behaviours,
     local.text_behaviours,
     local.pdf_cover_behaviours,

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
@@ -362,8 +362,6 @@ locals {
   ]
 
   prod_behaviours = concat(
-    // TODO: Remove this fallback line when Loris is decommissioned
-    // local.wellcome_images_loris_behaviours,
     local.wellcome_images_dlcs_behaviours_prod,
     local.dlcs_images_behaviours_prod,
     local.thumbs_behaviours,

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
@@ -10,7 +10,7 @@ module "dashboard_origin_set" {
   id     = "dashboard"
 
   prod = {
-    domain_name : "dash-stage.wellcomecollection.digirati.io"
+    domain_name : "dds.dlcs.io"
     origin_path : null
   }
   stage = {
@@ -191,6 +191,24 @@ module "dlcs_pdf_cover_origin_set" {
   }
 }
 
+module "dlcs_auth_origin_set" {
+  source = "./origin_sets"
+  id     = "dlcs_auth"
+
+  prod = {
+    domain_name : "dlcs.io"
+    origin_path : "/auth/2"
+  }
+  stage = {
+    domain_name : "dlcs.io"
+    origin_path : "/auth/2"
+  }
+  test = {
+    domain_name : "dlcs.io"
+    origin_path : "/auth/2"
+  }
+}
+
 locals {
 
   prod_origins = [
@@ -203,7 +221,8 @@ locals {
     module.dlcs_av_origin_set.origins["prod"],
     module.dlcs_pdf_origin_set.origins["prod"],
     module.dlcs_file_origin_set.origins["prod"],
-    module.dlcs_pdf_cover_origin_set.origins["prod"]
+    module.dlcs_pdf_cover_origin_set.origins["prod"],
+    module.dlcs_auth_origin_set.origins["prod"]
   ]
 
   stage_origins = [
@@ -216,7 +235,8 @@ locals {
     module.dlcs_av_origin_set.origins["stage"],
     module.dlcs_pdf_origin_set.origins["stage"],
     module.dlcs_file_origin_set.origins["stage"],
-    module.dlcs_pdf_cover_origin_set.origins["stage"]
+    module.dlcs_pdf_cover_origin_set.origins["stage"],
+    module.dlcs_auth_origin_set.origins["stage"]
   ]
 
   test_origins = [
@@ -229,6 +249,7 @@ locals {
     module.dlcs_av_origin_set.origins["test"],
     module.dlcs_pdf_origin_set.origins["test"],
     module.dlcs_file_origin_set.origins["test"],
-    module.dlcs_pdf_cover_origin_set.origins["test"]
+    module.dlcs_pdf_cover_origin_set.origins["test"],
+    module.dlcs_auth_origin_set.origins["test"]
   ]
 }

--- a/cloudfront/iiif.wellcomecollection.org/terraform/locals.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/locals.tf
@@ -3,7 +3,7 @@ locals {
   dlcs_path_rewrite_latest     = aws_lambda_function.dlcs_path_rewrite.version
   dlcs_path_rewrite_arn_latest = "${local.dlcs_path_rewrite_arn}:${local.dlcs_path_rewrite_latest}"
   dlcs_path_rewrite_arn_stage  = local.dlcs_path_rewrite_arn_latest
-  dlcs_path_rewrite_arn_prod   = "${local.dlcs_path_rewrite_arn}:12"
+  dlcs_path_rewrite_arn_prod   = "${local.dlcs_path_rewrite_arn}:14"
 
   edge_lambdas_bucket = data.terraform_remote_state.cloudfront_core.outputs.edge_lambdas_bucket
 }


### PR DESCRIPTION
auth, file, pdf + thumbs paths need to use Lambda to remove the initial matching segment from path. Introduced new origin for auth.

To simplify `/thumbs/` paths we are renaming the dds to `/thumb/` and keeping dlcs as `/thumbs/`.

Removed cookies from `thumbs` as they are not required.