### PR TITLE
extend data dev to access catalogue account

### DIFF
--- a/accounts/platform/rolesets.tf
+++ b/accounts/platform/rolesets.tf
@@ -249,14 +249,17 @@ module "data_dev_roleset" {
     local.data_account_roles["admin_role_arn"],
     local.data_account_roles["developer_role_arn"],
     local.data_account_roles["read_only_role_arn"],
+    local.data_account_roles["ci_role_arn"],
 
     # Reporting
     local.reporting_account_roles["developer_role_arn"],
     local.reporting_account_roles["read_only_role_arn"],
+    local.reporting_account_roles["ci_role_arn"],
 
     # Catalogue
     local.catalogue_account_roles["developer_role_arn"],
     local.catalogue_account_roles["read_only_role_arn"],
+    local.catalogue_account_roles["ci_role_arn"],
 
     # Scala lib read Role
     aws_iam_role.s3_scala_releases_read.arn,

--- a/accounts/platform/rolesets.tf
+++ b/accounts/platform/rolesets.tf
@@ -253,6 +253,10 @@ module "data_dev_roleset" {
     # Reporting
     local.reporting_account_roles["developer_role_arn"],
     local.reporting_account_roles["read_only_role_arn"],
+      
+    # Catalogue
+    local.catalogue_account_roles["developer_role_arn"],
+    local.catalogue_account_roles["read_only_role_arn"],
 
     # Scala lib read Role
     aws_iam_role.s3_scala_releases_read.arn,

--- a/accounts/platform/rolesets.tf
+++ b/accounts/platform/rolesets.tf
@@ -253,7 +253,7 @@ module "data_dev_roleset" {
     # Reporting
     local.reporting_account_roles["developer_role_arn"],
     local.reporting_account_roles["read_only_role_arn"],
-      
+
     # Catalogue
     local.catalogue_account_roles["developer_role_arn"],
     local.catalogue_account_roles["read_only_role_arn"],


### PR DESCRIPTION
As Harrison is working more on catalogue stuff, we need to extend his permissions.
```diff
resource "aws_iam_role_policy" "role_assumer" {
        id     = "data-dev:terraform-20190729114137699600000001"
        name   = "terraform-20190729114137699600000001"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = [
                            # (1 unchanged element hidden)
                            "arn:aws:iam::964279923020:role/data-developer",
                          + "arn:aws:iam::964279923020:role/data-ci",
                            "arn:aws:iam::964279923020:role/data-admin",
                            # (2 unchanged elements hidden)
                            "arn:aws:iam::760097843905:role/platform-developer",
                          + "arn:aws:iam::756629837203:role/catalogue-read_only",
                          + "arn:aws:iam::756629837203:role/catalogue-developer",
                          + "arn:aws:iam::756629837203:role/catalogue-ci",
                            "arn:aws:iam::269807742353:role/reporting-read_only",
                            "arn:aws:iam::269807742353:role/reporting-developer",
                          + "arn:aws:iam::269807742353:role/reporting-ci",
                        ]
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }
```