### PR TITLE
Recurse through @id containing elements

### DIFF
--- a/cloudfront/iiif.wellcomecollection.org/tests/rewrite_tests.py
+++ b/cloudfront/iiif.wellcomecollection.org/tests/rewrite_tests.py
@@ -44,21 +44,22 @@ def validate_auth(info_json, regex):
             return
 
         service_description = json.get("service", [])
+        if isinstance(service_description, dict):
+            service_description = [service_description]
 
-        if "service" in service_description:
-            for service in service_description["service"]:
-                info_id = service.get("@id", None)
-                if not p.match(info_id):
-                    click.echo(
-                        click.style(
-                            f"Id fail - expected '{regex}' but found '{info_id}'",
-                            fg="red",
-                        )
+        for service in service_description:
+            info_id = service.get("@id", None)
+            if not p.match(info_id):
+                click.echo(
+                    click.style(
+                        f"Id fail - expected '{regex}' but found '{info_id}'",
+                        fg="red",
                     )
-                else:
-                    click.echo(click.style(f"Found '{info_id}'", fg="green"))
+                )
+            else:
+                click.echo(click.style(f"Found '{info_id}'", fg="green"))
 
-                validate_service(service)
+            validate_service(service)
 
     validate_service(info_json)
 

--- a/cloudfront/iiif.wellcomecollection.org/tests/rewrite_tests.py
+++ b/cloudfront/iiif.wellcomecollection.org/tests/rewrite_tests.py
@@ -43,7 +43,7 @@ def validate_auth(info_json, regex):
         if not json:
             return
 
-        service_description = json.get("service",[])
+        service_description = json.get("service", [])
 
         if "service" in service_description:
             for service in service_description["service"]:
@@ -51,7 +51,8 @@ def validate_auth(info_json, regex):
                 if not p.match(info_id):
                     click.echo(
                         click.style(
-                            f"Id fail - expected '{regex}' but found '{info_id}'", fg="red"
+                            f"Id fail - expected '{regex}' but found '{info_id}'",
+                            fg="red",
                         )
                     )
                 else:

--- a/cloudfront/iiif.wellcomecollection.org/tests/rewrite_tests.py
+++ b/cloudfront/iiif.wellcomecollection.org/tests/rewrite_tests.py
@@ -43,20 +43,21 @@ def validate_auth(info_json, regex):
         if not json:
             return
 
-        service = json.get("service", [])
+        service_description = json.get("service",[])
 
-        for s in service:
-            info_id = s.get("@id", None)
-            if not p.match(info_id):
-                click.echo(
-                    click.style(
-                        f"Id fail - expected '{regex}' but found '{info_id}'", fg="red"
+        if "service" in service_description:
+            for service in service_description["service"]:
+                info_id = service.get("@id", None)
+                if not p.match(info_id):
+                    click.echo(
+                        click.style(
+                            f"Id fail - expected '{regex}' but found '{info_id}'", fg="red"
+                        )
                     )
-                )
-            else:
-                click.echo(click.style(f"Found '{info_id}'", fg="green"))
+                else:
+                    click.echo(click.style(f"Found '{info_id}'", fg="green"))
 
-            validate_service(s)
+                validate_service(service)
 
     validate_service(info_json)
 

--- a/cloudfront/iiif.wellcomecollection.org/tests/rewrite_tests.py
+++ b/cloudfront/iiif.wellcomecollection.org/tests/rewrite_tests.py
@@ -52,8 +52,7 @@ def validate_auth(info_json, regex):
             if not p.match(info_id):
                 click.echo(
                     click.style(
-                        f"Id fail - expected '{regex}' but found '{info_id}'",
-                        fg="red",
+                        f"Id fail - expected '{regex}' but found '{info_id}'", fg="red"
                     )
                 )
             else:


### PR DESCRIPTION
This started failing (https://buildkite.com/wellcomecollection/platform-infrastructure-redirects/builds?branch=master&page=7), and i'm not sure why - this change recurses through "service"s in the returned JSON. 

It does look like the results of the API have changed though. e.g.

Previous:
```

Checking: https://iiif-test.wellcomecollection.org/image/b19582183_RAMC_391_4_0001.jp2/info.json
--
  | Found 'https://iiif-test.wellcomecollection.org/image/b19582183_RAMC_391_4_0001.jp2'
  | Found 'https://iiif-test.wellcomecollection.org/auth/clickthrough'
  | Found 'https://iiif-test.wellcomecollection.org/auth/clickthrough/logout'
  | Found 'https://iiif-test.wellcomecollection.org/auth/token'
  | Found 'https://iiif-test.wellcomecollection.org/auth/login'
  | Found 'https://iiif-test.wellcomecollection.org/auth/login/logout'
  | Found 'https://iiif-test.wellcomecollection.org/auth/token'

```
Now:
```
Checking: https://iiif-test.wellcomecollection.org/image/b19582183_RAMC_391_4_0001.jp2/info.json
Found 'https://iiif-test.wellcomecollection.org/image/b19582183_RAMC_391_4_0001.jp2'
Found 'https://iiif-test.wellcomecollection.org/auth/clickthrough/logout'
Found 'https://iiif-test.wellcomecollection.org/auth/token'
```