### PR TITLE
Add CNAME record for status.wellcomecollection.org

### DIFF
--- a/cloudfront/wellcomecollection.org/terraform/locals.tf
+++ b/cloudfront/wellcomecollection.org/terraform/locals.tf
@@ -1,8 +1,5 @@
 
 locals {
-  # identity_zone_name_servers = data.terraform_remote_state.identity.outputs.identity_zone_name_servers
-  account_zone_name_servers = data.terraform_remote_state.identity.outputs.account_zone_name_servers
-
   // The outputs from the identity stack contain enough information to construct
   // the whole record (including type, and name) which is useful _but_ we don't
   // want to allow the outputs from that stack to set those details here in order

--- a/cloudfront/wellcomecollection.org/terraform/main.tf
+++ b/cloudfront/wellcomecollection.org/terraform/main.tf
@@ -19,6 +19,17 @@ resource "aws_route53_record" "rank" {
   provider = aws.dns
 }
 
+// This adds a CNAME record for Atlassion Statuspage (https://wellcomecollection.statuspage.io/)
+resource "aws_route53_record" "status" {
+  zone_id = data.aws_route53_zone.weco_zone.id
+  name    = "status.wellcomecollection.org"
+  type    = "CNAME"
+  records = ["qyhn8w55666p.stspg-customer.com"]
+  ttl     = "300"
+
+  provider = aws.dns
+}
+
 # See https://help.shopify.com/en/manual/online-store/os/domains/add-a-domain/using-existing-domains/connecting-domains#set-up-your-existing-domain-to-connect-to-shopify
 
 resource "aws_route53_record" "shop" {


### PR DESCRIPTION
## What's changing and why?

This change adds a CNAME record to have a custom domain for Statuspage (API & site status reporting tool) in order that we have a pleasant URL for our status page.

## `terraform plan` diff

```
Terraform will perform the following actions:

  # aws_route53_record.status will be created
  + resource "aws_route53_record" "status" {
      + allow_overwrite = (known after apply)                                                                                                                       + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "status.wellcomecollection.org"
      + records         = [
          + "qyhn8w55666p.stspg-customer.com",
        ]
      + ttl             = 300
      + type            = "CNAME"
      + zone_id         = "Z0902614YH73JBCZG1MA"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```
