### PR TITLE
add platform CI role to data_dev

### DIFF
--- a/accounts/platform/.terraform.lock.hcl
+++ b/accounts/platform/.terraform.lock.hcl
@@ -5,6 +5,17 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "3.34.0"
   hashes = [
     "h1:2xGmnG7UF0iScMGVWBazSYk1sRatXeZYgCGjdGm4A+w=",
+    "zh:003272229bd19bb63d6e77bc3d684268c417a151dfaee01c40b40e21cdd8bb0f",
+    "zh:103cacc1f3d97dfb7e9dd1e1905b075f92d9bd8aed434f811e8111788b648a57",
+    "zh:63a43c6e5fb2e5ad59ea068bede5c6bb54358affd32163d72785473a15440427",
+    "zh:6648af39a318c85eb336e2fb3ec1a01c5ffe8d75cc51686c37e892dd6f6a8974",
+    "zh:71ac8f6d5d61e5dee90099fd4fc1bb5bcd8ccb674eb6e7cd58d20757f7cecd12",
+    "zh:73baae4aa5bc0af12917e3bb17e1086050d25cdf7ba604f7fc422653c99f884c",
+    "zh:7d920ac05c45e77c59c49e0dd0cb010d64202c5a2fdfde6d9efe3dc61e396c97",
+    "zh:8a495e49f8fcbe276a74911f9ca48381533686ff71a9d4f7027bb9109769b639",
+    "zh:8ab9769581dfc1675c645e33e7ab8fea6ad1acc9e232eeda823070447e5ecaf1",
+    "zh:a170ecc560d49c251f4bebb6d6a82ff3637ae16a0f779a53489d4a64ddd1ee6a",
+    "zh:d9178201057b62666691ec206d1fbe09965bcfea532085b4e31f46073bf5898f",
   ]
 }
 

--- a/accounts/platform/rolesets.tf
+++ b/accounts/platform/rolesets.tf
@@ -244,6 +244,7 @@ module "data_dev_roleset" {
     # Platform
     module.aws_account.developer_role_arn,
     module.aws_account.read_only_role_arn,
+    module.aws_account.ci_role_arn,
 
     # Data
     local.data_account_roles["admin_role_arn"],


### PR DESCRIPTION
## What's changing and why?
Adding platform CI role to the data dev as they / Harrison needs it to run catalogue stuff locally. We need platform CI as the catalogue repo is still coupled to the platform account.

## `terraform plan` diff
```diff
resource "aws_iam_role_policy" "role_assumer" {
        id     = "data-dev:terraform-20190729114137699600000001"
        name   = "terraform-20190729114137699600000001"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = [
                            # (6 unchanged elements hidden)
                            "arn:aws:iam::760097843905:role/platform-developer",
                          + "arn:aws:iam::760097843905:role/platform-ci",
                            "arn:aws:iam::756629837203:role/catalogue-read_only",
                            # (5 unchanged elements hidden)
                        ]
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }
```
