### PR TITLE
add redirections for collections/browse

### DIFF
--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.test.ts
@@ -180,6 +180,22 @@ const rewriteTests = (): ExpectedRewrite[] => {
       out: expectedRedirect('https://iiif.wellcomecollection.org/bar/bat'),
       generateData: [() => 'https://iiif.wellcomecollection.org/bar/bat'],
     },
+    {
+      uri: '/collections/browse/authors/Wellcome Historical Medical Library./',
+      out: expectedRedirect('https://wellcomecollection.org/collections'),
+    },
+    {
+      uri: '/collections/browse/topics/Archives/',
+      out: expectedRedirect('https://wellcomecollection.org/collections'),
+    },
+    {
+      uri: '/collections/browse/genres/Archives/',
+      out: expectedRedirect('https://wellcomecollection.org/collections'),
+    },
+    {
+      uri: '/collections/browse/collections/digramc/',
+      out: expectedRedirect('https://wellcomecollection.org/collections'),
+    },
   ];
 };
 

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.ts
@@ -63,12 +63,15 @@ async function redirectRequestUri(
   const itemPathRegExp: RegExp = /^\/(item|player)\/.*/;
   const eventsPathRegExp: RegExp = /^\/events(\/)?.*/;
   const apiPathRegExp: RegExp = /^\/(iiif|service|ddsconf|dds-static|annoservices)\/.*/;
+  const collectionsBrowseExp: RegExp = /^\/collections\/browse(\/)?.*/;
   const staticRedirect = lookupRedirect(staticRedirects, uri);
 
   if (staticRedirect) {
     return staticRedirect;
   } else if (uri.match(itemPathRegExp)) {
     return getWorksRedirect(uri);
+  } else if (uri.match(collectionsBrowseExp)) {
+    return wellcomeCollectionRedirect('/collections');
   } else if (uri.match(eventsPathRegExp)) {
     return wellcomeCollectionRedirect('/whats-on');
   } else if (uri.match(apiPathRegExp)) {


### PR DESCRIPTION
## What's changing and why?
Adding redirectes from `wl.org/collections/browse/*` => `wc.org/collections`.

Examples were taken from analytics.

## `terraform plan` diff
Coming soon once code is reviewed.
