### PR TITLE
Allow lambda publishing from ci

### DIFF
--- a/builds/terraform/.terraform.lock.hcl
+++ b/builds/terraform/.terraform.lock.hcl
@@ -5,6 +5,18 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "2.47.0"
   hashes = [
     "h1:3qUZ+SZqdtlxCd4Luyz+MqHclZvnigwrY8LyKvIvq4U=",
+    "zh:0fafbaf8e62fc50dcb8ddfb57f8efaf2bf3c7aea3089edaf6dff294c644cbce5",
+    "zh:2647648813faefd98fda44af8cd54c8f458eec4bfa9f90d626e12c97851947e1",
+    "zh:34aa643bcb88392ba1528594a7474db0c52b3c00f7dbc1f7014d7e5aa8b02c5d",
+    "zh:61151c1ee60f5a221c085e8395e10052028560dd2e59b13e2ad926a163f8aa87",
+    "zh:623f1079c97f4fe55a506926361b2b86e5f5774218bd25a73131e5f389fcf66a",
+    "zh:6b44b84fbb1d8291bce79224f49fe0b177f971f96e042a638fe64bf99dceca7c",
+    "zh:9d126313acd9c3c66ca0a75fa84b1f8590c287227b2394c64d272c3453ac822a",
+    "zh:a1af70560370fe2facb1f6b1499bd4962f8927ac82c22e64dc86481db68f1afb",
+    "zh:cdba220fe92ad9110642369011ba6f323f1d93e2f3ea98c05720d45474da1210",
+    "zh:effddbc178eae941a3e80e6e3b5714cafeda1113609c7be9c06b481c01298cba",
+    "zh:f8ac343a11d66823b24e44f65eae49481a9def5e9d4bfb0875bf9e8b96c0d9d9",
+    "zh:f911141012df4eb79e401c5863e16569773b454eb2cac30e6a3323bb303bedb2",
   ]
 }
 
@@ -12,5 +24,15 @@ provider "registry.terraform.io/hashicorp/random" {
   version = "3.0.0"
   hashes = [
     "h1:yhHJpb4IfQQfuio7qjUXuUFTU/s+ensuEpm23A+VWz0=",
+    "zh:0fcb00ff8b87dcac1b0ee10831e47e0203a6c46aafd76cb140ba2bab81f02c6b",
+    "zh:123c984c0e04bad910c421028d18aa2ca4af25a153264aef747521f4e7c36a17",
+    "zh:287443bc6fd7fa9a4341dec235589293cbcc6e467a042ae225fd5d161e4e68dc",
+    "zh:2c1be5596dd3cca4859466885eaedf0345c8e7628503872610629e275d71b0d2",
+    "zh:684a2ef6f415287944a3d966c4c8cee82c20e393e096e2f7cdcb4b2528407f6b",
+    "zh:7625ccbc6ff17c2d5360ff2af7f9261c3f213765642dcd84e84ae02a3768fd51",
+    "zh:9a60811ab9e6a5bfa6352fbb943bb530acb6198282a49373283a8fa3aa2b43fc",
+    "zh:c73e0eaeea6c65b1cf5098b101d51a2789b054201ce7986a6d206a9e2dacaefd",
+    "zh:e8f9ed41ac83dbe407de9f0206ef1148204a0d51ba240318af801ffb3ee5f578",
+    "zh:fbdd0684e62563d3ac33425b0ac9439d543a3942465f4b26582bcfabcb149515",
   ]
 }

--- a/builds/terraform/buildkite.tf
+++ b/builds/terraform/buildkite.tf
@@ -138,6 +138,18 @@ data "aws_iam_policy_document" "ci_permissions" {
       ]
     }
   }
+
+  # Publish & retrieve lambdas
+   statement {
+      actions = [
+        "s3:*"
+      ]
+
+      resources = [
+        "${local.infra_bucket_arn}/lambdas/*",
+      ]
+
+  }
 }
 
 locals {

--- a/builds/terraform/buildkite.tf
+++ b/builds/terraform/buildkite.tf
@@ -140,14 +140,14 @@ data "aws_iam_policy_document" "ci_permissions" {
   }
 
   # Publish & retrieve lambdas
-   statement {
-      actions = [
-        "s3:*"
-      ]
+  statement {
+    actions = [
+      "s3:*"
+    ]
 
-      resources = [
-        "${local.infra_bucket_arn}/lambdas/*",
-      ]
+    resources = [
+      "${local.infra_bucket_arn}/lambdas/*",
+    ]
 
   }
 }


### PR DESCRIPTION
## What's changing and why?

This adds permissions to buildkite to publish lambdas.

## `terraform plan` diff
This is already applied to get the main build of catalogue-pipeline to pass