### PR TITLE
Archive redirects

### DIFF
--- a/cloudfront/wellcomelibrary.org/edge-lambda/archiveRedirects.csv
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/archiveRedirects.csv
@@ -1,0 +1,8 @@
+sourceUrl,targetUrl
+archives.wellcomelibrary.org/DServe/dserve.exe?dsqIni=Dserve.ini&dsqApp=Archive&dsqDb=Catalog&dsqCmd=NaviTree.tcl&dsqField=RefNo&dsqItem=PPMEL/C,https://wellcomecollection.org/works/cbms2pg6
+archives.wellcomelibrary.org/DServe/dserve.exe?dsqIni=Dserve.ini&dsqApp=Archive&dsqDb=Catalog&dsqCmd=show.tcl&dsqSearch=(RefNo==%27PPADA%27),https://wellcomecollection.org/works/jwj9b483
+archives.wellcomelibrary.org/DServe/dserve.exe?dsqIni=Dserve.ini&dsqApp=Archive&dsqCmd=Show.tcl&dsqDb=Catalog&dsqPos=0&dsqSearch=(AltRefNo=%27sa/whl%27),https://wellcomecollection.org/works/fjg4s86y
+archives.wellcomelibrary.org/DServe/dserve.exe?dsqIni=Dserve.ini&dsqApp=Archive&dsqCmd=Show.tcl&dsqDb=Catalog&dsqPos=2&dsqSearch=%28%28%28text%29%3D%27wa%2Fhmm%27%29AND%28%28text%29%3D%27durham%27%29%29,https://wellcomecollection.org/works?query=wa/hmm%20durham
+archives.wellcomelibrary.org/DServe/dserve.exe?dsqIni=Dserve.ini&dsqApp=Archive&dsqCmd=Show.tcl&dsqDb=Catalog&dsqPos=0&dsqSearch=((AltRefNo=%27MS%27)AND(AltRefNo=%27542%27)),https://wellcomecollection.org/works?query=MS%20542
+archives.wellcomelibrary.org/DServe/dserve.exe?&dsqIni=Dserve.ini&dsqApp=Archive&dsqDb=Catalog&dsqCmd=Search.tcl,https://wellcomecollection.org/collections
+archives.wellcomelibrary.org,https://wellcomecollection.org/collections

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/bnumberToWork.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/bnumberToWork.ts
@@ -1,43 +1,21 @@
-import { apiQuery, GetWorkResult, Identifier, Work } from './catalogueApi';
+import { findWorkWithIdentifierValue, GetWorkResult } from './catalogueApi';
 import { SierraIdentifier } from './paths';
-
-async function findMatchingWork(
-  identifierType: string,
-  identifierValue: string
-): Promise<Work | undefined> {
-  const resultList = apiQuery(identifierValue);
-
-  for await (const result of resultList) {
-    if (result.identifiers) {
-      const identifiers: Identifier[] = result.identifiers;
-      const hasMatchingId = identifiers.some(
-        (thing) =>
-          thing.identifierType.id === identifierType &&
-          thing.value === identifierValue
-      );
-
-      if (hasMatchingId) {
-        return result;
-      }
-    }
-  }
-}
 
 export async function getWork(
   sierraIdentifier: SierraIdentifier
 ): Promise<GetWorkResult> {
-  const sierraIdWork = await findMatchingWork(
-    'sierra-identifier',
-    sierraIdentifier.sierraIdentifier
+  const sierraIdWork = await findWorkWithIdentifierValue(
+    sierraIdentifier.sierraIdentifier,
+    'sierra-identifier'
   );
   if (sierraIdWork) {
     return sierraIdWork;
   }
 
   if (sierraIdentifier.sierraSystemNumber) {
-    const sierraSysNumWork = await findMatchingWork(
-      'sierra-system-number',
-      sierraIdentifier.sierraSystemNumber
+    const sierraSysNumWork = await findWorkWithIdentifierValue(
+      sierraIdentifier.sierraSystemNumber,
+      'sierra-system-number'
     );
     if (sierraSysNumWork) {
       return sierraSysNumWork;

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.ts
@@ -36,7 +36,7 @@ export async function* apiQuery(
   query: string
 ): AsyncGenerator<Work, void, void> {
   const url = `${apiBasePath}/works`;
-  const queryUrl = `${url}?include=identifiers&identifiers=${query}`;
+  const queryUrl = `${url}?include=identifiers&query=${query}`;
 
   const apiResult = await axios.get(queryUrl);
   const resultList = apiResult.data as CatalogueResultsList;

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.ts
@@ -56,3 +56,25 @@ export async function* apiQuery(
     }
   }
 }
+
+export async function findWorkWithIdentifierValue(
+  identifierValue: string,
+  identifierType?: string
+): Promise<Work | undefined> {
+  const resultList = apiQuery(identifierValue);
+
+  for await (const result of resultList) {
+    if (result.identifiers) {
+      const identifiers: Identifier[] = result.identifiers;
+      const hasMatchingId = identifiers.some(
+        (identifier) =>
+          identifier.value.toLowerCase() === identifierValue.toLowerCase() &&
+          (!identifierType || identifier.identifierType.id === identifierType)
+      );
+
+      if (hasMatchingId) {
+        return result;
+      }
+    }
+  }
+}

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.ts
@@ -68,8 +68,9 @@ export async function findWorkWithIdentifierValue(
       const identifiers: Identifier[] = result.identifiers;
       const hasMatchingId = identifiers.some(
         (identifier) =>
-          identifier.value.toLowerCase() === identifierValue.toLowerCase() &&
-          (!identifierType || identifier.identifierType.id === identifierType)
+          (!identifierType ||
+            identifier.identifierType.id === identifierType) &&
+          identifier.value.toLowerCase() === identifierValue.toLowerCase()
       );
 
       if (hasMatchingId) {

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.ts
@@ -36,7 +36,7 @@ export async function* apiQuery(
   query: string
 ): AsyncGenerator<Work, void, void> {
   const url = `${apiBasePath}/works`;
-  const queryUrl = `${url}?include=identifiers&query=${query}`;
+  const queryUrl = `${url}?include=identifiers&identifiers=${query}`;
 
   const apiResult = await axios.get(queryUrl);
   const resultList = apiResult.data as CatalogueResultsList;

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApiFixtures.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApiFixtures.ts
@@ -147,3 +147,45 @@ export const testDataNoResults = {
   totalResults: 0,
   results: [],
 };
+
+export function results(results: any[]) {
+  return {
+    '@context': 'https://api.wellcomecollection.org/catalogue/v2/context.json',
+    type: 'ResultList',
+    pageSize: 10,
+    totalPages: 1,
+    totalResults: results.length,
+    results,
+  };
+}
+
+export function resultWithIdentifier(
+  id: string,
+  idType: string,
+  idValue: string
+) {
+  return {
+    id,
+    title: 'Basic care of cats and kittens / The Cats Protection League.',
+    alternativeTitles: [],
+    description:
+      '<p>Leaflet outlining basic training and health tips for people with a new kitten.</p>',
+    physicalDescription: '1 folded sheet (4 p.) : ill. ; 21 cm.',
+    workType: {},
+    identifiers: [
+      {
+        identifierType: {
+          id: idType,
+          label: 'Identifier label',
+          type: 'IdentifierType',
+        },
+        value: idValue,
+        type: 'Identifier',
+      },
+    ],
+    thumbnail: {},
+    availableOnline: true,
+    availabilities: {},
+    type: 'Work',
+  };
+}

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryArchiveRedirect.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryArchiveRedirect.test.ts
@@ -72,6 +72,15 @@ const archiveTests = [
     ]),
     resolvedUri: 'https://wellcomecollection.org/works?query=MS%20542',
   },
+  {
+    label: 'No text to decipher',
+    qs: '',
+    results: results([
+      resultWithIdentifier('k2fae5cz', 'calm-ref-no', 'MS.542'),
+      resultWithIdentifier('dr6uy6dg', 'calm-ref-no', 'MS.345'),
+    ]),
+    resolvedUri: 'https://wellcomecollection.org/collections',
+  },
 ] as Test[];
 
 test.each(archiveTests)('$label', (test: Test) => {

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryArchiveRedirect.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryArchiveRedirect.test.ts
@@ -4,7 +4,7 @@ import { Context } from 'aws-lambda';
 import { results, resultWithIdentifier } from './catalogueApiFixtures';
 import { expectedRedirect } from './testHelpers';
 import axios from 'axios';
-import { afterEach, expect, jest, test } from '@jest/globals';
+import { expect, jest, test } from '@jest/globals';
 import { CatalogueResultsList } from './catalogueApi';
 
 jest.mock('axios');
@@ -18,70 +18,81 @@ const archivedHeaders = {
 };
 
 type Test = {
-  label: string;
   qs: string;
   results: CatalogueResultsList;
   resolvedUri: string;
 };
 const archiveTests = [
-  {
-    label: 'known RefNo in dsqItem',
-    qs: 'dsqField=RefNo&dsqItem=PPMEL/C',
-    results: results([
-      resultWithIdentifier('cbms2pg6', 'calm-ref-no', 'PPMEL/C'),
-      resultWithIdentifier('refd2pg6', 'calm-ref-no', 'REFNOT'),
-    ]),
-    resolvedUri: 'https://wellcomecollection.org/works/cbms2pg6',
-  },
-  {
-    label: 'known RefNo in dsqSearch',
-    qs: 'dsqSearch=(RefNo==%27PPADA%27)',
-    results: results([
-      resultWithIdentifier('jwj9b483', 'calm-ref-no', 'PPADA'),
-      resultWithIdentifier('refd2pg6', 'calm-ref-no', 'REFNOT'),
-    ]),
-    resolvedUri: 'https://wellcomecollection.org/works/jwj9b483',
-  },
-  {
-    label: 'known AltRefNo in dsqSeaarch',
-    qs: 'dsqSearch=(AltRefNo=%27sa/whl%27)',
-    results: results([
-      resultWithIdentifier('fjg4s86y', 'calm-alt-ref-no', 'SA/WHL'),
-      resultWithIdentifier('mtgtt57a', 'calm-alt-ref-no', 'SA/WHL/14'),
-    ]),
-    resolvedUri: 'https://wellcomecollection.org/works/fjg4s86y',
-  },
-  {
-    label: 'Unknown text in dsqSearch',
-    qs:
-      'dsqSearch=%28%28%28text%29%3D%27wa%2Fhmm%27%29AND%28%28text%29%3D%27durham%27%29%29',
-    results: results([
-      resultWithIdentifier('k2fae5cz', 'calm-ref-no', 'WA/HMM'),
-      resultWithIdentifier('dr6uy6dg', 'calm-ref-no', 'WA/HSW'),
-    ]),
-    resolvedUri: 'https://wellcomecollection.org/works?query=wa/hmm%20durham',
-  },
-  {
-    label: 'Unknown AltRefNo in dsqSearch',
-    qs: 'dsqSearch=((AltRefNo=%27MS%27)AND(AltRefNo=%27542%27))',
-    results: results([
-      resultWithIdentifier('k2fae5cz', 'calm-ref-no', 'MS.542'),
-      resultWithIdentifier('dr6uy6dg', 'calm-ref-no', 'MS.345'),
-    ]),
-    resolvedUri: 'https://wellcomecollection.org/works?query=MS%20542',
-  },
-  {
-    label: 'No text to decipher',
-    qs: '',
-    results: results([
-      resultWithIdentifier('k2fae5cz', 'calm-ref-no', 'MS.542'),
-      resultWithIdentifier('dr6uy6dg', 'calm-ref-no', 'MS.345'),
-    ]),
-    resolvedUri: 'https://wellcomecollection.org/collections',
-  },
-] as Test[];
+  [
+    'known RefNo in dsqItem',
+    {
+      qs: 'dsqField=RefNo&dsqItem=PPMEL/C',
+      results: results([
+        resultWithIdentifier('cbms2pg6', 'calm-ref-no', 'PPMEL/C'),
+        resultWithIdentifier('refd2pg6', 'calm-ref-no', 'REFNOT'),
+      ]),
+      resolvedUri: 'https://wellcomecollection.org/works/cbms2pg6',
+    },
+  ],
+  [
+    'known RefNo in dsqSearch',
+    {
+      qs: 'dsqSearch=(RefNo==%27PPADA%27)',
+      results: results([
+        resultWithIdentifier('jwj9b483', 'calm-ref-no', 'PPADA'),
+        resultWithIdentifier('refd2pg6', 'calm-ref-no', 'REFNOT'),
+      ]),
+      resolvedUri: 'https://wellcomecollection.org/works/jwj9b483',
+    },
+  ],
+  [
+    'known AltRefNo in dsqSeaarch',
+    {
+      qs: 'dsqSearch=(AltRefNo=%27sa/whl%27)',
+      results: results([
+        resultWithIdentifier('fjg4s86y', 'calm-alt-ref-no', 'SA/WHL'),
+        resultWithIdentifier('mtgtt57a', 'calm-alt-ref-no', 'SA/WHL/14'),
+      ]),
+      resolvedUri: 'https://wellcomecollection.org/works/fjg4s86y',
+    },
+  ],
+  [
+    'Unknown text in dsqSearch',
+    {
+      qs:
+        'dsqSearch=%28%28%28text%29%3D%27wa%2Fhmm%27%29AND%28%28text%29%3D%27durham%27%29%29',
+      results: results([
+        resultWithIdentifier('k2fae5cz', 'calm-ref-no', 'WA/HMM'),
+        resultWithIdentifier('dr6uy6dg', 'calm-ref-no', 'WA/HSW'),
+      ]),
+      resolvedUri: 'https://wellcomecollection.org/works?query=wa/hmm%20durham',
+    },
+  ],
+  [
+    'Unknown AltRefNo in dsqSearch',
+    {
+      qs: 'dsqSearch=((AltRefNo=%27MS%27)AND(AltRefNo=%27542%27))',
+      results: results([
+        resultWithIdentifier('k2fae5cz', 'calm-ref-no', 'MS.542'),
+        resultWithIdentifier('dr6uy6dg', 'calm-ref-no', 'MS.345'),
+      ]),
+      resolvedUri: 'https://wellcomecollection.org/works?query=MS%20542',
+    },
+  ],
+  [
+    'No text to decipher',
+    {
+      qs: '',
+      results: results([
+        resultWithIdentifier('k2fae5cz', 'calm-ref-no', 'MS.542'),
+        resultWithIdentifier('dr6uy6dg', 'calm-ref-no', 'MS.345'),
+      ]),
+      resolvedUri: 'https://wellcomecollection.org/collections',
+    },
+  ],
+] as [string, Test][];
 
-test.each(archiveTests)('$label', (test: Test) => {
+test.each(archiveTests)('%s', (name: string, test: Test) => {
   const request = testRequest(
     '/DServe/dserve.exe',
     `dsqIni=Dserve.ini&dsqApp=Archive&dsqCmd=Show.tcl&dsqDb=Catalog&dsqPos=0&${test.qs}`,
@@ -95,8 +106,4 @@ test.each(archiveTests)('$label', (test: Test) => {
   return expect(resultPromise).resolves.toEqual(
     expectedRedirect(test.resolvedUri)
   );
-});
-
-afterEach(() => {
-  jest.resetAllMocks();
 });

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryArchiveRedirect.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryArchiveRedirect.test.ts
@@ -46,8 +46,7 @@ const archiveTests = [
   },
   {
     label: 'known AltRefNo in dsqSeaarch',
-    qs:
-      'dsqIni=Dserve.ini&dsqApp=Archive&dsqCmd=Show.tcl&dsqDb=Catalog&dsqPos=0&dsqSearch=(AltRefNo=%27sa/whl%27)',
+    qs: 'dsqSearch=(AltRefNo=%27sa/whl%27)',
     results: results([
       resultWithIdentifier('fjg4s86y', 'calm-alt-ref-no', 'SA/WHL'),
       resultWithIdentifier('mtgtt57a', 'calm-alt-ref-no', 'SA/WHL/14'),
@@ -57,7 +56,7 @@ const archiveTests = [
   {
     label: 'Unknown text in dsqSearch',
     qs:
-      'dsqIni=Dserve.ini&dsqApp=Archive&dsqCmd=Show.tcl&dsqDb=Catalog&dsqPos=2&dsqSearch=%28%28%28text%29%3D%27wa%2Fhmm%27%29AND%28%28text%29%3D%27durham%27%29%29',
+      'dsqSearch=%28%28%28text%29%3D%27wa%2Fhmm%27%29AND%28%28text%29%3D%27durham%27%29%29',
     results: results([
       resultWithIdentifier('k2fae5cz', 'calm-ref-no', 'WA/HMM'),
       resultWithIdentifier('dr6uy6dg', 'calm-ref-no', 'WA/HSW'),
@@ -66,8 +65,7 @@ const archiveTests = [
   },
   {
     label: 'Unknown AltRefNo in dsqSearch',
-    qs:
-      'dsqIni=Dserve.ini&dsqApp=Archive&dsqCmd=Show.tcl&dsqDb=Catalog&dsqPos=0&dsqSearch=((AltRefNo=%27MS%27)AND(AltRefNo=%27542%27))',
+    qs: 'dsqSearch=((AltRefNo=%27MS%27)AND(AltRefNo=%27542%27))',
     results: results([
       resultWithIdentifier('k2fae5cz', 'calm-ref-no', 'MS.542'),
       resultWithIdentifier('dr6uy6dg', 'calm-ref-no', 'MS.345'),
@@ -77,7 +75,11 @@ const archiveTests = [
 ] as Test[];
 
 test.each(archiveTests)('$label', (test: Test) => {
-  const request = testRequest('/DServe/dserve.exe', test.qs, archivedHeaders);
+  const request = testRequest(
+    '/DServe/dserve.exe',
+    `dsqIni=Dserve.ini&dsqApp=Archive&dsqCmd=Show.tcl&dsqDb=Catalog&dsqPos=0&${test.qs}`,
+    archivedHeaders
+  );
   mockedAxios.get.mockResolvedValueOnce({
     data: test.results,
   });

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryArchiveRedirect.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryArchiveRedirect.test.ts
@@ -26,8 +26,7 @@ type Test = {
 const archiveTests = [
   {
     label: 'known RefNo in dsqItem',
-    qs:
-      'dsqIni=Dserve.ini&dsqApp=Archive&dsqDb=Catalog&dsqCmd=NaviTree.tcl&dsqField=RefNo&dsqItem=PPMEL/C',
+    qs: 'dsqField=RefNo&dsqItem=PPMEL/C',
     results: results([
       resultWithIdentifier('cbms2pg6', 'calm-ref-no', 'PPMEL/C'),
       resultWithIdentifier('refd2pg6', 'calm-ref-no', 'REFNOT'),
@@ -36,8 +35,7 @@ const archiveTests = [
   },
   {
     label: 'known RefNo in dsqSearch',
-    qs:
-      'dsqIni=Dserve.ini&dsqApp=Archive&dsqDb=Catalog&dsqCmd=show.tcl&dsqSearch=(RefNo==%27PPADA%27)',
+    qs: 'dsqSearch=(RefNo==%27PPADA%27)',
     results: results([
       resultWithIdentifier('jwj9b483', 'calm-ref-no', 'PPADA'),
       resultWithIdentifier('refd2pg6', 'calm-ref-no', 'REFNOT'),

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryArchiveRedirect.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryArchiveRedirect.test.ts
@@ -1,0 +1,93 @@
+import * as origin from './wellcomeLibraryArchiveRedirect';
+import testRequest from './testEventRequest';
+import { Context } from 'aws-lambda';
+import { results, resultWithIdentifier } from './catalogueApiFixtures';
+import { expectedRedirect } from './testHelpers';
+import axios from 'axios';
+import { afterEach, expect, jest, test } from '@jest/globals';
+import { CatalogueResultsList } from './catalogueApi';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const archivedHeaders = {
+  host: [{ key: 'host', value: 'archives.wellcomelibrary.org' }],
+  'cloudfront-forwarded-proto': [
+    { key: 'cloudfront-forwarded-proto', value: 'https' },
+  ],
+};
+
+type Test = {
+  label: string;
+  qs: string;
+  results: CatalogueResultsList;
+  resolvedUri: string;
+};
+const archiveTests = [
+  {
+    label: 'known RefNo in dsqItem',
+    qs:
+      'dsqIni=Dserve.ini&dsqApp=Archive&dsqDb=Catalog&dsqCmd=NaviTree.tcl&dsqField=RefNo&dsqItem=PPMEL/C',
+    results: results([
+      resultWithIdentifier('cbms2pg6', 'calm-ref-no', 'PPMEL/C'),
+      resultWithIdentifier('refd2pg6', 'calm-ref-no', 'REFNOT'),
+    ]),
+    resolvedUri: 'https://wellcomecollection.org/works/cbms2pg6',
+  },
+  {
+    label: 'known RefNo in dsqSearch',
+    qs:
+      'dsqIni=Dserve.ini&dsqApp=Archive&dsqDb=Catalog&dsqCmd=show.tcl&dsqSearch=(RefNo==%27PPADA%27)',
+    results: results([
+      resultWithIdentifier('jwj9b483', 'calm-ref-no', 'PPADA'),
+      resultWithIdentifier('refd2pg6', 'calm-ref-no', 'REFNOT'),
+    ]),
+    resolvedUri: 'https://wellcomecollection.org/works/jwj9b483',
+  },
+  {
+    label: 'known AltRefNo in dsqSeaarch',
+    qs:
+      'dsqIni=Dserve.ini&dsqApp=Archive&dsqCmd=Show.tcl&dsqDb=Catalog&dsqPos=0&dsqSearch=(AltRefNo=%27sa/whl%27)',
+    results: results([
+      resultWithIdentifier('fjg4s86y', 'calm-alt-ref-no', 'SA/WHL'),
+      resultWithIdentifier('mtgtt57a', 'calm-alt-ref-no', 'SA/WHL/14'),
+    ]),
+    resolvedUri: 'https://wellcomecollection.org/works/fjg4s86y',
+  },
+  {
+    label: 'Unknown text in dsqSearch',
+    qs:
+      'dsqIni=Dserve.ini&dsqApp=Archive&dsqCmd=Show.tcl&dsqDb=Catalog&dsqPos=2&dsqSearch=%28%28%28text%29%3D%27wa%2Fhmm%27%29AND%28%28text%29%3D%27durham%27%29%29',
+    results: results([
+      resultWithIdentifier('k2fae5cz', 'calm-ref-no', 'WA/HMM'),
+      resultWithIdentifier('dr6uy6dg', 'calm-ref-no', 'WA/HSW'),
+    ]),
+    resolvedUri: 'https://wellcomecollection.org/works?query=wa/hmm%20durham',
+  },
+  {
+    label: 'Unknown AltRefNo in dsqSearch',
+    qs:
+      'dsqIni=Dserve.ini&dsqApp=Archive&dsqCmd=Show.tcl&dsqDb=Catalog&dsqPos=0&dsqSearch=((AltRefNo=%27MS%27)AND(AltRefNo=%27542%27))',
+    results: results([
+      resultWithIdentifier('k2fae5cz', 'calm-ref-no', 'MS.542'),
+      resultWithIdentifier('dr6uy6dg', 'calm-ref-no', 'MS.345'),
+    ]),
+    resolvedUri: 'https://wellcomecollection.org/works?query=MS%20542',
+  },
+] as Test[];
+
+test.each(archiveTests)('$label', (test: Test) => {
+  const request = testRequest('/DServe/dserve.exe', test.qs, archivedHeaders);
+  mockedAxios.get.mockResolvedValueOnce({
+    data: test.results,
+  });
+
+  const resultPromise = origin.requestHandler(request, {} as Context);
+  return expect(resultPromise).resolves.toEqual(
+    expectedRedirect(test.resolvedUri)
+  );
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryArchiveRedirect.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryArchiveRedirect.ts
@@ -1,5 +1,40 @@
 import { CloudFrontRequestEvent, Context } from 'aws-lambda';
-import { CloudFrontRequest } from 'aws-lambda/common/cloudfront';
+import {
+  CloudFrontRequest,
+  CloudFrontResultResponse,
+} from 'aws-lambda/common/cloudfront';
+import querystring from 'querystring';
+import { wellcomeCollectionRedirect } from './redirectHelpers';
+import { findWorkWithIdentifierValue } from './catalogueApi';
+
+async function getWorkWithId(term: string) {
+  const work = await findWorkWithIdentifierValue(term);
+  if (work) {
+    return wellcomeCollectionRedirect(`/works/${work.id}`);
+  }
+}
+
+async function redirectRequestUri(
+  request: CloudFrontRequest
+): Promise<undefined | CloudFrontResultResponse> {
+  const qs = querystring.parse(request.querystring);
+  const dsqItem = qs.dsqItem ? qs.dsqItem.toString() : undefined;
+  const dsqSearch = qs.dsqSearch ? qs.dsqSearch.toString() : undefined;
+  const dsqSearchTermsMatch = dsqSearch
+    ? dsqSearch.match(/'([^']*)'/g)
+    : undefined;
+  // The dserve app puts all test it's searching for in the format of `(Field='{term}')`
+  // so we just search for anything between `'`
+  const dsqSearchTerms = dsqSearchTermsMatch
+    ? dsqSearchTermsMatch.map((term) => term.replace(/'/g, '')).join(' ')
+    : undefined;
+  const search = dsqItem ?? dsqSearchTerms;
+
+  if (search) {
+    const work = await getWorkWithId(search);
+    return work ?? wellcomeCollectionRedirect(`/works?query=${search}`);
+  }
+}
 
 export const requestHandler = async (
   event: CloudFrontRequestEvent,
@@ -7,8 +42,16 @@ export const requestHandler = async (
 ) => {
   const request: CloudFrontRequest = event.Records[0].cf.request;
 
+  const requestRedirect = await redirectRequestUri(request);
+
+  if (requestRedirect) {
+    return requestRedirect;
+  }
+
+  // If we've matched nothing so far then set the host header for Wellcome Library
+  // In future we may want to redirect to wellcomecollection.org if we find no match
   request.headers.host = [
-    { key: 'host', value: 'archives.wellcomelibrary.org' },
+    { key: 'host', value: 'archive.wellcomelibrary.org' },
   ];
 
   return request;

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryArchiveRedirect.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryArchiveRedirect.ts
@@ -28,6 +28,7 @@ async function redirectRequestUri(
   const dsqSearchTerms = dsqSearchTermsMatch
     ? dsqSearchTermsMatch.map((term) => term.replace(/'/g, '')).join(' ')
     : undefined;
+
   const search = dsqItem ?? dsqSearchTerms;
 
   if (search) {

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryArchiveRedirect.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryArchiveRedirect.ts
@@ -48,11 +48,5 @@ export const requestHandler = async (
     return requestRedirect;
   }
 
-  // If we've matched nothing so far then set the host header for Wellcome Library
-  // In future we may want to redirect to wellcomecollection.org if we find no match
-  request.headers.host = [
-    { key: 'host', value: 'archive.wellcomelibrary.org' },
-  ];
-
-  return request;
+  return wellcomeCollectionRedirect('/collections');
 };

--- a/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
@@ -5,6 +5,7 @@ import { readRedirects } from './src/readRedirects';
 import {
   staticRedirectFileLocation,
   staticRedirectHeaders,
+  staticRedirectsHost,
 } from './staticRedirects';
 
 type CsvHeader = string | undefined;
@@ -178,8 +179,8 @@ const blogTestSet = {
 const apexTestSet = {
   displayName: 'Apex (Content management) pages',
   fileLocation: staticRedirectFileLocation,
-  fileHostPrefix: 'blog.wellcomelibrary.org',
-  headers: ['sourceUrl', 'targetUrl'],
+  fileHostPrefix: staticRedirectsHost,
+  headers: staticRedirectHeaders,
   envs: {
     stage: 'https://blog.stage.wellcomelibrary.org/',
     prod: 'https://blog.wellcomelibrary.org/',
@@ -204,6 +205,7 @@ const testSets: RedirectTestSet[] = [
   itemTestSet,
   blogTestSet,
   apexTestSet,
+  archiveTestSet,
 ];
 
 const runTests = async (envId: EnvId) => {

--- a/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
@@ -190,11 +190,11 @@ const apexTestSet = {
 const archiveTestSet = {
   displayName: 'Archive search',
   fileLocation: 'archiveRedirects.csv',
-  fileHostPrefix: 'staticRedirectsHost',
-  headers: staticRedirectHeaders,
+  fileHostPrefix: 'archive.wellcomecollection.org',
+  headers: ['sourceUrl', 'targetUrl'],
   envs: {
-    stage: 'https://stage.wellcomelibrary.org',
-    prod: 'https://wellcomelibrary.org',
+    stage: 'https://archives.stage.wellcomelibrary.org',
+    prod: 'https://archives.wellcomelibrary.org',
   },
   checkResponse: checkMatchingUrl,
 };

--- a/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
@@ -5,7 +5,6 @@ import { readRedirects } from './src/readRedirects';
 import {
   staticRedirectFileLocation,
   staticRedirectHeaders,
-  staticRedirectsHost,
 } from './staticRedirects';
 
 type CsvHeader = string | undefined;
@@ -179,7 +178,19 @@ const blogTestSet = {
 const apexTestSet = {
   displayName: 'Apex (Content management) pages',
   fileLocation: staticRedirectFileLocation,
-  fileHostPrefix: staticRedirectsHost,
+  fileHostPrefix: 'blog.wellcomelibrary.org',
+  headers: ['sourceUrl', 'targetUrl'],
+  envs: {
+    stage: 'https://blog.stage.wellcomelibrary.org/',
+    prod: 'https://blog.wellcomelibrary.org/',
+  },
+  checkResponse: checkMatchingUrl,
+};
+
+const archiveTestSet = {
+  displayName: 'Archive search',
+  fileLocation: 'archiveRedirects.csv',
+  fileHostPrefix: 'staticRedirectsHost',
   headers: staticRedirectHeaders,
   envs: {
     stage: 'https://stage.wellcomelibrary.org',


### PR DESCRIPTION
## What's changing and why?
Ref: https://github.com/wellcomecollection/platform/issues/5058

Adds the redirects for `archives.wellcomecollection.org`.

The DServe application is a little fiddly, but there is some decernable information we can get from the QS.

In short
* `dsqItem` - which has a RefNo in it
* `dsqSearch`- can hold multiple types of search DSL. All search terms that are searched for are wrapped in `'`. We don't bother checking the field etc, we just take all the terms in `'`, join them on ` `, and search for it. If we find a matching ID in a work, we redirect to that work. If we don't, we search for the new search terms.

This should catch most URLs out there. The examples are taken from GA and Google searches, so real things that are happening.

## `terraform plan` diff
No-op.
