### PR TITLE
Removed the 'account.wellcomecollection.org' DNS delegation

### DIFF
--- a/cloudfront/account.wellcomecollection.org/terraform/main.tf
+++ b/cloudfront/account.wellcomecollection.org/terraform/main.tf
@@ -6,7 +6,7 @@ data "aws_route53_zone" "weco_zone" {
   provider = aws.dns
 }
 
-resource "aws_route53_zone" "account" {
+/*resource "aws_route53_zone" "account" {
   name = "account.${data.aws_route53_zone.weco_zone.name}"
 }
 
@@ -18,7 +18,7 @@ resource "aws_route53_record" "account-ns" {
   records = local.account_zone_name_servers
 
   provider = aws.dns
-}
+}*/
 
 resource "aws_route53_record" "identity-ses-txt" {
   zone_id = data.aws_route53_zone.weco_zone.id


### PR DESCRIPTION
## What's changing and why?

This PR removes the `NS` record for `account.wellcomecollection.org` from the `wellcomecollection.org` root zone. The delegation of this hostname is being removed and records relating to `account.wellcomecollection.org` will instead be created directly against the root `wellcomecollection.org` zone.

This is work around an issue with Auth0 preventing us from creating the required `CNAME` record at the apex of the `account.wellcomecollection.org` zone.

## `terraform plan` diff
```
  # aws_route53_record.account-ns will be destroyed
  - resource "aws_route53_record" "account-ns" {
      - fqdn    = "account.wellcomecollection.org" -> null
      - id      = "Z0902614YH73JBCZG1MA_account.wellcomecollection.org_NS" -> null
      - name    = "account.wellcomecollection.org" -> null
      - records = [
          - "ns-1100.awsdns-09.org",
          - "ns-1657.awsdns-15.co.uk",
          - "ns-34.awsdns-04.com",
          - "ns-570.awsdns-07.net",
        ] -> null
      - ttl     = 300 -> null
      - type    = "NS" -> null
      - zone_id = "Z0902614YH73JBCZG1MA" -> null
    }

  # aws_route53_zone.account will be destroyed
  - resource "aws_route53_zone" "account" {
      - comment      = "Managed by Terraform" -> null
      - id           = "Z01071952WZ7292VJBRAM" -> null
      - name         = "account.wellcomecollection.org" -> null
      - name_servers = [
          - "ns-1301.awsdns-34.org",
          - "ns-1689.awsdns-19.co.uk",
          - "ns-507.awsdns-63.com",
          - "ns-944.awsdns-54.net",
        ] -> null
      - tags         = {} -> null
      - zone_id      = "Z01071952WZ7292VJBRAM" -> null
    }
```
