### PR TITLE
Pass through if no valid redirect for Wellcome Library APIs

### DIFF
--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.test.ts
@@ -119,28 +119,22 @@ const rewriteTests = (): ExpectedRewrite[] => {
     },
     {
       uri: '/iiif/collection/not-found',
-      out: expectedServerError(
-        'Got 404 from https://iiif.wellcomecollection.org/wlorgp/iiif/collection/not-found'
-      ),
+      out: expectedPassthru('/iiif/collection/not-found'),
       error: axios404,
     },
     {
       uri: '/iiif/collection/no-response',
-      out: expectedServerError(
-        'No response from https://iiif.wellcomecollection.org/wlorgp/iiif/collection/no-response'
-      ),
+      out: expectedPassthru('/iiif/collection/no-response'),
       error: axiosNoResponse,
     },
     {
       uri: '/iiif/collection/error',
-      out: expectedServerError(
-        'Unknown error from https://iiif.wellcomecollection.org/wlorgp/iiif/collection/error: Error: nope'
-      ),
+      out: expectedPassthru('/iiif/collection/error'),
       error: Error('nope'),
     },
     {
       uri: '/iiif/collection/invalid-url',
-      out: expectedServerError('Invalid URL: not_a_url'),
+      out:  expectedPassthru('/iiif/collection/invalid-url'),
       generateData: () => 'not_a_url',
     },
     {

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.ts
@@ -40,12 +40,12 @@ async function getWorksRedirect(
   return wellcomeCollectionRedirect(`/works/${work.id}`);
 }
 
-async function getApiRedirects(uri: string): Promise<CloudFrontResultResponse> {
+async function getApiRedirects(uri: string): Promise<CloudFrontResultResponse | undefined> {
   const apiRedirectUri = await wlorgpLookup(uri);
 
   if (apiRedirectUri instanceof Error) {
     console.error(apiRedirectUri);
-    return createServerError(apiRedirectUri);
+    return Promise.resolve(undefined);
   }
 
   return createRedirect(apiRedirectUri);

--- a/cloudfront/wellcomelibrary.org/terraform/locals.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/locals.tf
@@ -4,7 +4,7 @@ locals {
   wellcome_library_redirect_arn_latest = "${local.wellcome_library_redirect_arn}:${local.wellcome_library_redirect_latest}"
   wellcome_library_redirect_arn_stage  = local.wellcome_library_redirect_arn_latest
   # This should be set manually when a stable prod deploy is established.
-  wellcome_library_redirect_arn_prod = "${local.wellcome_library_redirect_arn}:56"
+  wellcome_library_redirect_arn_prod = "${local.wellcome_library_redirect_arn}:58"
 
   wellcome_library_passthru_arn        = aws_lambda_function.wellcome_library_passthru.arn
   wellcome_library_passthru_latest     = aws_lambda_function.wellcome_library_passthru.version


### PR DESCRIPTION
This change will pass through requests to the old wellcome library site where there is no valid redirect, this is to help the Library API transition.