### PR TITLE
Tweak our BuildKite setup

### DIFF
--- a/builds/buildkite_agent_hook.sh
+++ b/builds/buildkite_agent_hook.sh
@@ -17,4 +17,7 @@ docker ps
 echo "I'm going to stop these containers now, so this job has a clean start."
 docker kill $(docker ps -q) || true
 
+echo "How much space am I using?"
+df -h
+
 echo "Goodbye! The agent hook is finished now!"

--- a/builds/terraform/buildkite.tf
+++ b/builds/terraform/buildkite.tf
@@ -12,7 +12,7 @@ resource "aws_cloudformation_stack" "buildkite" {
     ScaleDownPeriod     = 300
     ScaleCooldownPeriod = 60
 
-    SpotPrice = 0.04
+    SpotPrice = 0.05
 
     ScaleUpAdjustment   = 1
     ScaleDownAdjustment = -10

--- a/builds/terraform/buildkite.tf
+++ b/builds/terraform/buildkite.tf
@@ -20,7 +20,7 @@ resource "aws_cloudformation_stack" "buildkite" {
     AgentsPerInstance                         = 1
     BuildkiteTerminateInstanceAfterJobTimeout = 1800
 
-    RootVolumeSize = 250
+    RootVolumeSize = 150
     RootVolumeName = "/dev/xvda"
     RootVolumeType = "gp2"
 


### PR DESCRIPTION
This change is already applied.

Currently nothing is running in CI because the spot price of the r5.large instances we use has just passed $0.04:

> Launching a new EC2 instance. Status Reason: Your Spot request price of 0.04 is lower than the minimum required Spot request fulfillment price of 0.0411. Launching EC2 instance failed.

Since this is only a small part of our bill ($72/mo), we can safely increase the spot bid without breaking the bank.

We also spent $126 last month on gp2 EBS volumes, most of which will be our BuildKite runners. I'm reasonably confident that we don't actually need 250GB per instance, so I've reduced it and added a check that will help us spot if a job failed due to low disk space.