### PR TITLE
Add VPC for MoH migration

### DIFF
--- a/accounts/digirati/outputs.tf
+++ b/accounts/digirati/outputs.tf
@@ -41,3 +41,19 @@ output "digirati_vpc_public_subnets" {
 output "digirati_vpc_id" {
   value = module.digirati_vpc.vpc_id
 }
+
+output "moh_vpc_private_subnets" {
+  value = module.moh_vpc.private_subnets
+}
+
+output "moh_cidr_block_private" {
+  value = module.moh_vpc.cidr_block_private
+}
+
+output "moh_vpc_public_subnets" {
+  value = module.moh_vpc.public_subnets
+}
+
+output "moh_vpc_id" {
+  value = module.moh_vpc.vpc_id
+}

--- a/accounts/digirati/vpcs.tf
+++ b/accounts/digirati/vpcs.tf
@@ -7,3 +7,13 @@ module "digirati_vpc" {
   vpc_name   = "iiif-services"
   cidr_block = "172.56.0.0/16"
 }
+
+# Used by:
+# - London's Pulse: Medical Officer of Health reports
+
+module "moh_vpc" {
+  source = "../modules/vpc"
+
+  vpc_name   = "moh"
+  cidr_block = "172.57.0.0/16"
+}


### PR DESCRIPTION
## What's changing and why?

Adding new VPC to Digirati AWS account to contain infra for [MoH](https://github.com/wellcomecollection/londons-pulse) migration work.

## `terraform plan` diff

```hcl
  # module.moh_vpc.module.vpc.aws_vpc.vpc will be created
  + resource "aws_vpc" "vpc" {
      + arn                              = (known after apply)
      + assign_generated_ipv6_cidr_block = false
      + cidr_block                       = "172.57.0.0/16"
      + default_network_acl_id           = (known after apply)
      + default_route_table_id           = (known after apply)
      + default_security_group_id        = (known after apply)
      + dhcp_options_id                  = (known after apply)
      + enable_classiclink               = (known after apply)
      + enable_classiclink_dns_support   = (known after apply)
      + enable_dns_hostnames             = true
      + enable_dns_support               = true
      + id                               = (known after apply)
      + instance_tenancy                 = "default"
      + ipv6_association_id              = (known after apply)
      + ipv6_cidr_block                  = (known after apply)
      + main_route_table_id              = (known after apply)
      + owner_id                         = (known after apply)
      + tags                             = {
          + "Name" = "moh"
        }
      + tags_all                         = {
          + "Name" = "moh"
        }
    }

  # module.moh_vpc.module.vpc.module.dynamodb_endpoint.data.aws_vpc.selected will be read during apply
  # (config refers to values not yet known)
 <= data "aws_vpc" "selected"  {
      + arn                     = (known after apply)
      + cidr_block              = (known after apply)
      + cidr_block_associations = (known after apply)
      + default                 = (known after apply)
      + dhcp_options_id         = (known after apply)
      + enable_dns_hostnames    = (known after apply)
      + enable_dns_support      = (known after apply)
      + id                      = (known after apply)
      + instance_tenancy        = (known after apply)
      + ipv6_association_id     = (known after apply)
      + ipv6_cidr_block         = (known after apply)
      + main_route_table_id     = (known after apply)
      + owner_id                = (known after apply)
      + state                   = (known after apply)
      + tags                    = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.dynamodb_endpoint.aws_vpc_endpoint.endpoint will be created
  + resource "aws_vpc_endpoint" "endpoint" {
      + arn                   = (known after apply)
      + cidr_blocks           = (known after apply)
      + dns_entry             = (known after apply)
      + id                    = (known after apply)
      + network_interface_ids = (known after apply)
      + owner_id              = (known after apply)
      + policy                = (known after apply)
      + prefix_list_id        = (known after apply)
      + private_dns_enabled   = false
      + requester_managed     = (known after apply)
      + route_table_ids       = (known after apply)
      + security_group_ids    = (known after apply)
      + service_name          = "com.amazonaws.eu-west-1.dynamodb"
      + state                 = (known after apply)
      + subnet_ids            = (known after apply)
      + tags                  = (known after apply)
      + vpc_endpoint_type     = "Gateway"
      + vpc_id                = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.nat.aws_eip.nat will be created
  + resource "aws_eip" "nat" {
      + allocation_id        = (known after apply)
      + association_id       = (known after apply)
      + carrier_ip           = (known after apply)
      + customer_owned_ip    = (known after apply)
      + domain               = (known after apply)
      + id                   = (known after apply)
      + instance             = (known after apply)
      + network_border_group = (known after apply)
      + network_interface    = (known after apply)
      + private_dns          = (known after apply)
      + private_ip           = (known after apply)
      + public_dns           = (known after apply)
      + public_ip            = (known after apply)
      + public_ipv4_pool     = (known after apply)
      + tags                 = {
          + "Name" = "moh"
        }
      + vpc                  = true
    }

  # module.moh_vpc.module.vpc.module.nat.aws_nat_gateway.nat will be created
  + resource "aws_nat_gateway" "nat" {
      + allocation_id        = (known after apply)
      + id                   = (known after apply)
      + network_interface_id = (known after apply)
      + private_ip           = (known after apply)
      + public_ip            = (known after apply)
      + subnet_id            = (known after apply)
      + tags                 = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.nat.aws_route.private_route will be created
  + resource "aws_route" "private_route" {
      + destination_cidr_block     = "0.0.0.0/0"
      + destination_prefix_list_id = (known after apply)
      + id                         = (known after apply)
      + instance_id                = (known after apply)
      + instance_owner_id          = (known after apply)
      + nat_gateway_id             = (known after apply)
      + network_interface_id       = (known after apply)
      + origin                     = (known after apply)
      + route_table_id             = (known after apply)
      + state                      = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.private_subnets.aws_route_table.table will be created
  + resource "aws_route_table" "table" {
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + route            = (known after apply)
      + tags             = {
          + "Name" = "moh-private"
        }
      + vpc_id           = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.private_subnets.aws_route_table_association.network[0] will be created
  + resource "aws_route_table_association" "network" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.private_subnets.aws_route_table_association.network[1] will be created
  + resource "aws_route_table_association" "network" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.private_subnets.aws_route_table_association.network[2] will be created
  + resource "aws_route_table_association" "network" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.private_subnets.aws_subnet.subnet[0] will be created
  + resource "aws_subnet" "subnet" {
      + arn                             = (known after apply)
      + assign_ipv6_address_on_creation = false
      + availability_zone               = "eu-west-1a"
      + availability_zone_id            = (known after apply)
      + cidr_block                      = "172.57.128.0/19"
      + id                              = (known after apply)
      + ipv6_cidr_block_association_id  = (known after apply)
      + map_public_ip_on_launch         = false
      + owner_id                        = (known after apply)
      + tags                            = {
          + "Availability" = "private"
          + "Name"         = "moh-private-eu-west-1a-0"
        }
      + tags_all                        = {
          + "Availability" = "private"
          + "Name"         = "moh-private-eu-west-1a-0"
        }
      + vpc_id                          = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.private_subnets.aws_subnet.subnet[1] will be created
  + resource "aws_subnet" "subnet" {
      + arn                             = (known after apply)
      + assign_ipv6_address_on_creation = false
      + availability_zone               = "eu-west-1b"
      + availability_zone_id            = (known after apply)
      + cidr_block                      = "172.57.160.0/19"
      + id                              = (known after apply)
      + ipv6_cidr_block_association_id  = (known after apply)
      + map_public_ip_on_launch         = false
      + owner_id                        = (known after apply)
      + tags                            = {
          + "Availability" = "private"
          + "Name"         = "moh-private-eu-west-1b-1"
        }
      + tags_all                        = {
          + "Availability" = "private"
          + "Name"         = "moh-private-eu-west-1b-1"
        }
      + vpc_id                          = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.private_subnets.aws_subnet.subnet[2] will be created
  + resource "aws_subnet" "subnet" {
      + arn                             = (known after apply)
      + assign_ipv6_address_on_creation = false
      + availability_zone               = "eu-west-1c"
      + availability_zone_id            = (known after apply)
      + cidr_block                      = "172.57.192.0/19"
      + id                              = (known after apply)
      + ipv6_cidr_block_association_id  = (known after apply)
      + map_public_ip_on_launch         = false
      + owner_id                        = (known after apply)
      + tags                            = {
          + "Availability" = "private"
          + "Name"         = "moh-private-eu-west-1c-2"
        }
      + tags_all                        = {
          + "Availability" = "private"
          + "Name"         = "moh-private-eu-west-1c-2"
        }
      + vpc_id                          = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.public_subnets.aws_internet_gateway.gw will be created
  + resource "aws_internet_gateway" "gw" {
      + arn      = (known after apply)
      + id       = (known after apply)
      + owner_id = (known after apply)
      + tags     = {
          + "Name" = "moh-public"
        }
      + vpc_id   = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.public_subnets.aws_route.route will be created
  + resource "aws_route" "route" {
      + destination_cidr_block     = "0.0.0.0/0"
      + destination_prefix_list_id = (known after apply)
      + gateway_id                 = (known after apply)
      + id                         = (known after apply)
      + instance_id                = (known after apply)
      + instance_owner_id          = (known after apply)
      + network_interface_id       = (known after apply)
      + origin                     = (known after apply)
      + route_table_id             = (known after apply)
      + state                      = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.s3_endpoint.data.aws_vpc.selected will be read during apply
  # (config refers to values not yet known)
 <= data "aws_vpc" "selected"  {
      + arn                     = (known after apply)
      + cidr_block              = (known after apply)
      + cidr_block_associations = (known after apply)
      + default                 = (known after apply)
      + dhcp_options_id         = (known after apply)
      + enable_dns_hostnames    = (known after apply)
      + enable_dns_support      = (known after apply)
      + id                      = (known after apply)
      + instance_tenancy        = (known after apply)
      + ipv6_association_id     = (known after apply)
      + ipv6_cidr_block         = (known after apply)
      + main_route_table_id     = (known after apply)
      + owner_id                = (known after apply)
      + state                   = (known after apply)
      + tags                    = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.s3_endpoint.aws_vpc_endpoint.endpoint will be created
  + resource "aws_vpc_endpoint" "endpoint" {
      + arn                   = (known after apply)
      + cidr_blocks           = (known after apply)
      + dns_entry             = (known after apply)
      + id                    = (known after apply)
      + network_interface_ids = (known after apply)
      + owner_id              = (known after apply)
      + policy                = (known after apply)
      + prefix_list_id        = (known after apply)
      + private_dns_enabled   = false
      + requester_managed     = (known after apply)
      + route_table_ids       = (known after apply)
      + security_group_ids    = (known after apply)
      + service_name          = "com.amazonaws.eu-west-1.s3"
      + state                 = (known after apply)
      + subnet_ids            = (known after apply)
      + tags                  = (known after apply)
      + vpc_endpoint_type     = "Gateway"
      + vpc_id                = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.public_subnets.module.subnets.aws_route_table.table will be created
  + resource "aws_route_table" "table" {
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + route            = (known after apply)
      + tags             = {
          + "Name" = "moh-public"
        }
      + vpc_id           = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.public_subnets.module.subnets.aws_route_table_association.network[0] will be created
  + resource "aws_route_table_association" "network" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.public_subnets.module.subnets.aws_route_table_association.network[1] will be created
  + resource "aws_route_table_association" "network" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.public_subnets.module.subnets.aws_route_table_association.network[2] will be created
  + resource "aws_route_table_association" "network" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.public_subnets.module.subnets.aws_subnet.subnet[0] will be created
  + resource "aws_subnet" "subnet" {
      + arn                             = (known after apply)
      + assign_ipv6_address_on_creation = false
      + availability_zone               = "eu-west-1a"
      + availability_zone_id            = (known after apply)
      + cidr_block                      = "172.57.0.0/19"
      + id                              = (known after apply)
      + ipv6_cidr_block_association_id  = (known after apply)
      + map_public_ip_on_launch         = true
      + owner_id                        = (known after apply)
      + tags                            = {
          + "Availability" = "public"
          + "Name"         = "moh-public-eu-west-1a-0"
        }
      + tags_all                        = {
          + "Availability" = "public"
          + "Name"         = "moh-public-eu-west-1a-0"
        }
      + vpc_id                          = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.public_subnets.module.subnets.aws_subnet.subnet[1] will be created
  + resource "aws_subnet" "subnet" {
      + arn                             = (known after apply)
      + assign_ipv6_address_on_creation = false
      + availability_zone               = "eu-west-1b"
      + availability_zone_id            = (known after apply)
      + cidr_block                      = "172.57.32.0/19"
      + id                              = (known after apply)
      + ipv6_cidr_block_association_id  = (known after apply)
      + map_public_ip_on_launch         = true
      + owner_id                        = (known after apply)
      + tags                            = {
          + "Availability" = "public"
          + "Name"         = "moh-public-eu-west-1b-1"
        }
      + tags_all                        = {
          + "Availability" = "public"
          + "Name"         = "moh-public-eu-west-1b-1"
        }
      + vpc_id                          = (known after apply)
    }

  # module.moh_vpc.module.vpc.module.public_subnets.module.subnets.aws_subnet.subnet[2] will be created
  + resource "aws_subnet" "subnet" {
      + arn                             = (known after apply)
      + assign_ipv6_address_on_creation = false
      + availability_zone               = "eu-west-1c"
      + availability_zone_id            = (known after apply)
      + cidr_block                      = "172.57.64.0/19"
      + id                              = (known after apply)
      + ipv6_cidr_block_association_id  = (known after apply)
      + map_public_ip_on_launch         = true
      + owner_id                        = (known after apply)
      + tags                            = {
          + "Availability" = "public"
          + "Name"         = "moh-public-eu-west-1c-2"
        }
      + tags_all                        = {
          + "Availability" = "public"
          + "Name"         = "moh-public-eu-west-1c-2"
        }
      + vpc_id                          = (known after apply)
    }

Plan: 22 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + moh_cidr_block_private  = "172.57.128.0/17"
  + moh_vpc_id              = (known after apply)
  + moh_vpc_private_subnets = [
      + (known after apply),
      + (known after apply),
      + (known after apply),
    ]
  + moh_vpc_public_subnets  = [
      + (known after apply),
      + (known after apply),
      + (known after apply),
    ]

```
<!-- Please make sure you don't paste anything secure that shouldn't be shared here -->
