### PR TITLE
Auto-create profile in terraform runner

### DIFF
--- a/critical/run_terraform.sh
+++ b/critical/run_terraform.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-AWS_CLI_PROFILE=${AWS_PROFILE:-platform-dev}
+AWS_CLI_PROFILE="platform-infrastructure-terraform"
+PLATFORM_DEVELOPER_ARN="arn:aws:iam::760097843905:role/platform-developer"
+
+aws configure set region eu-west-1 --profile $AWS_CLI_PROFILE
+aws configure set role_arn "$PLATFORM_DEVELOPER_ARN" --profile $AWS_CLI_PROFILE
+aws configure set source_profile default --profile $AWS_CLI_PROFILE
 
 EC_API_KEY=$(aws secretsmanager get-secret-value --secret-id elastic_cloud/api_key --profile "$AWS_CLI_PROFILE" --output text --query 'SecretString')
 


### PR DESCRIPTION
## What's changing and why?

This change makes it easier to use `run_terraform.sh` in the `critical` stack. 

Previously the terraform runner depended on a developer having a profile of a particular name, associated with the correct role. This change auto-creates a profile already associated with the correct role and uses that to get the secrets required to run `terraform`.

## `terraform plan` diff

No changes.