### PR TITLE
Allow identity-ci to assume itself

### DIFF
--- a/accounts/identity/iam_identity_ci.tf
+++ b/accounts/identity/iam_identity_ci.tf
@@ -119,4 +119,25 @@ data "aws_iam_policy_document" "identity_ci" {
       "arn:aws:iam::${local.account_ids.identity}:role/identity-ecs-execution-role-stage"
     ]
   }
+
+  # This slightly unusual clause allows the identity-ci role to assume… itself.
+  #
+  # This is because Buildkite uses the identity-ci role to run tasks
+  # in CI for https://github.com/wellcomecollection/identity, and those CI
+  # tasks in turn run Terraform, which has an "assume_role" block for the
+  # provider (to match our other Terraform configurations).
+  #
+  # When Buildkite running as identity-ci tries to assume identity-ci, that
+  # isn't allowed by default -- we need to explicitly allow it.
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    resources = [
+      "arn:aws:iam::${local.account_ids.identity}:role/identity-ci",
+    ]
+  }
 }


### PR DESCRIPTION
## What's changing and why?

This allows the identity-ci role to assume itself – see comment for why this is useful.

In the immediate term, this is about fixing the tests on https://github.com/wellcomecollection/identity/pull/111

This change is already applied.

## `terraform plan` diff

```
Terraform will perform the following actions:

  # aws_iam_role_policy.identity_ci will be updated in-place
  ~ resource "aws_iam_role_policy" "identity_ci" {
        id     = "identity-ci:terraform-20201119102354636800000001"
        name   = "terraform-20201119102354636800000001"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                    # (8 unchanged elements hidden)
                    {
                        Action   = "iam:PassRole"
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:iam::770700576653:role/identity-ecs-task-role-stage",
                            "arn:aws:iam::770700576653:role/identity-ecs-execution-role-stage",
                        ]
                        Sid      = ""
                    },
                  + {
                      + Action   = "sts:AssumeRole"
                      + Effect   = "Allow"
                      + Resource = "arn:aws:iam::770700576653:role/identity-ci"
                      + Sid      = ""
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }
```
