### PR TITLE
bump wl redirect lambda

### DIFF
--- a/cloudfront/wellcomelibrary.org/edge-lambda/collectionsBrowse.csv
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/collectionsBrowse.csv
@@ -1,0 +1,3 @@
+sourceUrl,targetUrl
+wellcomelibrary.org/collections/browse/authors/Wellcome Historical Medical Library./,https://wellcomecollection.org/collections
+wellcomelibrary.org/collections/browse/collections/digramc/,https://wellcomecollection.org/collections

--- a/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
@@ -188,11 +188,24 @@ const apexTestSet = {
   checkResponse: checkMatchingUrl,
 };
 
+const collectionBrowseTestSet = {
+  displayName: 'Collection browse pages',
+  fileLocation: 'collectionsBrowse.csv',
+  fileHostPrefix: 'wellcomelibrary.org',
+  headers: ['sourceUrl', 'targetUrl'],
+  envs: {
+    stage: 'https://stage.wellcomelibrary.org',
+    prod: 'https://wellcomelibrary.org',
+  },
+  checkResponse: checkMatchingUrl,
+};
+
 const testSets: RedirectTestSet[] = [
   apiTestSet,
   itemTestSet,
   blogTestSet,
   apexTestSet,
+  collectionBrowseTestSet,
 ];
 
 const runTests = async (envId: EnvId) => {

--- a/cloudfront/wellcomelibrary.org/terraform/locals.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/locals.tf
@@ -4,7 +4,7 @@ locals {
   wellcome_library_redirect_arn_latest = "${local.wellcome_library_redirect_arn}:${local.wellcome_library_redirect_latest}"
   wellcome_library_redirect_arn_stage  = local.wellcome_library_redirect_arn_latest
   # This should be set manually when a stable prod deploy is established.
-  wellcome_library_redirect_arn_prod = "${local.wellcome_library_redirect_arn}:72"
+  wellcome_library_redirect_arn_prod = "${local.wellcome_library_redirect_arn}:73"
 
   wellcome_library_passthru_arn        = aws_lambda_function.wellcome_library_passthru.arn
   wellcome_library_passthru_latest     = aws_lambda_function.wellcome_library_passthru.version


### PR DESCRIPTION
## What's changing and why?
Making things proddy.
Test: https://stage.wellcomelibrary.org/collections/browse/wowzer

## `terraform plan` diff
```
# module.wellcomelibrary-prod.aws_cloudfront_distribution.distro will be updated in-place
  ~ resource "aws_cloudfront_distribution" "distro" {
        id                             = "EHUBCZTWBQL8L"
        tags                           = {
            "Managed" = "terraform"
        }
        # (17 unchanged attributes hidden)

      ~ default_cache_behavior {
            # (10 unchanged attributes hidden)


          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:760097843905:function:cf_edge_wellcome_library_redirect:72" -> null
            }
          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = "arn:aws:lambda:us-east-1:760097843905:function:cf_edge_wellcome_library_redirect:73"
            }
            # (1 unchanged block hidden)
        }

        # (10 unchanged blocks hidden)
    }
```