### PR TITLE
Move the unhandled Miro images to Glacier Deep Archive

### DIFF
--- a/assets/s3_workingstorage.tf
+++ b/assets/s3_workingstorage.tf
@@ -38,6 +38,31 @@ resource "aws_s3_bucket" "working_storage" {
     enabled = true
   }
 
+  # We lifecycle all the remaining Miro images to Glacier.  We aren't
+  # going to look at these again until we move the Editorial Photography
+  # images into the storage service.
+  #
+  # We were going to delete all of these, but this might cause us to lose
+  # images -- we can't rely on "same ID" == "same image".  When we eventually
+  # sort out the Editorial Photography images, we'll have to inspect these
+  # images quite carefully to be sure we don't lose anything.
+  #
+  # In the meantime, putting them in Deep Archive will save us ~$1000 a year.
+  #
+  # See https://github.com/wellcomecollection/platform/issues/4885#issuecomment-816703253
+  lifecycle_rule {
+    id = "transition_miro_to_glacier"
+
+    prefix = "miro/"
+
+    transition {
+      days          = 90
+      storage_class = "DEEP_ARCHIVE"
+    }
+
+    enabled = true
+  }
+
   tags = local.default_tags
 }
 


### PR DESCRIPTION
## What's changing and why?

We have ~8TB of unhandled Miro images in `wellcomecollection-assets-workingstorage`.

* We can’t delete them indiscriminately – we'd be deleting the only copy of some images
* We can't compare them to the backups in `wellcomecollection-editorial-photography` – all those backups are lifecycled to Glacier, plus we'd need to spend way more time on this problem

See my comment on https://github.com/wellcomecollection/platform/issues/4885#issuecomment-816703253 for more explanation.

So for now, we'll push all these images off into Glacier Deep Archive – and restore them when we come back to put Editorial Photography images in the storage service. (Which is on the roadmap, but not the immediate one.)

The storage cost of Deep Archive is ~$100/year rather than $1250/year for Standard-IA. Retrieving them from Deep Archive will cost ~$200, so we'll definitely make a saving here (and emphasise that these images aren't in active use).

I haven't applied this change yet, pending discussion.

<details><summary><code>terraform plan</code> diff</summary>

```
Terraform will perform the following actions:

  # data.aws_iam_policy_document.working_storage will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "working_storage"  {
      ~ id      = "4276359186" -> (known after apply)
      ~ json    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "s3:List*"
                      - Effect    = "Allow"
                      - Principal = {
                          - AWS = [
                              - "arn:aws:iam::975596993436:root",
                              - "arn:aws:iam::404315009621:root",
                              - "arn:aws:iam::299497370133:root",
                            ]
                        }
                      - Resource  = "arn:aws:s3:::wellcomecollection-assets-workingstorage"
                      - Sid       = ""
                    },
                  - {
                      - Action    = "s3:Get*"
                      - Effect    = "Allow"
                      - Principal = {
                          - AWS = [
                              - "arn:aws:iam::975596993436:root",
                              - "arn:aws:iam::404315009621:root",
                              - "arn:aws:iam::299497370133:root",
                            ]
                        }
                      - Resource  = [
                          - "arn:aws:s3:::wellcomecollection-assets-workingstorage/proquest/*",
                          - "arn:aws:s3:::wellcomecollection-assets-workingstorage/preservica/*",
                        ]
                      - Sid       = ""
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> (known after apply)
      - version = "2012-10-17" -> null

      ~ statement {
          - effect        = "Allow" -> null
          - not_actions   = [] -> null
          - not_resources = [] -> null
            # (2 unchanged attributes hidden)

            # (1 unchanged block hidden)
        }
      ~ statement {
          - effect        = "Allow" -> null
          - not_actions   = [] -> null
          - not_resources = [] -> null
            # (2 unchanged attributes hidden)

            # (1 unchanged block hidden)
        }
    }

  # aws_s3_bucket.working_storage will be updated in-place
  ~ resource "aws_s3_bucket" "working_storage" {
        id                          = "wellcomecollection-assets-workingstorage"
        tags                        = {
            "TerraformConfigurationURL" = "https://github.com/wellcomecollection/platform-infrastructure/tree/master/assets"
        }
        # (9 unchanged attributes hidden)

      + lifecycle_rule {
          + enabled = true
          + id      = "transition_miro_to_glacier"
          + prefix  = "miro/"

          + transition {
              + days          = 90
              + storage_class = "DEEP_ARCHIVE"
            }
        }

        # (3 unchanged blocks hidden)
    }

  # aws_s3_bucket_policy.working_storage will be updated in-place
  ~ resource "aws_s3_bucket_policy" "working_storage" {
        id     = "wellcomecollection-assets-workingstorage"
      ~ policy = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "s3:List*"
                      - Effect    = "Allow"
                      - Principal = {
                          - AWS = [
                              - "arn:aws:iam::404315009621:root",
                              - "arn:aws:iam::975596993436:root",
                              - "arn:aws:iam::299497370133:root",
                            ]
                        }
                      - Resource  = "arn:aws:s3:::wellcomecollection-assets-workingstorage"
                      - Sid       = ""
                    },
                  - {
                      - Action    = "s3:Get*"
                      - Effect    = "Allow"
                      - Principal = {
                          - AWS = [
                              - "arn:aws:iam::404315009621:root",
                              - "arn:aws:iam::975596993436:root",
                              - "arn:aws:iam::299497370133:root",
                            ]
                        }
                      - Resource  = [
                          - "arn:aws:s3:::wellcomecollection-assets-workingstorage/proquest/*",
                          - "arn:aws:s3:::wellcomecollection-assets-workingstorage/preservica/*",
                        ]
                      - Sid       = ""
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> (known after apply)
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```
</details>


