### PR TITLE
Updated 'identity-ci' permissions following PROD deployment

### DIFF
--- a/accounts/identity/iam_identity_ci.tf
+++ b/accounts/identity/iam_identity_ci.tf
@@ -76,6 +76,8 @@ data "aws_iam_policy_document" "identity_ci" {
     resources = [
       "arn:aws:s3:::identity-public-swagger-ui-v1-stage",
       "arn:aws:s3:::identity-public-swagger-ui-v1-stage/*",
+      "arn:aws:s3:::identity-public-swagger-ui-v1-prod",
+      "arn:aws:s3:::identity-public-swagger-ui-v1-prod/*",
     ]
   }
 
@@ -96,27 +98,6 @@ data "aws_iam_policy_document" "identity_ci" {
     ]
     resources = [
       "*",
-    ]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "ecs:UpdateService"
-    ]
-    resources = [
-      "arn:aws:ecs:eu-west-1:${local.account_ids.identity}:service/*",
-    ]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "iam:PassRole"
-    ]
-    resources = [
-      "arn:aws:iam::${local.account_ids.identity}:role/identity-ecs-task-role-stage",
-      "arn:aws:iam::${local.account_ids.identity}:role/identity-ecs-execution-role-stage"
     ]
   }
 


### PR DESCRIPTION
## What's changing and why?

In order to publish SwaggerUI, the `identity-ci` IAM role needs permission to write to the newly created `identity-public-swagger-ui-v1-prod` bucket.

This PR also removes some redundant ECS permissions from the same IAM role.

## `terraform plan` diff

```
Terraform will perform the following actions:

  # aws_iam_role_policy.identity_ci will be updated in-place
  ~ resource "aws_iam_role_policy" "identity_ci" {
        id     = "identity-ci:terraform-20201119102354636800000001"
        name   = "terraform-20201119102354636800000001"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                    # (3 unchanged elements hidden)
                    {
                        Action   = [
                            "s3:List*",
                            "s3:Get*",
                        ]
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:s3:::identity-static-remote-state/*",
                            "arn:aws:s3:::identity-static-remote-state",
                            "arn:aws:s3:::identity-remote-state/*",
                            "arn:aws:s3:::identity-remote-state",
                        ]
                        Sid      = ""
                    },
                  ~ {
                      ~ Resource = [
                            # (1 unchanged element hidden)
                            "arn:aws:s3:::identity-public-swagger-ui-v1-stage",
                          + "arn:aws:s3:::identity-public-swagger-ui-v1-prod/*",
                          + "arn:aws:s3:::identity-public-swagger-ui-v1-prod",
                        ]
                        # (3 unchanged elements hidden)
                    },
                    {
                        Action   = "cloudfront:CreateInvalidation"
                        Effect   = "Allow"
                        Resource = "arn:aws:cloudfront::770700576653:distribution/*"
                        Sid      = ""
                    },
                    {
                        Action   = "ecs:RegisterTaskDefinition"
                        Effect   = "Allow"
                        Resource = "*"
                        Sid      = ""
                    },
                  - {
                      - Action   = "ecs:UpdateService"
                      - Effect   = "Allow"
                      - Resource = "arn:aws:ecs:eu-west-1:770700576653:service/*"
                      - Sid      = ""
                    },
                  - {
                      - Action   = "iam:PassRole"
                      - Effect   = "Allow"
                      - Resource = [
                          - "arn:aws:iam::770700576653:role/identity-ecs-task-role-stage",
                          - "arn:aws:iam::770700576653:role/identity-ecs-execution-role-stage",
                        ]
                      - Sid      = ""
                    },
                    {
                        Action   = "sts:AssumeRole"
                        Effect   = "Allow"
                        Resource = "arn:aws:iam::770700576653:role/identity-ci"
                        Sid      = ""
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
