### PR TITLE
Add permissions for our CI users to push to ECR Public

### DIFF
--- a/accounts/catalogue/.terraform.lock.hcl
+++ b/accounts/catalogue/.terraform.lock.hcl
@@ -2,9 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "2.35.0"
-  constraints = "2.35.0"
+  version = "3.34.0"
   hashes = [
-    "h1:tFahhxnsS/XpP6MzyaPPuLQVDqC0N28OUqnbz2ogdi4=",
+    "h1:2xGmnG7UF0iScMGVWBazSYk1sRatXeZYgCGjdGm4A+w=",
   ]
 }

--- a/accounts/data/.terraform.lock.hcl
+++ b/accounts/data/.terraform.lock.hcl
@@ -2,8 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "2.35.0"
+  version = "3.34.0"
   hashes = [
-    "h1:tFahhxnsS/XpP6MzyaPPuLQVDqC0N28OUqnbz2ogdi4=",
+    "h1:2xGmnG7UF0iScMGVWBazSYk1sRatXeZYgCGjdGm4A+w=",
   ]
 }

--- a/accounts/digirati/.terraform.lock.hcl
+++ b/accounts/digirati/.terraform.lock.hcl
@@ -2,8 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.25.0"
+  version = "3.34.0"
   hashes = [
-    "h1:oyaXLqVhtPnHDnwk2yU9qP4dTgfPHyuo27mX/ljeCTQ=",
+    "h1:2xGmnG7UF0iScMGVWBazSYk1sRatXeZYgCGjdGm4A+w=",
   ]
 }

--- a/accounts/digitisation/.terraform.lock.hcl
+++ b/accounts/digitisation/.terraform.lock.hcl
@@ -2,8 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.25.0"
+  version = "3.34.0"
   hashes = [
-    "h1:oyaXLqVhtPnHDnwk2yU9qP4dTgfPHyuo27mX/ljeCTQ=",
+    "h1:2xGmnG7UF0iScMGVWBazSYk1sRatXeZYgCGjdGm4A+w=",
   ]
 }

--- a/accounts/experience/.terraform.lock.hcl
+++ b/accounts/experience/.terraform.lock.hcl
@@ -2,8 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "2.35.0"
+  version = "3.34.0"
   hashes = [
-    "h1:tFahhxnsS/XpP6MzyaPPuLQVDqC0N28OUqnbz2ogdi4=",
+    "h1:2xGmnG7UF0iScMGVWBazSYk1sRatXeZYgCGjdGm4A+w=",
   ]
 }

--- a/accounts/identity/.terraform.lock.hcl
+++ b/accounts/identity/.terraform.lock.hcl
@@ -2,19 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.33.0"
+  version = "3.34.0"
   hashes = [
-    "h1:4+2CO4Pb3BKwI0MD+DBmnX5GFsYTs47y6w4/kQbPJIQ=",
-    "zh:0e89b10323a59de9dd6f286423cc172cb1733683d654c886493c3bd4e43e6290",
-    "zh:288df55f0f4fac1e920cfa61616ac42a4e4414bd7a637902db03d0c7101f14ca",
-    "zh:303c9136c5bf97e6c1deda6e27f0d0931fe0eaaab547bf219b996623fb0ad522",
-    "zh:457a5da9f323e2781942df534153d000ea81727798ee0771177009d84b04aad7",
-    "zh:857fa3e29cc25ace76556a5edfded41628a3380cebf457e627576a83084852f8",
-    "zh:85e1eb383372f834630fac7b02ec9ae1e33d24d61cf5a7d832583a16e6b5add4",
-    "zh:9dd01eb05ac73146ac5f25421b7683fe4bffec23e408162887e1265f9bfe8462",
-    "zh:b1561e1335754ec93a54f45c18dc1cab70f38bc08adf244d793791134f5641ef",
-    "zh:bb96f57b80e3d94ee4bc05a5450fdd796424272b46cfc67ff9d094d5316c5fac",
-    "zh:e4ce241d8b5dd1124dc0f1da6c0840ab777de8717dac6e76afbbad9883f5ce34",
-    "zh:f2b292e813844d6d611db89017fc420ac05f2e3b25324e3c893481d375e23396",
+    "h1:2xGmnG7UF0iScMGVWBazSYk1sRatXeZYgCGjdGm4A+w=",
   ]
 }

--- a/accounts/modules/role_policies/ci/policies.tf
+++ b/accounts/modules/role_policies/ci/policies.tf
@@ -1,7 +1,28 @@
 data "aws_iam_policy_document" "ci_permissions" {
   statement {
     actions = [
-      "ecr:*",
+      # This list of actions is based on an example from the AWS docs,
+      # with some read-only actions added based on the IAM Visual Editor.
+      # https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policy-examples.html
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGet*",
+      "ecr:Describe*",
+      "ecr:Get*",
+      "ecr:List*",
+      "ecr:TagResource",
+      "ecr:PutImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr-public:BatchCheckLayerAvailability",
+      "ecr-public:Describe*",
+      "ecr-public:Get*",
+      "ecr-public:List*",
+      "ecr-public:TagResource",
+      "ecr-public:PutImage",
+      "ecr-public:InitiateLayerUpload",
+      "ecr-public:UploadLayerPart",
+      "ecr-public:CompleteLayerUpload",
     ]
 
     resources = [

--- a/accounts/modules/role_policies/ci/policies.tf
+++ b/accounts/modules/role_policies/ci/policies.tf
@@ -23,6 +23,8 @@ data "aws_iam_policy_document" "ci_permissions" {
       "ecr-public:InitiateLayerUpload",
       "ecr-public:UploadLayerPart",
       "ecr-public:CompleteLayerUpload",
+      # This is required for uploading to public repositories; see https://docs.aws.amazon.com/AmazonECR/latest/public/public-repository-policy-examples.html
+      "sts:GetServiceBearerToken",
     ]
 
     resources = [

--- a/accounts/platform/.terraform.lock.hcl
+++ b/accounts/platform/.terraform.lock.hcl
@@ -2,19 +2,9 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.27.0"
+  version = "3.34.0"
   hashes = [
-    "h1:lJaA23rrNSgLEumcW7Y0KKvno5isVVNNIEV5pT92O8E=",
-    "zh:2986eb5a1ffbb0336c6390aad533b62efc832aa8aa5460d523e1f2daa4f42f79",
-    "zh:825317cdb80860833125a856c0befc877cba22d41c631c5a7ca22400693d4356",
-    "zh:a47aad668cc74058f508c56c5407cd715dbb9b6389aa68d37543e897895db43f",
-    "zh:c0011502d0eb4637918127c3987a8cc07a015ea00f74f4956fd111c736286a4d",
-    "zh:d5088ab51043bb2239132f4ed3760292b6aa4f7296232e4b8017f8c5c34f051a",
-    "zh:d893658e983eb17a23a8124c79a910cc729cb1d751d5509b8e756101c828ad91",
-    "zh:dcc4384ee79ea9492c87eb01e664f7f6b1f1d156471476f30b28336c9d9a4aec",
-    "zh:e4abfaf013f31791cd029af7b6f989f73e3efca28fe2917057b428d051c4085f",
-    "zh:f2a4d9446d23afe2a42421e7d5f902d34451fb31b7787b5e3aef95c08fec5ced",
-    "zh:f54a6af10b077db9dc11556c27f59ba5c60e1b2ba96fe3aa9cd90d8c67d980f6",
+    "h1:2xGmnG7UF0iScMGVWBazSYk1sRatXeZYgCGjdGm4A+w=",
   ]
 }
 

--- a/accounts/reporting/.terraform.lock.hcl
+++ b/accounts/reporting/.terraform.lock.hcl
@@ -2,8 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.25.0"
+  version = "3.34.0"
   hashes = [
-    "h1:oyaXLqVhtPnHDnwk2yU9qP4dTgfPHyuo27mX/ljeCTQ=",
+    "h1:2xGmnG7UF0iScMGVWBazSYk1sRatXeZYgCGjdGm4A+w=",
   ]
 }

--- a/accounts/storage/.terraform.lock.hcl
+++ b/accounts/storage/.terraform.lock.hcl
@@ -2,8 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.25.0"
+  version = "3.34.0"
   hashes = [
-    "h1:oyaXLqVhtPnHDnwk2yU9qP4dTgfPHyuo27mX/ljeCTQ=",
+    "h1:2xGmnG7UF0iScMGVWBazSYk1sRatXeZYgCGjdGm4A+w=",
   ]
 }

--- a/accounts/workflow/.terraform.lock.hcl
+++ b/accounts/workflow/.terraform.lock.hcl
@@ -2,8 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.25.0"
+  version = "3.34.0"
   hashes = [
-    "h1:oyaXLqVhtPnHDnwk2yU9qP4dTgfPHyuo27mX/ljeCTQ=",
+    "h1:2xGmnG7UF0iScMGVWBazSYk1sRatXeZYgCGjdGm4A+w=",
   ]
 }

--- a/cloudfront/wellcomelibrary.org/terraform/main.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/main.tf
@@ -15,7 +15,7 @@ module "wellcomelibrary-prod" {
   default_lambda_function_association_event_type = "origin-request"
   default_lambda_function_association_lambda_arn = local.wellcome_library_passthru_arn_prod
 
-  default_forwarded_headers = ["Host"]
+  default_forwarded_headers      = ["Host"]
   default_viewer_protocol_policy = "allow-all"
 }
 


### PR DESCRIPTION
A first step towards https://github.com/wellcomecollection/platform/issues/4910

I'm testing this with a modified version of weco-deploy that pushes to an ECR Public repository for the METS adapter.