### PR TITLE
Add x-forwarded-host to specified origins

### DIFF
--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
@@ -152,7 +152,7 @@ locals {
     {
       path_pattern     = "thumbs/*"
       target_origin_id = "dlcs_thumbs"
-      headers          = ["X-Forwarded-Host"]
+      headers          = []
       cookies          = "none"
       lambdas = [
         {

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
@@ -152,7 +152,7 @@ locals {
     {
       path_pattern     = "thumbs/*"
       target_origin_id = "dlcs_thumbs"
-      headers          = []
+      headers          = ["X-Forwarded-Host"]
       cookies          = "none"
       lambdas = [
         {

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
@@ -105,6 +105,8 @@ module "dlcs_thumbs_origin_set" {
   source = "./origin_sets"
   id     = "dlcs_thumbs"
 
+  forward_host = true
+
   prod = {
     domain_name : "dlcs.io"
     origin_path : "/thumbs/wellcome/5"

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cloudfront_distro/main.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cloudfront_distro/main.tf
@@ -15,9 +15,11 @@ resource "aws_cloudfront_distribution" "iiif" {
       domain_name = origin.value["domain_name"]
       origin_path = origin.value["origin_path"]
 
-      custom_header = {
-        name  = "X-Forwarded-Host"
-        value = local.distro_alias
+      dynamic "custom_header" {
+        for_each = origin.value["forward_host"] ? [] : [1]
+        content {
+          name  = "X-Forwarded-Host"
+          value = local.distro_alias
       }
 
       custom_origin_config {

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cloudfront_distro/main.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cloudfront_distro/main.tf
@@ -11,19 +11,19 @@ resource "aws_cloudfront_distribution" "iiif" {
   dynamic "origin" {
     for_each = var.origins
     content {
-      origin_id = origin.value["origin_id"]
+      origin_id   = origin.value["origin_id"]
       domain_name = origin.value["domain_name"]
       origin_path = origin.value["origin_path"]
 
       dynamic "custom_header" {
         for_each = origin.value["forward_host"] ? [
-          1] : []
+        1] : []
         content {
-          name = "X-Forwarded-Host"
+          name  = "X-Forwarded-Host"
           value = local.distro_alias
         }
       }
-      
+
       custom_origin_config {
         origin_protocol_policy = "match-viewer"
         origin_ssl_protocols = [
@@ -32,7 +32,7 @@ resource "aws_cloudfront_distribution" "iiif" {
           "TLSv1.2",
         ]
 
-        http_port = 80
+        http_port  = 80
         https_port = 443
       }
     }

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cloudfront_distro/main.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cloudfront_distro/main.tf
@@ -11,17 +11,19 @@ resource "aws_cloudfront_distribution" "iiif" {
   dynamic "origin" {
     for_each = var.origins
     content {
-      origin_id   = origin.value["origin_id"]
+      origin_id = origin.value["origin_id"]
       domain_name = origin.value["domain_name"]
       origin_path = origin.value["origin_path"]
 
       dynamic "custom_header" {
-        for_each = origin.value["forward_host"] ? [1] : []
+        for_each = origin.value["forward_host"] ? [
+          1] : []
         content {
-          name  = "X-Forwarded-Host"
+          name = "X-Forwarded-Host"
           value = local.distro_alias
+        }
       }
-
+      
       custom_origin_config {
         origin_protocol_policy = "match-viewer"
         origin_ssl_protocols = [
@@ -30,7 +32,7 @@ resource "aws_cloudfront_distribution" "iiif" {
           "TLSv1.2",
         ]
 
-        http_port  = 80
+        http_port = 80
         https_port = 443
       }
     }
@@ -110,3 +112,4 @@ resource "aws_cloudfront_distribution" "iiif" {
     }
   }
 }
+

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cloudfront_distro/main.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cloudfront_distro/main.tf
@@ -16,7 +16,7 @@ resource "aws_cloudfront_distribution" "iiif" {
       origin_path = origin.value["origin_path"]
 
       dynamic "custom_header" {
-        for_each = origin.value["forward_host"] ? [] : [1]
+        for_each = origin.value["forward_host"] ? [1] : []
         content {
           name  = "X-Forwarded-Host"
           value = local.distro_alias

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cloudfront_distro/main.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cloudfront_distro/main.tf
@@ -15,6 +15,11 @@ resource "aws_cloudfront_distribution" "iiif" {
       domain_name = origin.value["domain_name"]
       origin_path = origin.value["origin_path"]
 
+      custom_header = {
+        name  = "X-Forwarded-Host"
+        value = local.distro_alias
+      }
+
       custom_origin_config {
         origin_protocol_policy = "match-viewer"
         origin_ssl_protocols = [

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cloudfront_distro/variables.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cloudfront_distro/variables.tf
@@ -15,6 +15,7 @@ variable "origins" {
     origin_id : string
     domain_name : string
     origin_path : string
+    forward_host : bool
   }))
 }
 

--- a/cloudfront/iiif.wellcomecollection.org/terraform/origin_sets/origin_set.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/origin_sets/origin_set.tf
@@ -2,6 +2,11 @@ variable "id" {
   type = string
 }
 
+variable "forward_host" {
+  type    = bool
+  default = false
+}
+
 variable "prod" {
   type = object({
     domain_name : string
@@ -24,19 +29,22 @@ variable "test" {
 output "origins" {
   value = {
     prod : {
-      origin_id   = var.id
-      domain_name = var.prod.domain_name
-      origin_path = var.prod.origin_path
+      origin_id    = var.id
+      domain_name  = var.prod.domain_name
+      origin_path  = var.prod.origin_path
+      forward_host = var.forward_host
     },
     stage : {
-      origin_id   = var.id
-      domain_name = var.stage.domain_name
-      origin_path = var.stage.origin_path
+      origin_id    = var.id
+      domain_name  = var.stage.domain_name
+      origin_path  = var.stage.origin_path
+      forward_host = var.forward_host
     },
     test : {
-      origin_id   = var.id
-      domain_name = var.test.domain_name
-      origin_path = var.test.origin_path
+      origin_id    = var.id
+      domain_name  = var.test.domain_name
+      origin_path  = var.test.origin_path
+      forward_host = var.forward_host
     }
   }
 }


### PR DESCRIPTION
> I can't plan this locally so syntax could be wrong!

Added `forward_host` variable to origin_set. If this is true then `x-forwarded-host` is added to origin custom headers, set to value of alias for distro. Added to `/thumbs/` requests only for now, this will allow me to validate it works without affecting anything called by external code.

Applying this should update the 3 "dlcs_thumbs" origins in the 3 iiif.wc.org distros.

Tested setting this in a test CF distro with and without going via an Origin request lambda and the value is persisted.