### PR TITLE
prodify the MOH

### DIFF
--- a/cloudfront/wellcomelibrary.org/terraform/cf_behaviours.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/cf_behaviours.tf
@@ -118,7 +118,9 @@ locals {
     }
   ]
 
-  prod_behaviours = []
+  prod_behaviours = concat(
+    local.moh_behaviours,
+  )
 
   stage_behaviours = concat(
     local.moh_behaviours,

--- a/cloudfront/wellcomelibrary.org/terraform/cf_behaviours.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/cf_behaviours.tf
@@ -104,7 +104,7 @@ locals {
   moh_paths = ["moh/*", "spas/*", "assets/*", "plugins/*", "scripts/*", "timelines/*"]
 
   moh_behaviours = [
-    for path in local.moh_paths:
+    for path in local.moh_paths :
     {
       path_pattern     = path
       target_origin_id = local.wellcome_library_moh_origin.origin_id

--- a/cloudfront/wellcomelibrary.org/terraform/cf_origins.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/cf_origins.tf
@@ -14,7 +14,8 @@ locals {
   }
 
   prod_origins = [
-    local.wellcome_library_origin
+    local.wellcome_library_origin,
+    local.wellcome_library_moh_origin
   ]
 
   stage_origins = [


### PR DESCRIPTION
## What's changing and why?
Makes changes to the MoH on prod.

We couldn't find any meaningful tests, as these aren't redirects, but rather pushing through to another service, that serves up almost identical content.

## `terraform plan` diff
```
# module.wellcomelibrary-prod.aws_cloudfront_distribution.distro will be updated in-place
  ~ resource "aws_cloudfront_distribution" "distro" {
        id                             = "EHUBCZTWBQL8L"
        tags                           = {
            "Managed" = "terraform"
        }
        # (17 unchanged attributes hidden)


      + ordered_cache_behavior {
          + allowed_methods        = [
              + "DELETE",
              + "GET",
              + "HEAD",
              + "OPTIONS",
              + "PATCH",
              + "POST",
              + "PUT",
            ]
          + cached_methods         = [
              + "GET",
              + "HEAD",
              + "OPTIONS",
            ]
          + compress               = false
          + min_ttl                = 0
          + path_pattern           = "moh/*"
          + target_origin_id       = "moh_origin"
          + viewer_protocol_policy = "allow-all"

          + forwarded_values {
              + headers                 = [
                  + "CloudFront-Forwarded-Proto",
                  + "Host",
                ]
              + query_string            = true
              + query_string_cache_keys = (known after apply)

              + cookies {
                  + forward = "all"
                }
            }
        }
      + ordered_cache_behavior {
          + allowed_methods        = [
              + "DELETE",
              + "GET",
              + "HEAD",
              + "OPTIONS",
              + "PATCH",
              + "POST",
              + "PUT",
            ]
          + cached_methods         = [
              + "GET",
              + "HEAD",
              + "OPTIONS",
            ]
          + compress               = false
          + min_ttl                = 0
          + path_pattern           = "spas/*"
          + target_origin_id       = "moh_origin"
          + viewer_protocol_policy = "allow-all"

          + forwarded_values {
              + headers                 = [
                  + "CloudFront-Forwarded-Proto",
                  + "Host",
                ]
              + query_string            = true
              + query_string_cache_keys = (known after apply)

              + cookies {
                  + forward = "all"
                }
            }
        }
      + ordered_cache_behavior {
          + allowed_methods        = [
              + "DELETE",
              + "GET",
              + "HEAD",
              + "OPTIONS",
              + "PATCH",
              + "POST",
              + "PUT",
            ]
          + cached_methods         = [
              + "GET",
              + "HEAD",
              + "OPTIONS",
            ]
          + compress               = false
          + min_ttl                = 0
          + path_pattern           = "assets/*"
          + target_origin_id       = "moh_origin"
          + viewer_protocol_policy = "allow-all"

          + forwarded_values {
              + headers                 = [
                  + "CloudFront-Forwarded-Proto",
                  + "Host",
                ]
              + query_string            = true
              + query_string_cache_keys = (known after apply)

              + cookies {
                  + forward = "all"
                }
            }
        }
      + ordered_cache_behavior {
          + allowed_methods        = [
              + "DELETE",
              + "GET",
              + "HEAD",
              + "OPTIONS",
              + "PATCH",
              + "POST",
              + "PUT",
            ]
          + cached_methods         = [
              + "GET",
              + "HEAD",
              + "OPTIONS",
            ]
          + compress               = false
          + min_ttl                = 0
          + path_pattern           = "plugins/*"
          + target_origin_id       = "moh_origin"
          + viewer_protocol_policy = "allow-all"

          + forwarded_values {
              + headers                 = [
                  + "CloudFront-Forwarded-Proto",
                  + "Host",
                ]
              + query_string            = true
              + query_string_cache_keys = (known after apply)

              + cookies {
                  + forward = "all"
                }
            }
        }
      + ordered_cache_behavior {
          + allowed_methods        = [
              + "DELETE",
              + "GET",
              + "HEAD",
              + "OPTIONS",
              + "PATCH",
              + "POST",
              + "PUT",
            ]
          + cached_methods         = [
              + "GET",
              + "HEAD",
              + "OPTIONS",
            ]
          + compress               = false
          + min_ttl                = 0
          + path_pattern           = "scripts/*"
          + target_origin_id       = "moh_origin"
          + viewer_protocol_policy = "allow-all"

          + forwarded_values {
              + headers                 = [
                  + "CloudFront-Forwarded-Proto",
                  + "Host",
                ]
              + query_string            = true
              + query_string_cache_keys = (known after apply)

              + cookies {
                  + forward = "all"
                }
            }
        }
      + ordered_cache_behavior {
          + allowed_methods        = [
              + "DELETE",
              + "GET",
              + "HEAD",
              + "OPTIONS",
              + "PATCH",
              + "POST",
              + "PUT",
            ]
          + cached_methods         = [
              + "GET",
              + "HEAD",
              + "OPTIONS",
            ]
          + compress               = false
          + min_ttl                = 0
          + path_pattern           = "timelines/*"
          + target_origin_id       = "moh_origin"
          + viewer_protocol_policy = "allow-all"

          + forwarded_values {
              + headers                 = [
                  + "CloudFront-Forwarded-Proto",
                  + "Host",
                ]
              + query_string            = true
              + query_string_cache_keys = (known after apply)

              + cookies {
                  + forward = "all"
                }
            }
        }

      + origin {
          + domain_name = "moh.wellcomecollection.digirati.io"
          + origin_id   = "moh_origin"

          + custom_origin_config {
              + http_port                = 80
              + https_port               = 443
              + origin_keepalive_timeout = 5
              + origin_protocol_policy   = "match-viewer"
              + origin_read_timeout      = 30
              + origin_ssl_protocols     = [
                  + "TLSv1",
                  + "TLSv1.1",
                  + "TLSv1.2",
                ]
            }
        }
      - origin {
          - domain_name = "origin.wellcomelibrary.org" -> null
          - origin_id   = "origin" -> null

          - custom_origin_config {
              - http_port                = 80 -> null
              - https_port               = 443 -> null
              - origin_keepalive_timeout = 5 -> null
              - origin_protocol_policy   = "match-viewer" -> null
              - origin_read_timeout      = 30 -> null
              - origin_ssl_protocols     = [
                  - "TLSv1",
                  - "TLSv1.1",
                  - "TLSv1.2",
                ] -> null
            }
        }
      + origin {
          + domain_name = "origin.wellcomelibrary.org"
          + origin_id   = "origin"

          + custom_origin_config {
              + http_port                = 80
              + https_port               = 443
              + origin_keepalive_timeout = 5
              + origin_protocol_policy   = "match-viewer"
              + origin_read_timeout      = 30
              + origin_ssl_protocols     = [
                  + "TLSv1",
                  + "TLSv1.1",
                  + "TLSv1.2",
                ]
            }
        }


        # (3 unchanged blocks hidden)
    }
```
