### PR TITLE
Enable Item page redirects & tests

### DIFF
--- a/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
@@ -159,7 +159,7 @@ const itemTestSet = {
   headers: staticRedirectHeaders,
   envs: {
     stage: 'https://stage.wellcomelibrary.org',
-    // prod: 'https://wellcomelibrary.org',
+    prod: 'https://wellcomelibrary.org',
   },
   checkResponse: checkMatchingUrl,
 };

--- a/cloudfront/wellcomelibrary.org/terraform/cf_behaviours.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/cf_behaviours.tf
@@ -103,7 +103,6 @@ locals {
 
   prod_behaviours = concat(
     local.api_behaviours,
-    local.items_behaviours
   )
 
   stage_behaviours = []


### PR DESCRIPTION
## What's changing and why?

Item page redirections are being made available in the production environment as aprt of deceommisioning the wellcomelibrary.org site.

## `terraform plan` diff
```
 # module.wellcomelibrary-prod.aws_cloudfront_distribution.distro will be updated in-place
  ~ resource "aws_cloudfront_distribution" "distro" {
        id                             = "EHUBCZTWBQL8L"
        tags                           = {
            "Managed" = "terraform"
        }
        # (17 unchanged attributes hidden)


      - ordered_cache_behavior {
          - allowed_methods        = [
              - "DELETE",
              - "GET",
              - "HEAD",
              - "OPTIONS",
              - "PATCH",
              - "POST",
              - "PUT",
            ] -> null
          - cached_methods         = [
              - "GET",
              - "HEAD",
              - "OPTIONS",
            ] -> null
          - compress               = false -> null
          - default_ttl            = 0 -> null
          - max_ttl                = 0 -> null
          - min_ttl                = 0 -> null
          - path_pattern           = "item/*" -> null
          - smooth_streaming       = false -> null
          - target_origin_id       = "origin" -> null
          - trusted_signers        = [] -> null
          - viewer_protocol_policy = "allow-all" -> null

          - forwarded_values {
              - headers                 = [
                  - "CloudFront-Forwarded-Proto",
                  - "Host",
                ] -> null
              - query_string            = true -> null
              - query_string_cache_keys = [] -> null

              - cookies {
                  - forward           = "all" -> null
                  - whitelisted_names = [] -> null
                }
            }

          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:760097843905:function:cf_edge_wellcome_library_passthru:37" -> null
            }
        }



        # (9 unchanged blocks hidden)
    }
```

**Note:** This change is applied.