### PR TITLE
bump redirect arn

### DIFF
--- a/cloudfront/wellcomelibrary.org/terraform/locals.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/locals.tf
@@ -4,7 +4,7 @@ locals {
   wellcome_library_redirect_arn_latest = "${local.wellcome_library_redirect_arn}:${local.wellcome_library_redirect_latest}"
   wellcome_library_redirect_arn_stage  = local.wellcome_library_redirect_arn_latest
   # This should be set manually when a stable prod deploy is established.
-  wellcome_library_redirect_arn_prod = "${local.wellcome_library_redirect_arn}:69"
+  wellcome_library_redirect_arn_prod = "${local.wellcome_library_redirect_arn}:72"
 
   wellcome_library_passthru_arn        = aws_lambda_function.wellcome_library_passthru.arn
   wellcome_library_passthru_latest     = aws_lambda_function.wellcome_library_passthru.version


### PR DESCRIPTION
## What's changing and why?
Added some static redirects - this deploys them

## `terraform plan` diff
```
~ resource "aws_cloudfront_distribution" "distro" {
        id                             = "EHUBCZTWBQL8L"
        tags                           = {
            "Managed" = "terraform"
        }
        # (17 unchanged attributes hidden)

      ~ default_cache_behavior {
            # (10 unchanged attributes hidden)


          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:760097843905:function:cf_edge_wellcome_library_redirect:69" -> null
            }
          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = "arn:aws:lambda:us-east-1:760097843905:function:cf_edge_wellcome_library_redirect:72"
            }
            # (1 unchanged block hidden)
        }




        # (10 unchanged blocks hidden)
    }
```
