### PR TITLE
Identity CI needs to read some secrets

### DIFF
--- a/accounts/identity/iam_identity_ci.tf
+++ b/accounts/identity/iam_identity_ci.tf
@@ -101,6 +101,20 @@ data "aws_iam_policy_document" "identity_ci" {
     ]
   }
 
+  # Secrets required for smoke tests to run
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+
+    resources = [
+      "${local.secrets_base_arn}identity/stage/account_management_system/api_key",
+      "${local.secrets_base_arn}identity/stage/smoke_test/credentials",
+      "${local.secrets_base_arn}identity/prod/account_management_system/api_key",
+      "${local.secrets_base_arn}identity/prod/smoke_test/credentials",
+    ]
+  }
+
   # This slightly unusual clause allows the identity-ci role to assume… itself.
   #
   # This is because Buildkite uses the identity-ci role to run tasks

--- a/accounts/identity/locals.tf
+++ b/accounts/identity/locals.tf
@@ -4,5 +4,9 @@ locals {
     identity = "770700576653"
   }
 
+  aws_region = "eu-west-1"
+
+  secrets_base_arn = "arn:aws:secretsmanager:${local.aws_region}:${local.account_ids["identity"]}:secret:"
+
   account_principals = { for key, value in local.account_ids : key => "arn:aws:iam::${value}:root" }
 }


### PR DESCRIPTION
## What's changing and why?

CI needs to read some secrets in order that it can run smoke tests.

## `terraform plan` diff
```
Terraform will perform the following actions:

  # aws_iam_role_policy.identity_ci will be updated in-place
  ~ resource "aws_iam_role_policy" "identity_ci" {
        id     = "identity-ci:terraform-20201119102354636800000001"
        name   = "terraform-20201119102354636800000001"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                    # (6 unchanged elements hidden)
                    {
                        Action   = "ecs:RegisterTaskDefinition"
                        Effect   = "Allow"
                        Resource = "*"
                        Sid      = ""
                    },
                  + {
                      + Action   = "secretsmanager:GetSecretValue"
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:secretsmanager:eu-west-1:770700576653:secret:identity/stage/smoke_test/credentials",
                          + "arn:aws:secretsmanager:eu-west-1:770700576653:secret:identity/stage/account_management_system/api_key",
                          + "arn:aws:secretsmanager:eu-west-1:770700576653:secret:identity/prod/smoke_test/credentials",
                          + "arn:aws:secretsmanager:eu-west-1:770700576653:secret:identity/prod/account_management_system/api_key",
                        ]
                      + Sid      = ""
                    },
                    {
                        Action   = "sts:AssumeRole"
                        Effect   = "Allow"
                        Resource = "arn:aws:iam::770700576653:role/identity-ci"
                        Sid      = ""
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
