### PR TITLE
Remove access to the Miro images in workingstorage

### DIFF
--- a/accounts/workflow/iam_workflow_support.tf
+++ b/accounts/workflow/iam_workflow_support.tf
@@ -67,7 +67,6 @@ data "aws_iam_policy_document" "workflow_support" {
     ]
 
     resources = [
-      "arn:aws:s3:::wellcomecollection-assets-workingstorage/miro/*",
       "arn:aws:s3:::wellcomecollection-assets-workingstorage/preservica/*",
     ]
   }

--- a/assets/iam_users.tf
+++ b/assets/iam_users.tf
@@ -28,7 +28,6 @@ data "aws_iam_policy_document" "allow_miro_access" {
     ]
 
     resources = [
-      "${aws_s3_bucket.working_storage.arn}/miro/*",
       "arn:aws:s3:::wellcomecollection-storage/miro/*",
     ]
   }

--- a/assets/s3_workingstorage.tf
+++ b/assets/s3_workingstorage.tf
@@ -49,12 +49,6 @@ locals {
 }
 
 data "aws_iam_policy_document" "working_storage" {
-
-  # These two statements allow the digitisation team to view the MIRO archive,
-  # which is in s3://wc-assets-workingstorage/miro
-  #
-  # It also allows them to view the files that were saved from Preservica
-  # for reingest through Goobi, in /preservica.
   statement {
     principals {
       identifiers = [
@@ -91,7 +85,6 @@ data "aws_iam_policy_document" "working_storage" {
     ]
 
     resources = [
-      "${aws_s3_bucket.working_storage.arn}/miro/*",
       "${aws_s3_bucket.working_storage.arn}/preservica/*",
       "${aws_s3_bucket.working_storage.arn}/proquest/*",
     ]


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/4885

These images have been copied to the storage service, and people should be downloading them from there instead – we sent out instructions several weeks ago, and warned people we'd be turning off access this week.

This change is applied, but I haven't deleted any objects yet.