### PR TITLE
Add authorization header to iiif /images requests

### DIFF
--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
@@ -15,7 +15,7 @@ locals {
     {
       path_pattern     = "image/${pattern}"
       target_origin_id = "dlcs_wellcome_images"
-      headers          = []
+      headers          = ["Authorization"]
       cookies          = "none"
       lambdas = [
         {
@@ -35,7 +35,7 @@ locals {
     {
       path_pattern     = "image/${pattern}"
       target_origin_id = "dlcs_wellcome_images"
-      headers          = []
+      headers          = ["Authorization"]
       cookies          = "none"
       lambdas = [
         {
@@ -94,7 +94,7 @@ locals {
     {
       path_pattern     = "image/*"
       target_origin_id = "dlcs_images"
-      headers          = []
+      headers          = ["Authorization"]
       cookies          = "all"
       lambdas = [
         {
@@ -113,7 +113,7 @@ locals {
     {
       path_pattern     = "image/*"
       target_origin_id = "dlcs_images"
-      headers          = []
+      headers          = ["Authorization"]
       cookies          = "all"
       lambdas = [
         {


### PR DESCRIPTION
`Bearer` token used for authorization to restricted or "clickthrough" images.

Couldn't easily add tests for these as it's not a simple request/response, instead the viewer uses cookies + JS redirects to get token.