### PR TITLE
Use VPC endpoints to talk to ECR in CI

### DIFF
--- a/accounts/modules/interface_endpoint/main.tf
+++ b/accounts/modules/interface_endpoint/main.tf
@@ -1,0 +1,40 @@
+variable "service" {}
+variable "vpc_id" {}
+
+variable "security_group_ids" {
+  type = list(string)
+}
+
+variable "subnet_ids" {
+  type = list(string)
+}
+
+data "aws_vpc" "selected" {
+  id = var.vpc_id
+}
+
+locals {
+  vpc_name  = lookup(data.aws_vpc.selected.tags, "Name", var.vpc_id)
+  vpc_label = split("-", local.vpc_name)[0]
+}
+
+data "aws_vpc_endpoint_service" "service" {
+  service = var.service
+}
+
+resource "aws_vpc_endpoint" "endpoint" {
+  vpc_id            = var.vpc_id
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = var.security_group_ids
+
+  subnet_ids = var.subnet_ids
+
+  service_name = data.aws_vpc_endpoint_service.service.service_name
+
+  private_dns_enabled = true
+
+  tags = {
+    Name = "${local.vpc_label}-${var.service}-vpc_endpoint"
+  }
+}

--- a/builds/terraform/buildkite.tf
+++ b/builds/terraform/buildkite.tf
@@ -28,8 +28,9 @@ resource "aws_cloudformation_stack" "buildkite" {
     InstanceCreationTimeout = "PT5M"
     InstanceRoleName        = local.ci_agent_role_name
 
-    VpcId   = local.ci_vpc_id
-    Subnets = join(",", local.ci_vpc_private_subnets)
+    VpcId           = local.ci_vpc_id
+    Subnets         = join(",", local.ci_vpc_private_subnets)
+    SecurityGroupId = aws_security_group.buildkite.id
 
     AssociatePublicIpAddress = true
 

--- a/builds/terraform/security_group.tf
+++ b/builds/terraform/security_group.tf
@@ -1,0 +1,38 @@
+resource "aws_security_group" "buildkite" {
+  name   = "buildkite-vpc-endpoints"
+  vpc_id = local.ci_vpc_id
+
+  tags = {
+    Name = "buildkite-vpc-endpoints"
+  }
+
+  ingress {
+    description = "Allow SSH access"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # See https://aws.amazon.com/premiumsupport/knowledge-center/ecs-pull-container-api-error-ecr/
+  #
+  #     If you're using AWS PrivateLink for Amazon ECR, then confirm that
+  #     the security group, associated with the interface VPC endpoints
+  #     for Amazon ECR, allows inbound traffic over HTTPS (port 443)
+  #     from within the security group […].
+  #
+  ingress {
+    description = "Allow ECR access"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/builds/terraform/vpc.tf
+++ b/builds/terraform/vpc.tf
@@ -5,8 +5,7 @@ module "ecr_dkr_vpc_endpoint" {
   vpc_id  = local.ci_vpc_id
 
   security_group_ids = [
-    # buildkite-elastic
-    "sg-0b5a4d52331945b7e",
+    aws_security_group.buildkite.id,
   ]
 
   subnet_ids = local.ci_vpc_private_subnets
@@ -19,8 +18,7 @@ module "ecr_api_vpc_endpoint" {
   vpc_id  = local.ci_vpc_id
 
   security_group_ids = [
-    # buildkite-elastic
-    "sg-0b5a4d52331945b7e",
+    aws_security_group.buildkite.id,
   ]
 
   subnet_ids = local.ci_vpc_private_subnets

--- a/builds/terraform/vpc.tf
+++ b/builds/terraform/vpc.tf
@@ -1,0 +1,27 @@
+module "ecr_dkr_vpc_endpoint" {
+  source = "../../accounts/modules/interface_endpoint"
+
+  service = "ecr.dkr"
+  vpc_id  = local.ci_vpc_id
+
+  security_group_ids = [
+    # buildkite-elastic
+    "sg-0b5a4d52331945b7e",
+  ]
+
+  subnet_ids = local.ci_vpc_private_subnets
+}
+
+module "ecr_api_vpc_endpoint" {
+  source = "../../accounts/modules/interface_endpoint"
+
+  service = "ecr.api"
+  vpc_id  = local.ci_vpc_id
+
+  security_group_ids = [
+    # buildkite-elastic
+    "sg-0b5a4d52331945b7e",
+  ]
+
+  subnet_ids = local.ci_vpc_private_subnets
+}


### PR DESCRIPTION
We spent ~$250/mo in NAT Gateway costs for CI; see [Cost Explorer](https://console.aws.amazon.com/cost-management/home?#/custom?excludeRIRecurringCharges=false&startDate=2021-02-20&excludeTax=false&excludeSupportCharges=false&endDate=2021-03-22&timeRangeOption=Custom&hasAmortized=false&excludeRIUpfrontFees=false&filter=%5B%7B%22dimension%22:%22Operation%22,%22values%22:%5B%22NatGateway%22%5D,%22include%22:true,%22children%22:null%7D%5D&isTemplate=true&groupBy=TagKeyValue:Name&forecastTimeRangeOption=None&excludeCredit=false&excludeTaggedResources=false&reportType=CostUsage&chartStyle=Line&granularity=Daily&excludeOtherSubscriptionCosts=false&hasBlended=false&excludeRefund=false&reportName=Daily%20API%20operation%20costs&excludeDiscounts=true&usageAs=usageQuantity&excludeCategorizedResources=false&excludeForecast=false)

A substantial part of this is likely to be sending Docker images to/from ECR – at $0.045/GB and ~200MB/application image, it stacks up. I'm hoping this bends the curve down a bit.

Tentatively closes https://github.com/wellcomecollection/platform/issues/4920