### PR TITLE
Allow experience-ci to read api keys for items api

### DIFF
--- a/accounts/experience/iam_experience_ci.tf
+++ b/accounts/experience/iam_experience_ci.tf
@@ -34,4 +34,14 @@ data "aws_iam_policy_document" "experience_ci" {
       "arn:aws:secretsmanager:${local.aws_region}:${local.account_ids["experience"]}:secret:builds/*",
     ]
   }
+
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+
+    resources = [
+      "arn:aws:secretsmanager:${local.aws_region}:${local.account_ids["experience"]}:secret:catalogue_api/items/*",
+    ]
+  }
 }


### PR DESCRIPTION
## What's changing and why?

Allows experience-ci to read the items-api api keys so it can run tests.

**Note:** This is applied.