### PR TITLE
Manage DServe DNS

### DIFF
--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryArchiveRedirect.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryArchiveRedirect.ts
@@ -1,0 +1,20 @@
+import { CloudFrontRequestEvent, Context } from 'aws-lambda';
+import { CloudFrontRequest } from 'aws-lambda/common/cloudfront';
+import { redirectToRoot } from './redirectToRoot';
+
+
+export const requestHandler = async (
+  event: CloudFrontRequestEvent,
+  _: Context
+) => {
+  const request: CloudFrontRequest = event.Records[0].cf.request;
+
+  const rootRedirect = redirectToRoot(request);
+  if (rootRedirect) {
+    return rootRedirect;
+  }
+
+  request.headers.host = [{ key: 'host', value: 'archives.wellcomelibrary.org' }];
+
+  return request;
+};

--- a/cloudfront/wellcomelibrary.org/terraform/blog.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/blog.tf
@@ -10,7 +10,7 @@ module "wellcomelibrary_blog-prod" {
     origin_id : "origin"
     domain_name : "origin.wellcomelibrary.org"
     origin_path : null
-    origin_protocol_policy: "match-viewer"
+    origin_protocol_policy : "match-viewer"
   }]
 
   default_target_origin_id                       = "origin"
@@ -31,7 +31,7 @@ module "wellcomelibrary_blog-stage" {
     origin_id : "origin"
     domain_name : "origin.wellcomelibrary.org"
     origin_path : null
-    origin_protocol_policy: "match-viewer"
+    origin_protocol_policy : "match-viewer"
   }]
 
   default_target_origin_id                       = "origin"

--- a/cloudfront/wellcomelibrary.org/terraform/blog.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/blog.tf
@@ -10,6 +10,7 @@ module "wellcomelibrary_blog-prod" {
     origin_id : "origin"
     domain_name : "origin.wellcomelibrary.org"
     origin_path : null
+    origin_protocol_policy: "match-viewer"
   }]
 
   default_target_origin_id                       = "origin"
@@ -30,6 +31,7 @@ module "wellcomelibrary_blog-stage" {
     origin_id : "origin"
     domain_name : "origin.wellcomelibrary.org"
     origin_path : null
+    origin_protocol_policy: "match-viewer"
   }]
 
   default_target_origin_id                       = "origin"

--- a/cloudfront/wellcomelibrary.org/terraform/cf_origins.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/cf_origins.tf
@@ -3,7 +3,7 @@ locals {
     origin_id : "origin"
     domain_name : "origin.wellcomelibrary.org"
     origin_path : null
-    origin_protocol_policy: "match-viewer"
+    origin_protocol_policy : "match-viewer"
   }
 
   prod_origins = [

--- a/cloudfront/wellcomelibrary.org/terraform/cf_origins.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/cf_origins.tf
@@ -3,6 +3,7 @@ locals {
     origin_id : "origin"
     domain_name : "origin.wellcomelibrary.org"
     origin_path : null
+    origin_protocol_policy: "match-viewer"
   }
 
   prod_origins = [

--- a/cloudfront/wellcomelibrary.org/terraform/cloudfront_distro/main.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/cloudfront_distro/main.tf
@@ -9,7 +9,7 @@ resource "aws_cloudfront_distribution" "distro" {
       origin_path = origin.value["origin_path"]
 
       custom_origin_config {
-        origin_protocol_policy = "match-viewer"
+        origin_protocol_policy = origin.value["origin_protocol_policy"]
         origin_ssl_protocols = [
           "TLSv1",
           "TLSv1.1",

--- a/cloudfront/wellcomelibrary.org/terraform/cloudfront_distro/variables.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/cloudfront_distro/variables.tf
@@ -28,7 +28,7 @@ variable "origins" {
     origin_id : string
     domain_name : string
     origin_path : string
-    origin_protocol_policy: string
+    origin_protocol_policy : string
   }))
 }
 

--- a/cloudfront/wellcomelibrary.org/terraform/cloudfront_distro/variables.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/cloudfront_distro/variables.tf
@@ -28,6 +28,7 @@ variable "origins" {
     origin_id : string
     domain_name : string
     origin_path : string
+    origin_protocol_policy: string
   }))
 }
 

--- a/cloudfront/wellcomelibrary.org/terraform/dserve.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/dserve.tf
@@ -28,18 +28,16 @@ module "wellcomelibrary_dserve-stage" {
   ]
   acm_certificate_arn = module.cert-stage.arn
 
-  // TODO:
-  // - Must direct to HTTP
-  // - Must have archives.wellcomelibrary.org header
   origins = [{
     origin_id : "origin"
     domain_name : "archives.origin.wellcomelibrary.org"
     origin_path : null
+    origin_protocol_policy: "http-only"
   }]
 
   default_target_origin_id                       = "origin"
   default_lambda_function_association_event_type = "origin-request"
-  default_lambda_function_association_lambda_arn = local.wellcome_library_passthru_arn_prod
+  default_lambda_function_association_lambda_arn = local.wellcome_library_archive_redirect_arn_prod
   default_forwarded_headers                      = ["Host"]
 }
 

--- a/cloudfront/wellcomelibrary.org/terraform/dserve.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/dserve.tf
@@ -1,0 +1,76 @@
+// DServe links (archives.wellcomelibrary.org)
+
+//module "wellcomelibrary_dserve-prod" {
+//  source = "./cloudfront_distro"
+//
+//  distro_alternative_names = [
+//    "archives.wellcomelibrary.org"
+//  ]
+//  acm_certificate_arn = module.cert-stage.arn
+//
+//  origins = [{
+//    origin_id : "origin"
+//    domain_name : "archives.origin.wellcomelibrary.org"
+//    origin_path : null
+//  }]
+//
+//  default_target_origin_id                       = "origin"
+//  default_lambda_function_association_event_type = "origin-request"
+//  default_lambda_function_association_lambda_arn = local.wellcome_library_passthru_arn_prod
+//  default_forwarded_headers                      = ["Host"]
+//}
+//
+module "wellcomelibrary_dserve-stage" {
+  source = "./cloudfront_distro"
+
+  distro_alternative_names = [
+    "archives.stage.wellcomelibrary.org"
+  ]
+  acm_certificate_arn = module.cert-stage.arn
+
+  // TODO:
+  // - Must direct to HTTP
+  // - Must have archives.wellcomelibrary.org header
+  origins = [{
+    origin_id : "origin"
+    domain_name : "archives.origin.wellcomelibrary.org"
+    origin_path : null
+  }]
+
+  default_target_origin_id                       = "origin"
+  default_lambda_function_association_event_type = "origin-request"
+  default_lambda_function_association_lambda_arn = local.wellcome_library_passthru_arn_prod
+  default_forwarded_headers                      = ["Host"]
+}
+
+resource "aws_route53_record" "dserve-prod" {
+  zone_id = data.aws_route53_zone.zone.id
+  name    = "archives.wellcomelibrary.org"
+  type    = "CNAME"
+
+  records = ["archives.wellcome.ac.uk."]
+  ttl     = "300"
+
+  provider = aws.dns
+}
+
+resource "aws_route53_record" "dserve-origin" {
+  zone_id = data.aws_route53_zone.zone.id
+  name    = "archives.origin.wellcomelibrary.org"
+  type    = "CNAME"
+
+  records = ["archives.wellcome.ac.uk."]
+  ttl     = "60"
+
+  provider = aws.dns
+}
+
+resource "aws_route53_record" "dserve-stage" {
+  zone_id = data.aws_route53_zone.zone.id
+  name    = "archives.stage.wellcomelibrary.org"
+  type    = "CNAME"
+  records = [module.wellcomelibrary_dserve-stage.distro_domain_name]
+  ttl     = "60"
+
+  provider = aws.dns
+}

--- a/cloudfront/wellcomelibrary.org/terraform/dserve.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/dserve.tf
@@ -32,7 +32,7 @@ module "wellcomelibrary_dserve-stage" {
     origin_id : "origin"
     domain_name : "archives.origin.wellcomelibrary.org"
     origin_path : null
-    origin_protocol_policy: "http-only"
+    origin_protocol_policy : "http-only"
   }]
 
   default_target_origin_id                       = "origin"

--- a/cloudfront/wellcomelibrary.org/terraform/lambdas.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/lambdas.tf
@@ -12,6 +12,20 @@ resource "aws_lambda_function" "wellcome_library_passthru" {
   s3_object_version = data.aws_s3_bucket_object.wellcome_library_redirect.version_id
 }
 
+resource "aws_lambda_function" "wellcome_library_archive_redirect" {
+  provider = aws.us_east_1
+
+  function_name = "cf_edge_wellcome_library_archive_redirect"
+  role          = aws_iam_role.edge_lambda_role.arn
+  runtime       = "nodejs12.x"
+  handler       = "wellcomeLibraryArchiveRedirect.requestHandler"
+  publish       = true
+
+  s3_bucket         = data.aws_s3_bucket_object.wellcome_library_redirect.bucket
+  s3_key            = data.aws_s3_bucket_object.wellcome_library_redirect.key
+  s3_object_version = data.aws_s3_bucket_object.wellcome_library_redirect.version_id
+}
+
 resource "aws_lambda_function" "wellcome_library_blog_redirect" {
   provider = aws.us_east_1
 

--- a/cloudfront/wellcomelibrary.org/terraform/locals.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/locals.tf
@@ -20,5 +20,12 @@ locals {
   # This should be set manually when a stable prod deploy is established.
   wellcome_library_blog_redirect_arn_prod = "${local.wellcome_library_blog_redirect_arn}:12"
 
+  wellcome_library_archive_redirect_arn        = aws_lambda_function.wellcome_library_archive_redirect.arn
+  wellcome_library_archive_redirect_latest     = aws_lambda_function.wellcome_library_archive_redirect.version
+  wellcome_library_archive_redirect_arn_latest = "${local.wellcome_library_archive_redirect_arn}:${local.wellcome_library_archive_redirect_latest}"
+  wellcome_library_archive_redirect_arn_stage  = local.wellcome_library_archive_redirect_arn_latest
+  # This should be set manually when a stable prod deploy is established.
+  wellcome_library_archive_redirect_arn_prod = local.wellcome_library_archive_redirect_arn_latest
+  
   edge_lambdas_bucket = data.terraform_remote_state.cloudfront_core.outputs.edge_lambdas_bucket
 }

--- a/cloudfront/wellcomelibrary.org/terraform/locals.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/locals.tf
@@ -26,6 +26,6 @@ locals {
   wellcome_library_archive_redirect_arn_stage  = local.wellcome_library_archive_redirect_arn_latest
   # This should be set manually when a stable prod deploy is established.
   wellcome_library_archive_redirect_arn_prod = local.wellcome_library_archive_redirect_arn_latest
-  
+
   edge_lambdas_bucket = data.terraform_remote_state.cloudfront_core.outputs.edge_lambdas_bucket
 }

--- a/cloudfront/wellcomelibrary.org/terraform/opac.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/opac.tf
@@ -32,7 +32,7 @@ module "wellcomelibrary_opac-stage" {
     origin_id : "origin"
     domain_name : "catalogue.origin.wellcomelibrary.org"
     origin_path : null
-    origin_protocol_policy: "match-viewer"
+    origin_protocol_policy : "match-viewer"
   }]
 
   default_target_origin_id                       = "origin"

--- a/cloudfront/wellcomelibrary.org/terraform/opac.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/opac.tf
@@ -32,6 +32,7 @@ module "wellcomelibrary_opac-stage" {
     origin_id : "origin"
     domain_name : "catalogue.origin.wellcomelibrary.org"
     origin_path : null
+    origin_protocol_policy: "match-viewer"
   }]
 
   default_target_origin_id                       = "origin"


### PR DESCRIPTION
Manage DServe DNS (archives.wellcomelibrary.org) in terraform. 

This PR adds DNS records / stage cloudfront distro to be added to later.

Part of https://github.com/wellcomecollection/platform/issues/5057

Depends:
- https://github.com/wellcomecollection/platform-infrastructure/pull/145

**Note:** this is applied.