### PR TITLE
Redirect Dserve URLs 

### DIFF
--- a/cloudfront/wellcomelibrary.org/README.md
+++ b/cloudfront/wellcomelibrary.org/README.md
@@ -5,3 +5,9 @@ CloudFront distributions & edge-lambdas for managing the redirection of results 
 ## AWS Route53 
 
 If you need access to the Route53 console use [this link](https://console.aws.amazon.com/route53/v2/hostedzones?#ListRecordSets/Z78J6G8RSOLSZ). You will need to have permissions to assume the role: `arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update`.
+
+## Deployment
+```bash
+./deploy
+```
+

--- a/cloudfront/wellcomelibrary.org/README.md
+++ b/cloudfront/wellcomelibrary.org/README.md
@@ -5,9 +5,3 @@ CloudFront distributions & edge-lambdas for managing the redirection of results 
 ## AWS Route53 
 
 If you need access to the Route53 console use [this link](https://console.aws.amazon.com/route53/v2/hostedzones?#ListRecordSets/Z78J6G8RSOLSZ). You will need to have permissions to assume the role: `arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update`.
-
-## Deployment
-```bash
-./deploy
-```
-

--- a/cloudfront/wellcomelibrary.org/deploy
+++ b/cloudfront/wellcomelibrary.org/deploy
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-pushd ./edge-lambda
-  yarn && yarn deploy
-popd
-
-pushd ./terraform
-  terraform apply
-popd

--- a/cloudfront/wellcomelibrary.org/deploy
+++ b/cloudfront/wellcomelibrary.org/deploy
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+pushd ./edge-lambda
+  yarn && yarn deploy
+popd
+
+pushd ./terraform
+  terraform apply
+popd

--- a/cloudfront/wellcomelibrary.org/terraform/dserve.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/dserve.tf
@@ -1,25 +1,26 @@
 // DServe links (archives.wellcomelibrary.org)
 
-//module "wellcomelibrary_dserve-prod" {
-//  source = "./cloudfront_distro"
-//
-//  distro_alternative_names = [
-//    "archives.wellcomelibrary.org"
-//  ]
-//  acm_certificate_arn = module.cert-stage.arn
-//
-//  origins = [{
-//    origin_id : "origin"
-//    domain_name : "archives.origin.wellcomelibrary.org"
-//    origin_path : null
-//  }]
-//
-//  default_target_origin_id                       = "origin"
-//  default_lambda_function_association_event_type = "origin-request"
-//  default_lambda_function_association_lambda_arn = local.wellcome_library_passthru_arn_prod
-//  default_forwarded_headers                      = ["Host"]
-//}
-//
+module "wellcomelibrary_dserve-prod" {
+  source = "./cloudfront_distro"
+
+  distro_alternative_names = [
+    "archives.wellcomelibrary.org"
+  ]
+  acm_certificate_arn = module.cert-stage.arn
+
+  origins = [{
+    origin_id : "origin"
+    domain_name : "archives.origin.wellcomelibrary.org"
+    origin_path : null
+    origin_protocol_policy : "match-viewer"
+  }]
+
+  default_target_origin_id                       = "origin"
+  default_lambda_function_association_event_type = "origin-request"
+  default_lambda_function_association_lambda_arn = local.wellcome_library_archive_redirect_arn_prod
+  default_forwarded_headers                      = ["Host"]
+}
+
 module "wellcomelibrary_dserve-stage" {
   source = "./cloudfront_distro"
 
@@ -41,23 +42,23 @@ module "wellcomelibrary_dserve-stage" {
   default_forwarded_headers                      = ["Host"]
 }
 
-resource "aws_route53_record" "dserve-prod" {
-  zone_id = data.aws_route53_zone.zone.id
-  name    = "archives.wellcomelibrary.org"
-  type    = "CNAME"
-
-  records = ["archives.wellcome.ac.uk."]
-  ttl     = "300"
-
-  provider = aws.dns
-}
-
 resource "aws_route53_record" "dserve-origin" {
   zone_id = data.aws_route53_zone.zone.id
   name    = "archives.origin.wellcomelibrary.org"
   type    = "CNAME"
 
   records = ["archives.wellcome.ac.uk."]
+  ttl     = "60"
+
+  provider = aws.dns
+}
+
+resource "aws_route53_record" "dserve-prod" {
+  zone_id = data.aws_route53_zone.zone.id
+  name    = "archives.wellcomelibrary.org"
+  type    = "CNAME"
+
+  records = [module.wellcomelibrary_dserve-prod.distro_domain_name]
   ttl     = "60"
 
   provider = aws.dns

--- a/cloudfront/wellcomelibrary.org/terraform/locals.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/locals.tf
@@ -25,7 +25,7 @@ locals {
   wellcome_library_archive_redirect_arn_latest = "${local.wellcome_library_archive_redirect_arn}:${local.wellcome_library_archive_redirect_latest}"
   wellcome_library_archive_redirect_arn_stage  = local.wellcome_library_archive_redirect_arn_latest
   # This should be set manually when a stable prod deploy is established.
-  wellcome_library_archive_redirect_arn_prod = local.wellcome_library_archive_redirect_arn_latest
+  wellcome_library_archive_redirect_arn_prod = "${local.wellcome_library_archive_redirect_arn}:22"
 
   wellcome_library_encore_redirect_arn        = aws_lambda_function.wellcome_library_encore_redirect.arn
   wellcome_library_encore_redirect_latest     = aws_lambda_function.wellcome_library_encore_redirect.version


### PR DESCRIPTION
## What's changing and why?
Redirects archive.wellcomelibrary.org URLs because they are not wellcomecollection.org URLs.
Closes https://github.com/wellcomecollection/platform/issues/5058

## `terraform plan` diff
```
# module.wellcomelibrary_dserve-prod.aws_cloudfront_distribution.distro will be created
  + resource "aws_cloudfront_distribution" "distro" {
      + aliases                        = [
          + "archives.wellcomelibrary.org",
        ]
      + arn                            = (known after apply)
      + caller_reference               = (known after apply)
      + comment                        = "Wellcome Library (archives.wellcomelibrary.org)"
      + domain_name                    = (known after apply)
      + enabled                        = true
      + etag                           = (known after apply)
      + hosted_zone_id                 = (known after apply)
      + http_version                   = "http2"
      + id                             = (known after apply)
      + in_progress_validation_batches = (known after apply)
      + is_ipv6_enabled                = true
      + last_modified_time             = (known after apply)
      + price_class                    = "PriceClass_100"
      + retain_on_delete               = false
      + status                         = (known after apply)
      + tags                           = {
          + "Managed" = "terraform"
        }
      + trusted_signers                = (known after apply)
      + wait_for_deployment            = true

      + default_cache_behavior {
          + allowed_methods        = [
              + "DELETE",
              + "GET",
              + "HEAD",
              + "OPTIONS",
              + "PATCH",
              + "POST",
              + "PUT",
            ]
          + cached_methods         = [
              + "GET",
              + "HEAD",
            ]
          + compress               = false
          + default_ttl            = (known after apply)
          + max_ttl                = (known after apply)
          + min_ttl                = 0
          + target_origin_id       = "origin"
          + trusted_signers        = (known after apply)
          + viewer_protocol_policy = "redirect-to-https"

          + forwarded_values {
              + headers                 = [
                  + "Host",
                ]
              + query_string            = true
              + query_string_cache_keys = (known after apply)

              + cookies {
                  + forward           = "all"
                  + whitelisted_names = (known after apply)
                }
            }

          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = "arn:aws:lambda:us-east-1:760097843905:function:cf_edge_wellcome_library_passthru:37"
            }
        }

      + origin {
          + domain_name = "archives.origin.wellcomelibrary.org"
          + origin_id   = "origin"

          + custom_origin_config {
              + http_port                = 80
              + https_port               = 443
              + origin_keepalive_timeout = 5
              + origin_protocol_policy   = "match-viewer"
              + origin_read_timeout      = 30
              + origin_ssl_protocols     = [
                  + "TLSv1",
                  + "TLSv1.1",
                  + "TLSv1.2",
                ]
            }
        }

      + restrictions {
          + geo_restriction {
              + locations        = (known after apply)
              + restriction_type = "none"
            }
        }

      + viewer_certificate {
          + acm_certificate_arn      = "arn:aws:acm:us-east-1:760097843905:certificate/bc1b8762-ce4f-420a-8804-7cf938c51322"
          + minimum_protocol_version = "TLSv1"
          + ssl_support_method       = "sni-only"
        }
    }
```


[Second part of the PR](https://github.com/wellcomecollection/platform-infrastructure/pull/201/commits/5561bd131371a3939c134ddddbb1b4399258211d)
```
# aws_route53_record.dserve-prod will be updated in-place
  ~ resource "aws_route53_record" "dserve-prod" {
        id      = "Z78J6G8RSOLSZ_archives.wellcomelibrary.org_CNAME"
        name    = "archives.wellcomelibrary.org"
      ~ records = [
          - "archives.wellcome.ac.uk.",
          + "d2fe9olipvobw6.cloudfront.net",
        ]
        # (4 unchanged attributes hidden)
    }
```