### PR TITLE
Add digirati-admin user

### DIFF
--- a/accounts/platform/rolesets.tf
+++ b/accounts/platform/rolesets.tf
@@ -1,3 +1,7 @@
+locals {
+  route53_wellcomecolection_update = "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update",
+}
+
 module "super_dev_roleset" {
   source = "../modules/roleset"
 
@@ -88,7 +92,7 @@ module "super_dev_roleset" {
     module.s3_releases_scala_fixtures.role_arn,
 
     # Route 53
-    "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update",
+    local.route53_wellcomecolection_update
   ]
 }
 
@@ -348,7 +352,7 @@ module "digirati_dev_roleset" {
     local.identity_account_roles["read_only_role_arn"],
     local.identity_account_roles["ci_role_arn"],
 
-    # Identity
+    # Experience
     local.experience_account_roles["developer_role_arn"],
     local.experience_account_roles["read_only_role_arn"],
     local.experience_account_roles["ci_role_arn"],
@@ -358,5 +362,45 @@ module "digirati_dev_roleset" {
 
     # Storage
     local.storage_account_roles["read_only_role_arn"]
+  ]
+}
+
+module "digirati_admin_roleset" {
+  source = "../modules/roleset"
+
+  name = "digirati-admin"
+
+  federated_principal = module.account_federation.principal
+  aws_principal       = local.aws_principal
+
+  assumable_role_arns = [
+    # Platform
+    module.aws_account.read_only_role_arn,
+
+    # Digirati
+    local.digirati_account_roles["admin_role_arn"],
+    local.digirati_account_roles["developer_role_arn"],
+    local.digirati_account_roles["read_only_role_arn"],
+    local.digirati_account_roles["ci_role_arn"],
+
+    # Identity
+    local.identity_account_roles["admin_role_arn"],
+    local.identity_account_roles["developer_role_arn"],
+    local.identity_account_roles["read_only_role_arn"],
+    local.identity_account_roles["ci_role_arn"],
+
+    # Experience
+    local.experience_account_roles["developer_role_arn"],
+    local.experience_account_roles["read_only_role_arn"],
+    local.experience_account_roles["ci_role_arn"],
+
+    # Workflow
+    local.workflow_account_roles["read_only_role_arn"],
+
+    # Storage
+    local.storage_account_roles["read_only_role_arn"],
+
+    # Route 53
+    local.route53_wellcomecolection_update
   ]
 }

--- a/accounts/platform/rolesets.tf
+++ b/accounts/platform/rolesets.tf
@@ -1,5 +1,5 @@
 locals {
-  route53_wellcomecolection_update = "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update",
+  route53_wellcomecolection_update = "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update"
 }
 
 module "super_dev_roleset" {


### PR DESCRIPTION
## What's changing and why?

The work Digirati are doing on `identity` requires that they are able to update `account.wellcomecollection.org`. 

Previously this has been delegated by a `account.wellcomecollection.org` hosted zone to the `identity` AWS account - however there is a requirement from Auth0 to add a CNAME for the apex domain to an Auth0 domain. 

It is not possible to add a CNAME if the hosted zone apex is `account.wellcomecollection.org` - the remedy is to remove the hosted zone delegation.

**Note:** This is applied

## `terraform plan` diff
```
# module.digirati_admin_roleset.module.role.aws_iam_role.role will be created
  + resource "aws_iam_role" "role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRoleWithSAML"
                      + Condition = {
                          + StringEquals = {
                              + SAML:aud = [
                                  + "https://signin.aws.amazon.com/saml",
                                ]
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + Federated = "arn:aws:iam::760097843905:saml-provider/azure_sso-saml_provider"
                        }
                      + Sid       = ""
                    },
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::760097843905:root"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"                                                                                                                                                                                                                                                                                                                                                                                                                                                                }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)                                                                                                                                                                                                                                                                                                                                                                                                                                               + max_session_duration  = 3600
      + name                  = "digirati-admin"
      + path                  = "/"
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # module.digirati_admin_roleset.module.role_policy.aws_iam_role_policy.role_assumer will be created
  + resource "aws_iam_role_policy" "role_assumer" {
      + id     = (known after apply)
      + name   = (known after apply)
      + policy = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = "sts:AssumeRole"
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:iam::975596993436:role/storage-read_only",
                          + "arn:aws:iam::770700576653:role/identity-read_only",
                          + "arn:aws:iam::770700576653:role/identity-developer",
                          + "arn:aws:iam::770700576653:role/identity-ci",
                          + "arn:aws:iam::770700576653:role/identity-admin",
                          + "arn:aws:iam::760097843905:role/platform-read_only",
                          + "arn:aws:iam::653428163053:role/digirati-read_only",
                          + "arn:aws:iam::653428163053:role/digirati-developer",
                          + "arn:aws:iam::653428163053:role/digirati-ci",
                          + "arn:aws:iam::653428163053:role/digirati-admin",
                          + "arn:aws:iam::299497370133:role/workflow-read_only",
                          + "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update",
                          + "arn:aws:iam::130871440101:role/experience-read_only",
                          + "arn:aws:iam::130871440101:role/experience-developer",
                          + "arn:aws:iam::130871440101:role/experience-ci",
                        ]
                      + Sid      = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + role   = "digirati-admin"
    }
```
