### PR TITLE
add platform admin priveledges to data-dev

### DIFF
--- a/accounts/platform/rolesets.tf
+++ b/accounts/platform/rolesets.tf
@@ -242,6 +242,9 @@ module "data_dev_roleset" {
 
   assumable_role_arns = [
     # Platform
+    # Currently the admin role is needed as we have a lot of
+    # infra in the platform account that should be in the catalogue account
+    module.aws_account.admin_role_arn,
     module.aws_account.developer_role_arn,
     module.aws_account.read_only_role_arn,
     module.aws_account.ci_role_arn,


### PR DESCRIPTION
## What's changing and why?
@harrisonpim needs to be able to provision ecr image within the platform account.

I do wonder if maybe we have a less-than-admin account that allows for s3/ecr editing, but maybe that's too far. We should get on moving catalogue stuff across to the catalogue account. This is a bandaid to get the image inferrer work out.

## `terraform plan` diff
```diff
~ resource "aws_iam_role_policy" "role_assumer" {
        id     = "data-dev:terraform-20190729114137699600000001"
        name   = "terraform-20190729114137699600000001"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = [
                            # (7 unchanged elements hidden)
                            "arn:aws:iam::760097843905:role/platform-ci",
                          + "arn:aws:iam::760097843905:role/platform-admin",
                            "arn:aws:iam::756629837203:role/catalogue-read_only",
                            # (5 unchanged elements hidden)
                        ]
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }
```
