### PR TITLE
/player redirects

### DIFF
--- a/cloudfront/wellcomelibrary.org/edge-lambda/itemRedirects.csv
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/itemRedirects.csv
@@ -11,3 +11,6 @@ Tusk of the narwhal,wellcomelibrary.org/item/b14657314,https://wellcomecollectio
 Daddy cool,wellcomelibrary.org/item/b28516266,https://wellcomecollection.org/works/r6fsquw6,Daddy cool,item
 Etmullerus abridg'd,wellcomelibrary.org/item/b22885651,https://wellcomecollection.org/works/g24u6b49,Etmullerus abridg'd,item
 The biocrats,wellcomelibrary.org/item/b18035978,https://wellcomecollection.org/works/zjytxny8,The biocrats,item
+Burdock Blood Bitters,wellcomelibrary.org/player/b2868624,https://wellcomecollection.org/works/mzfepu4d, Burdock Blood Bitters, player
+Health its friends and its foes,wellcomelibrary.org/player/b2114332,https://wellcomecollection.org/works/ct3663dw, Health its friends and its foes, player
+International exhibition on wellness,wellcomelibrary.org/player/b1754225,https://wellcomecollection.org/works/hre497n5, International exhibition on wellness, player

--- a/cloudfront/wellcomelibrary.org/edge-lambda/itemRedirects.csv
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/itemRedirects.csv
@@ -19,3 +19,7 @@ health facility counter,wellcomelibrary.org/player/b1757055,https://wellcomecoll
 Pontecorvo guestbook,wellcomelibrary.org/item/b19872586,https://wellcomecollection.org/works/p8rwxcnz,Pontecorvo guestbook,item
 John Dee performing an experiment,wellcomelibrary.org/item/b14658197,https://wellcomecollection.org/works/nydjbrr7,John Dee performing an experiment,item
 Traffic lights,wellcomelibrary.org/item/b16772969,https://wellcomecollection.org/works/knzgmnj6,Traffic lights,item
+Correspondence Klug Aaron,wellcomelibrary.org/player/b1816375,https://wellcomecollection.org/works/bq3mkudq,Correspondence Klug Aaron,player
+Jean Elizabeth Cameron Mourant,wellcomelibrary.org/player/b1772688,https://wellcomecollection.org/works/qbvz9arx,Jean Elizabeth Cameron Mourant,player
+Pencil sketch of the DNA double helix,wellcomelibrary.org/player/b1613633,https://wellcomecollection.org/works/kmebmktz,Pencil sketch of the DNA double helix,player
+Boaistuau Pierre,wellcomelibrary.org/player/b1966250,https://wellcomecollection.org/works/zx3es3zp,Boaistuau Pierre,player

--- a/cloudfront/wellcomelibrary.org/edge-lambda/itemRedirects.csv
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/itemRedirects.csv
@@ -14,3 +14,8 @@ The biocrats,wellcomelibrary.org/item/b18035978,https://wellcomecollection.org/w
 Burdock Blood Bitters,wellcomelibrary.org/player/b2868624,https://wellcomecollection.org/works/mzfepu4d, Burdock Blood Bitters, player
 Health its friends and its foes,wellcomelibrary.org/player/b2114332,https://wellcomecollection.org/works/ct3663dw, Health its friends and its foes, player
 International exhibition on wellness,wellcomelibrary.org/player/b1754225,https://wellcomecollection.org/works/hre497n5, International exhibition on wellness, player
+Posters,wellcomelibrary.org/player/b1977755,https://wellcomecollection.org/works/p2ebzusp,Posters,player
+health facility counter,wellcomelibrary.org/player/b1757055,https://wellcomecollection.org/works/pnrsujxs,health facility counter,player
+Pontecorvo guestbook,wellcomelibrary.org/item/b19872586,https://wellcomecollection.org/works/p8rwxcnz,Pontecorvo guestbook,item
+John Dee performing an experiment,wellcomelibrary.org/item/b14658197,https://wellcomecollection.org/works/nydjbrr7,John Dee performing an experiment,item
+Traffic lights,wellcomelibrary.org/item/b16772969,https://wellcomecollection.org/works/knzgmnj6,Traffic lights,item

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/bnumberToWork.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/bnumberToWork.test.ts
@@ -4,7 +4,6 @@ import {
   testDataMultiPageFirstPage,
   testDataMultiPageNextPage,
   testDataNoResults,
-  testDataSingleResult,
 } from './catalogueApiFixtures';
 import { Work, CatalogueResultsList, Identifier } from './catalogueApi';
 import { getWork } from './bnumberToWork';

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/bnumberToWork.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/bnumberToWork.test.ts
@@ -19,15 +19,6 @@ test('returns an Error when none available', async () => {
   expect(workResults).toEqual(Error('No matching Catalogue API results found'));
 });
 
-test('returns a Work when one result available', async () => {
-  mockedAxios.get.mockResolvedValueOnce({ data: testDataSingleResult });
-
-  const expectedWork = testDataSingleResult.results[0] as Work;
-
-  const workResults = await getWork('bnumber');
-  expect(workResults).toEqual(expectedWork);
-});
-
 const includesSierraIdentifiers = [
   {
     identifierType: {
@@ -77,27 +68,7 @@ function addIdentifiersToPage(
   };
 }
 
-test('returns the last work when no identifiers', async () => {
-  const firstPageWithoutSierraIdentifiers = addIdentifiersToPage(
-    excludesSierraIdentifiers,
-    testDataMultiPageFirstPage as CatalogueResultsList
-  );
-  const nextPageWithoutSierraIdentifiers = addIdentifiersToPage(
-    excludesSierraIdentifiers,
-    testDataMultiPageNextPage as CatalogueResultsList
-  );
-
-  mockedAxios.get
-    .mockResolvedValueOnce({ data: firstPageWithoutSierraIdentifiers })
-    .mockResolvedValueOnce({ data: nextPageWithoutSierraIdentifiers });
-
-  const expectedWork = nextPageWithoutSierraIdentifiers.results[0] as Work;
-
-  const workResults = await getWork('bnumber');
-  expect(workResults).toEqual(expectedWork);
-});
-
-test('returns the first Work with a "sierra-identifier" identifier', async () => {
+test('returns the work with a "sierra-identifier" identifier', async () => {
   const firstPageWithSierraIdentifiers = addIdentifiersToPage(
     includesSierraIdentifiers,
     testDataMultiPageFirstPage as CatalogueResultsList

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/bnumberToWork.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/bnumberToWork.test.ts
@@ -69,7 +69,8 @@ test('returns an Error when none available', async () => {
     .mockResolvedValueOnce({ data: testDataNoResults });
 
   const workResults = await getWork({
-    sierraIdentifier: 'b1234567',
+    sierraIdentifier: '1234567',
+    sierraSystemNumber: 'b1234567x',
   });
 
   expect(workResults).toEqual(Error('No matching Catalogue API results found'));
@@ -93,6 +94,7 @@ test('returns the work with a "sierra-identifier" identifier', async () => {
 
   const workResults = await getWork({
     sierraIdentifier: includesSierraId[0].value,
+    sierraSystemNumber: 'b12062789',
   });
 
   expect(workResults).toEqual(expectedWork);

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/bnumberToWork.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/bnumberToWork.ts
@@ -6,10 +6,7 @@ export async function getWork(bNumber: string): Promise<GetWorkResult> {
     include: ['identifiers'],
   });
 
-  let work;
-
   for await (const result of resultList) {
-    work = result;
 
     if (result.identifiers) {
       const identifiers: Identifier[] = result.identifiers;
@@ -20,14 +17,10 @@ export async function getWork(bNumber: string): Promise<GetWorkResult> {
         (thing) => thing.identifierType.id === 'sierra-identifier'
       );
       if (hasSierraId) {
-        break;
+        return result;
       }
     }
   }
 
-  if (work) {
-    return work;
-  } else {
-    return Error('No matching Catalogue API results found');
-  }
+  return Error('No matching Catalogue API results found');
 }

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/bnumberToWork.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/bnumberToWork.ts
@@ -1,13 +1,9 @@
 import { apiQuery, GetWorkResult, Identifier } from './catalogueApi';
 
 export async function getWork(bNumber: string): Promise<GetWorkResult> {
-  const resultList = apiQuery({
-    query: bNumber,
-    include: ['identifiers'],
-  });
+  const resultList = apiQuery(bNumber);
 
   for await (const result of resultList) {
-
     if (result.identifiers) {
       const identifiers: Identifier[] = result.identifiers;
       // If the work has a sierra-identifier identifier, that

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.test.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { jest, test, expect } from '@jest/globals';
+import { jest, test, expect, afterEach } from '@jest/globals';
 
 import { apiQuery, Work } from './catalogueApi';
 import {
@@ -77,4 +77,8 @@ test('returns multiple result across pages', async () => {
   ];
 
   expect(works).toEqual(expectedResults);
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
 });

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.test.ts
@@ -16,10 +16,7 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 test('returns no results when none available', async () => {
   mockedAxios.get.mockResolvedValueOnce({ data: testDataNoResults });
 
-  const resultList = apiQuery({
-    query: 'bnumber',
-    include: ['identifiers'],
-  });
+  const resultList = apiQuery('bnumber');
 
   const works = [];
 
@@ -33,10 +30,7 @@ test('returns no results when none available', async () => {
 test('returns a result when one available', async () => {
   mockedAxios.get.mockResolvedValueOnce({ data: testDataSingleResult });
 
-  const resultList = apiQuery({
-    query: 'bnumber',
-    include: ['identifiers'],
-  });
+  const resultList = apiQuery('bnumber');
 
   const works = [];
 
@@ -50,10 +44,7 @@ test('returns a result when one available', async () => {
 test('returns multiple result when available', async () => {
   mockedAxios.get.mockResolvedValueOnce({ data: testDataMultipleResults });
 
-  const resultList = apiQuery({
-    query: 'bnumber',
-    include: ['identifiers'],
-  });
+  const resultList = apiQuery('bnumber');
 
   const works = [];
   for await (const result of resultList) {
@@ -73,10 +64,7 @@ test('returns multiple result across pages', async () => {
     .mockResolvedValueOnce({ data: testDataMultiPageFirstPage })
     .mockResolvedValueOnce({ data: testDataMultiPageNextPage });
 
-  const resultList = apiQuery({
-    query: 'bnumber',
-    include: ['identifiers'],
-  });
+  const resultList = apiQuery('bnumber');
 
   const works = [];
   for await (const result of resultList) {

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.ts
@@ -2,11 +2,6 @@ import axios from 'axios';
 
 const apiBasePath = 'https://api.wellcomecollection.org/catalogue/v2';
 
-export type ApiQuery = {
-  query: string;
-  include: string[];
-};
-
 export type IdentifierType = {
   id: string;
   label: string;
@@ -38,12 +33,12 @@ export type CatalogueResultsList<Result = Work> = {
 export type GetWorkResult = Work | Error;
 
 export async function* apiQuery(
-  query: ApiQuery
+  query: string
 ): AsyncGenerator<Work, void, void> {
   const url = `${apiBasePath}/works`;
-  const config = { params: query };
+  const queryUrl = `${url}?include=identifiers&query=${query}`;
 
-  const apiResult = await axios.get(url, config);
+  const apiResult = await axios.get(queryUrl);
   const resultList = apiResult.data as CatalogueResultsList;
 
   let nextPage = resultList.nextPage;

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.ts
@@ -27,7 +27,7 @@ export type CatalogueResultsList<Result = Work> = {
   results: Result[];
   pageSize: number;
   prevPage?: string;
-  nextPage: string | undefined;
+  nextPage?: string | undefined;
 };
 
 export type GetWorkResult = Work | Error;

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApiFixtures.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApiFixtures.ts
@@ -16,13 +16,13 @@ export const testDataSingleResult = {
       identifiers: [
         {
           identifierType: {
-            id: "sierra-identifier",
-            label: "Sierra identifier",
-            type: "IdentifierType"
+            id: 'sierra-identifier',
+            label: 'Sierra identifier',
+            type: 'IdentifierType',
           },
-          value: "2242512",
-          type: "Identifier"
-        }
+          value: '2242512',
+          type: 'Identifier',
+        },
       ],
       thumbnail: {},
       availableOnline: true,
@@ -50,13 +50,13 @@ export const testDataMultipleResults = {
       identifiers: [
         {
           identifierType: {
-            id: "sierra-identifier",
-            label: "Sierra identifier",
-            type: "IdentifierType"
+            id: 'sierra-identifier',
+            label: 'Sierra identifier',
+            type: 'IdentifierType',
           },
-          value: "2242512",
-          type: "Identifier"
-        }
+          value: '2242512',
+          type: 'Identifier',
+        },
       ],
       thumbnail: {},
       availableOnline: true,
@@ -96,13 +96,13 @@ export const testDataMultiPageFirstPage = {
       identifiers: [
         {
           identifierType: {
-            id: "sierra-identifier",
-            label: "Sierra identifier",
-            type: "IdentifierType"
+            id: 'sierra-identifier',
+            label: 'Sierra identifier',
+            type: 'IdentifierType',
           },
-          value: "2242512",
-          type: "Identifier"
-        }
+          value: '2242512',
+          type: 'Identifier',
+        },
       ],
       thumbnail: {},
       availableOnline: true,

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApiFixtures.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApiFixtures.ts
@@ -13,6 +13,17 @@ export const testDataSingleResult = {
         '<p>Leaflet outlining basic training and health tips for people with a new kitten.</p>',
       physicalDescription: '1 folded sheet (4 p.) : ill. ; 21 cm.',
       workType: {},
+      identifiers: [
+        {
+          identifierType: {
+            id: "sierra-identifier",
+            label: "Sierra identifier",
+            type: "IdentifierType"
+          },
+          value: "2242512",
+          type: "Identifier"
+        }
+      ],
       thumbnail: {},
       availableOnline: true,
       availabilities: {},
@@ -36,6 +47,17 @@ export const testDataMultipleResults = {
         '<p>Leaflet outlining basic training and health tips for people with a new kitten.</p>',
       physicalDescription: '1 folded sheet (4 p.) : ill. ; 21 cm.',
       workType: {},
+      identifiers: [
+        {
+          identifierType: {
+            id: "sierra-identifier",
+            label: "Sierra identifier",
+            type: "IdentifierType"
+          },
+          value: "2242512",
+          type: "Identifier"
+        }
+      ],
       thumbnail: {},
       availableOnline: true,
       availabilities: {},
@@ -71,6 +93,17 @@ export const testDataMultiPageFirstPage = {
         '<p>Leaflet outlining basic training and health tips for people with a new kitten.</p>',
       physicalDescription: '1 folded sheet (4 p.) : ill. ; 21 cm.',
       workType: {},
+      identifiers: [
+        {
+          identifierType: {
+            id: "sierra-identifier",
+            label: "Sierra identifier",
+            type: "IdentifierType"
+          },
+          value: "2242512",
+          type: "Identifier"
+        }
+      ],
       thumbnail: {},
       availableOnline: true,
       availabilities: {},

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.test.ts
@@ -1,43 +1,67 @@
 import { expect, test } from '@jest/globals';
-import { getBnumberFromPath } from './paths';
+import { getBnumberFromPath, SierraIdentifier } from './paths';
 
 type ExpectedPath = {
   in: string;
-  out: string | Error;
+  out: SierraIdentifier | Error;
 };
 const pathTests = (): ExpectedPath[] => {
   return [
     {
       in: '/item/b21293302',
-      out: '2129330',
+      out: {
+        sierraIdentifier: '2129330',
+        sierraSystemNumber: 'b21293302',
+      },
     },
     {
       in: '/item/B21293302',
-      out: '2129330',
+      out: {
+        sierraIdentifier: '2129330',
+        sierraSystemNumber: 'b21293302',
+      },
     },
     {
       in: '/item/b2129330x',
-      out: '2129330',
+      out: {
+        sierraIdentifier: '2129330',
+        sierraSystemNumber: undefined,
+      },
     },
     {
       in: '/item/b2129330',
-      out: '2129330',
+      out: {
+        sierraIdentifier: '2129330',
+        sierraSystemNumber: undefined,
+      },
     },
     {
       in: '/player/b21293302',
-      out: '2129330',
+      out: {
+        sierraIdentifier: '2129330',
+        sierraSystemNumber: 'b21293302',
+      },
     },
     {
       in: '/player/B21293302',
-      out: '2129330',
+      out: {
+        sierraIdentifier: '2129330',
+        sierraSystemNumber: 'b21293302',
+      },
     },
     {
       in: '/player/b2129330x',
-      out: '2129330',
+      out: {
+        sierraIdentifier: '2129330',
+        sierraSystemNumber: undefined,
+      },
     },
     {
       in: '/player/b2129330',
-      out: '2129330',
+      out: {
+        sierraIdentifier: '2129330',
+        sierraSystemNumber: undefined,
+      },
     },
     {
       in: '/item/b21293302/nope',

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.test.ts
@@ -9,19 +9,19 @@ const pathTests = (): ExpectedPath[] => {
   return [
     {
       in: '/item/b21293302',
-      out: 'b21293302',
+      out: '2129330',
     },
     {
       in: '/item/B21293302',
-      out: 'b21293302',
+      out: '2129330',
     },
     {
       in: '/item/b2129330x',
-      out: 'b2129330x',
+      out: '2129330',
     },
     {
       in: '/item/b2129330',
-      out: 'b2129330',
+      out: '2129330',
     },
     {
       in: '/item/b21293302/nope',

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.test.ts
@@ -24,6 +24,22 @@ const pathTests = (): ExpectedPath[] => {
       out: '2129330',
     },
     {
+      in: '/player/b21293302',
+      out: '2129330',
+    },
+    {
+      in: '/player/B21293302',
+      out: '2129330',
+    },
+    {
+      in: '/player/b2129330x',
+      out: '2129330',
+    },
+    {
+      in: '/player/b2129330',
+      out: '2129330',
+    },
+    {
       in: '/item/b21293302/nope',
       out: Error(
         'Path /item/b21293302/nope has the wrong number many elements (expected 2)'
@@ -43,7 +59,7 @@ const pathTests = (): ExpectedPath[] => {
     },
     {
       in: '/notitem/gary',
-      out: Error('Path /notitem/gary does not start with /item'),
+      out: Error('Path /notitem/gary does not start with /item or /player'),
     },
     {
       in: '/item/i21293302',

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.test.ts
@@ -25,14 +25,14 @@ const pathTests = (): ExpectedPath[] => {
       in: '/item/b2129330x',
       out: {
         sierraIdentifier: '2129330',
-        sierraSystemNumber: undefined,
+        sierraSystemNumber: 'b21293302',
       },
     },
     {
       in: '/item/b2129330',
       out: {
         sierraIdentifier: '2129330',
-        sierraSystemNumber: undefined,
+        sierraSystemNumber: 'b21293302',
       },
     },
     {
@@ -53,14 +53,14 @@ const pathTests = (): ExpectedPath[] => {
       in: '/player/b2129330x',
       out: {
         sierraIdentifier: '2129330',
-        sierraSystemNumber: undefined,
+        sierraSystemNumber: 'b21293302',
       },
     },
     {
       in: '/player/b2129330',
       out: {
         sierraIdentifier: '2129330',
-        sierraSystemNumber: undefined,
+        sierraSystemNumber: 'b21293302',
       },
     },
     {

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.ts
@@ -24,5 +24,8 @@ export function getBnumberFromPath(path: string): GetBNumberResult {
     return Error(`b number in ${path} does not match ${bNumberRegexp}`);
   }
 
-  return splitPath[2].toLowerCase();
+  return splitPath[2]
+      .toLowerCase()
+      .substr(1,7)
+
 }

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.ts
@@ -1,10 +1,16 @@
-export type GetBNumberResult = string | Error;
+export type SierraIdentifier = {
+  sierraIdentifier: string;
+  sierraSystemNumber?: string;
+};
+
+export type GetBNumberResult = SierraIdentifier | Error;
 
 export function getBnumberFromPath(path: string): GetBNumberResult {
   const splitPath = path.split('/');
 
   // Match on paths like b1234567x / b12345678
-  const bNumberRegexp = /^[bB][0-9]{7}/;
+  const sierraIdRegexp = /^[bB][0-9]{7}/;
+  const sierraSystemNumberRegexp = /^[bB][0-9]{8}/;
 
   if (splitPath[0] !== '') {
     return Error(`Path ${path} does not start with /`);
@@ -20,9 +26,17 @@ export function getBnumberFromPath(path: string): GetBNumberResult {
     return Error(`Path ${path} does not start with /item or /player`);
   }
 
-  if (!bNumberRegexp.test(splitPath[2])) {
-    return Error(`b number in ${path} does not match ${bNumberRegexp}`);
+  if (!sierraIdRegexp.test(splitPath[2])) {
+    return Error(`b number in ${path} does not match ${sierraIdRegexp}`);
   }
 
-  return splitPath[2].toLowerCase().substr(1, 7);
+  const sierraIdentifier = splitPath[2].toLowerCase().substr(1, 7);
+  const sierraSystemNumber = sierraSystemNumberRegexp.test(splitPath[2])
+    ? splitPath[2].toLowerCase().substr(0, 9)
+    : undefined;
+
+  return {
+    sierraIdentifier: sierraIdentifier,
+    sierraSystemNumber: sierraSystemNumber,
+  };
 }

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.ts
@@ -7,17 +7,17 @@ export type GetBNumberResult = SierraIdentifier | Error;
 
 // Copied from https://github.com/SydneyUniLibrary/sierra-record-check-digit/blob/master/index.js#L21
 function calcCheckDigit(recordNumber: number) {
-  let m = 2
-  let x = 0
-  let i = Number(recordNumber)
+  let m = 2;
+  let x = 0;
+  let i = Number(recordNumber);
   while (i > 0) {
-    let a = i % 10
-    i = Math.floor(i / 10)
-    x += a * m
-    m += 1
+    const a = i % 10;
+    i = Math.floor(i / 10);
+    x += a * m;
+    m += 1;
   }
-  const r = x % 11
-  return r === 10 ? 'x' : String(r)
+  const r = x % 11;
+  return r === 10 ? 'x' : String(r);
 }
 
 export function getBnumberFromPath(path: string): GetBNumberResult {
@@ -45,7 +45,9 @@ export function getBnumberFromPath(path: string): GetBNumberResult {
   }
 
   const sierraIdentifier = splitPath[2].toLowerCase().substr(1, 7);
-  const sierraSystemNumber = `b${sierraIdentifier}${calcCheckDigit(parseInt(sierraIdentifier))}`
+  const sierraSystemNumber = `b${sierraIdentifier}${calcCheckDigit(
+    parseInt(sierraIdentifier)
+  )}`;
 
   return {
     sierraIdentifier: sierraIdentifier,

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.ts
@@ -16,16 +16,13 @@ export function getBnumberFromPath(path: string): GetBNumberResult {
     );
   }
 
-  if (splitPath[1] !== 'item') {
-    return Error(`Path ${path} does not start with /item`);
+  if (!(splitPath[1] === 'item' || splitPath[1] === 'player')) {
+    return Error(`Path ${path} does not start with /item or /player`);
   }
 
   if (!bNumberRegexp.test(splitPath[2])) {
     return Error(`b number in ${path} does not match ${bNumberRegexp}`);
   }
 
-  return splitPath[2]
-      .toLowerCase()
-      .substr(1,7)
-
+  return splitPath[2].toLowerCase().substr(1, 7);
 }

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/safeGet.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/safeGet.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, jest } from '@jest/globals';
+import { expect, test, jest, afterEach } from '@jest/globals';
 import axios from 'axios';
 import { safeGet } from './safeGet';
 
@@ -51,4 +51,8 @@ test('returns the data value with a success response', async () => {
   const getResult = await safeGet('http://www.example.com');
 
   expect(getResult).toEqual(expectedData);
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
 });

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.test.ts
@@ -10,7 +10,6 @@ import {
   axiosNoResponse,
   expectedPassthru,
   expectedRedirect,
-  expectedServerError,
 } from './testHelpers';
 import {
   CloudFrontRequest,
@@ -67,7 +66,7 @@ type ExpectedRewrite = {
 
 const rewriteTests = (): ExpectedRewrite[] => {
   return [
-    // Item page tests
+    // Item & player page tests
     {
       uri: '/item/b21293302',
       out: expectedRedirect('https://wellcomecollection.org/works/k2a8y7q6'),
@@ -75,6 +74,16 @@ const rewriteTests = (): ExpectedRewrite[] => {
     },
     {
       uri: '/item/b21293302',
+      out: expectedRedirect('https://wellcomecollection.org/works/not-found'),
+      generateData: () => testDataNoResults,
+    },
+    {
+      uri: '/player/b21293302',
+      out: expectedRedirect('https://wellcomecollection.org/works/k2a8y7q6'),
+      generateData: () => testDataSingleResult,
+    },
+    {
+      uri: '/player/b21293302',
       out: expectedRedirect('https://wellcomecollection.org/works/not-found'),
       generateData: () => testDataNoResults,
     },
@@ -134,7 +143,7 @@ const rewriteTests = (): ExpectedRewrite[] => {
     },
     {
       uri: '/iiif/collection/invalid-url',
-      out:  expectedPassthru('/iiif/collection/invalid-url'),
+      out: expectedPassthru('/iiif/collection/invalid-url'),
       generateData: () => 'not_a_url',
     },
     {

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.ts
@@ -21,15 +21,15 @@ async function getWorksRedirect(
   uri: string
 ): Promise<CloudFrontResultResponse> {
   // Try and find b-number in item path
-  const bNumberResult = getBnumberFromPath(uri);
+  const sierraIdentifier = getBnumberFromPath(uri);
 
-  if (bNumberResult instanceof Error) {
-    console.error(bNumberResult);
+  if (sierraIdentifier instanceof Error) {
+    console.error(sierraIdentifier);
     return wellcomeCollectionNotFoundRedirect;
   }
 
   // Find corresponding work id
-  const work = await getWork(bNumberResult);
+  const work = await getWork(sierraIdentifier);
 
   if (work instanceof Error) {
     console.error(work);

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.ts
@@ -59,7 +59,7 @@ async function redirectRequestUri(
     uri = `${uri}?${request.querystring}`;
   }
 
-  const itemPathRegExp: RegExp = /^\/item\/.*/;
+  const itemPathRegExp: RegExp = /^\/(item|player)\/.*/;
   const eventsPathRegExp: RegExp = /^\/events(\/)?.*/;
   const apiPathRegExp: RegExp = /^\/(iiif|service|ddsconf|dds-static|annoservices)\/.*/;
   const staticRedirect = lookupRedirect(staticRedirects, uri);

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.ts
@@ -9,7 +9,6 @@ import {
   createRedirect,
   wellcomeCollectionNotFoundRedirect,
   wellcomeCollectionRedirect,
-  createServerError,
 } from './redirectHelpers';
 import { redirectToRoot } from './redirectToRoot';
 import { lookupRedirect } from './lookupRedirect';
@@ -40,7 +39,9 @@ async function getWorksRedirect(
   return wellcomeCollectionRedirect(`/works/${work.id}`);
 }
 
-async function getApiRedirects(uri: string): Promise<CloudFrontResultResponse | undefined> {
+async function getApiRedirects(
+  uri: string
+): Promise<CloudFrontResultResponse | undefined> {
   const apiRedirectUri = await wlorgpLookup(uri);
 
   if (apiRedirectUri instanceof Error) {

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wlorgpLookup.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wlorgpLookup.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, jest } from '@jest/globals';
+import { expect, test, jest, afterEach } from '@jest/globals';
 import { safeGet } from './safeGet';
 
 import { wlorgpLookup } from './wlorgpLookup';
@@ -37,4 +37,8 @@ test('returns a URL if valid is returned', async () => {
   const lookupResult = await wlorgpLookup('http://www.example.com');
 
   expect(lookupResult).toEqual(new URL(validUrl));
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
 });

--- a/cloudfront/wellcomelibrary.org/terraform/cf_behaviours.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/cf_behaviours.tf
@@ -103,7 +103,6 @@ locals {
 
   prod_behaviours = concat(
     local.api_behaviours,
-    local.items_behaviours
   )
 
   stage_behaviours = []

--- a/cloudfront/wellcomelibrary.org/terraform/cf_behaviours.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/cf_behaviours.tf
@@ -103,6 +103,7 @@ locals {
 
   prod_behaviours = concat(
     local.api_behaviours,
+    local.items_behaviours
   )
 
   stage_behaviours = []

--- a/cloudfront/wellcomelibrary.org/terraform/locals.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/locals.tf
@@ -4,7 +4,7 @@ locals {
   wellcome_library_redirect_arn_latest = "${local.wellcome_library_redirect_arn}:${local.wellcome_library_redirect_latest}"
   wellcome_library_redirect_arn_stage  = local.wellcome_library_redirect_arn_latest
   # This should be set manually when a stable prod deploy is established.
-  wellcome_library_redirect_arn_prod = "${local.wellcome_library_redirect_arn}:58"
+  wellcome_library_redirect_arn_prod = "${local.wellcome_library_redirect_arn}:69"
 
   wellcome_library_passthru_arn        = aws_lambda_function.wellcome_library_passthru.arn
   wellcome_library_passthru_latest     = aws_lambda_function.wellcome_library_passthru.version


### PR DESCRIPTION
## What's changing and why?

This redirects `/player` paths from the wellcomelibrary.org site, as these links (in addition to /item) are also displayed by encore (and "in the wild").

## `terraform plan` diff

TBD
