### PR TITLE
Add new AWS account for DAM Prototype

### DIFF
--- a/accounts/README.md
+++ b/accounts/README.md
@@ -67,17 +67,18 @@ Platfrom SSH Keys available to authorised users in the `wc_platform` Keybase tea
 
 These are the VPCs contained within these accounts - note that they are non-overlapping.
 
-| Account      | VPC name                   | CIDR block    |
-|--------------|----------------------------|---------------|
-| `catalogue`  | `catalogue` *(deprecated)* | `172.31.0.0/16` |
-| `catalogue`  | `catalogue`                | `172.18.0.0/16` |
-| `data`       | `datascience`              | `172.17.0.0/16` |
-| `digirati`   | `iiif-services`            | `172.56.0.0/16` |
-| `digirati`   | `moh`                      | `172.57.0.0/16` |
-| `experience` | `experience`               | `172.19.0.0/16` |
-| `identity`   | `identity-services-prod`   | `172.72.0.0/16` |
-| `identity`   | `identity-services-stage`  | `172.73.0.0/16` |
-| `platform`   | `ci`                       | `172.43.0.0/16` |
-| `platform`   | `developer`                | `172.42.0.0/16` |
-| `platform`   | `monitoring`               | `172.28.0.0/16` |
-| `storage`    | `storage`                  | `172.30.0.0/16` |
+| Account         | VPC name                   | CIDR block      |
+|-----------------|----------------------------|-----------------|
+| `catalogue`     | `catalogue` *(deprecated)* | `172.31.0.0/16` |
+| `catalogue`     | `catalogue`                | `172.18.0.0/16` |
+| `dam_prototype` | `dam-prototype`            | `172.31.0.0/16` |
+| `data`          | `datascience`              | `172.17.0.0/16` |
+| `digirati`      | `iiif-services`            | `172.56.0.0/16` |
+| `digirati`      | `moh`                      | `172.57.0.0/16` |
+| `experience`    | `experience`               | `172.19.0.0/16` |
+| `identity`      | `identity-services-prod`   | `172.72.0.0/16` |
+| `identity`      | `identity-services-stage`  | `172.73.0.0/16` |
+| `platform`      | `ci`                       | `172.43.0.0/16` |
+| `platform`      | `developer`                | `172.42.0.0/16` |
+| `platform`      | `monitoring`               | `172.28.0.0/16` |
+| `storage`       | `storage`                  | `172.30.0.0/16` |

--- a/accounts/dam_prototype/account.tf
+++ b/accounts/dam_prototype/account.tf
@@ -1,4 +1,4 @@
-module "identity_account" {
+module "dam_prototype_account" {
   source = "../modules/account/aws"
 
   prefix = "dam_prototype"

--- a/accounts/dam_prototype/cloudhealth.tf
+++ b/accounts/dam_prototype/cloudhealth.tf
@@ -1,0 +1,3 @@
+module "cloudhealth-experience" {
+  source = "../modules/cloudhealth"
+}

--- a/accounts/dam_prototype/locals.tf
+++ b/accounts/dam_prototype/locals.tf
@@ -1,0 +1,12 @@
+locals {
+  account_ids = {
+    platform      = "760097843905"
+    dam_prototype = "241906670800"
+  }
+
+  aws_region = "eu-west-1"
+
+  secrets_base_arn = "arn:aws:secretsmanager:${local.aws_region}:${local.account_ids["dam_prototype"]}:secret:"
+
+  account_principals = { for key, value in local.account_ids : key => "arn:aws:iam::${value}:root" }
+}

--- a/accounts/dam_prototype/outputs.tf
+++ b/accounts/dam_prototype/outputs.tf
@@ -1,0 +1,43 @@
+output "admin_role_arn" {
+  value = module.dam_prototype_account.admin_role_arn
+}
+
+output "billing_role_arn" {
+  value = module.dam_prototype_account.billing_role_arn
+}
+
+output "developer_role_arn" {
+  value = module.dam_prototype_account.developer_role_arn
+}
+
+output "monitoring_role_arn" {
+  value = module.dam_prototype_account.monitoring_role_arn
+}
+
+output "read_only_role_arn" {
+  value = module.dam_prototype_account.read_only_role_arn
+}
+
+output "publisher_role_arn" {
+  value = module.dam_prototype_account.publisher_role_arn
+}
+
+output "ci_role_arn" {
+  value = module.dam_prototype_account.ci_role_arn
+}
+
+output "dam_prototype_vpc_private_subnets" {
+  value = module.dam_prototype_vpc.private_subnets
+}
+
+output "dam_prototype_vpc_cidr_block_private" {
+  value = module.dam_prototype_vpc.cidr_block_private
+}
+
+output "dam_prototype_vpc_vpc_public_subnets" {
+  value = module.dam_prototype_vpc.public_subnets
+}
+
+output "dam_prototype_vpc_vpc_id" {
+  value = module.dam_prototype_vpc.vpc_id
+}

--- a/accounts/dam_prototype/provider.tf
+++ b/accounts/dam_prototype/provider.tf
@@ -1,0 +1,16 @@
+provider "aws" {
+  region = "eu-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::241906670800:role/dam_prototype-admin"
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+  alias  = "platform"
+
+  assume_role {
+    role_arn = "arn:aws:iam::760097843905:role/platform-admin"
+  }
+}

--- a/accounts/dam_prototype/terraform.tf
+++ b/accounts/dam_prototype/terraform.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 0.9"
+
+  backend "s3" {
+    bucket         = "wellcomecollection-platform-infra"
+    key            = "terraform/platform-infrastructure/accounts/dam_prototype.tfstate"
+    dynamodb_table = "terraform-locktable"
+
+    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    region   = "eu-west-1"
+  }
+}

--- a/accounts/dam_prototype/vpcs.tf
+++ b/accounts/dam_prototype/vpcs.tf
@@ -1,0 +1,6 @@
+module "dam_prototype_vpc" {
+  source = "../modules/vpc"
+
+  vpc_name   = "dam-prototype"
+  cidr_block = "172.31.0.0/16"
+}

--- a/accounts/identity/account.tf
+++ b/accounts/identity/account.tf
@@ -1,10 +1,10 @@
 module "identity_account" {
   source = "../modules/account/aws"
 
-  prefix = "dam_prototype"
+  prefix = "identity"
 
   principals = [
     local.account_principals["platform"],
-    local.account_principals["dam_prototype"],
+    local.account_principals["identity"],
   ]
 }

--- a/accounts/platform/locals.tf
+++ b/accounts/platform/locals.tf
@@ -5,15 +5,16 @@ locals {
 
   aws_region = "eu-west-1"
 
-  catalogue_account_roles    = data.terraform_remote_state.accounts_catalogue.outputs
-  data_account_roles         = data.terraform_remote_state.accounts_data.outputs
-  digirati_account_roles     = data.terraform_remote_state.accounts_digirati.outputs
-  digitisation_account_roles = data.terraform_remote_state.accounts_digitisation.outputs
-  experience_account_roles   = data.terraform_remote_state.accounts_experience.outputs
-  reporting_account_roles    = data.terraform_remote_state.accounts_reporting.outputs
-  storage_account_roles      = data.terraform_remote_state.accounts_storage.outputs
-  workflow_account_roles     = data.terraform_remote_state.accounts_workflow.outputs
-  identity_account_roles     = data.terraform_remote_state.accounts_identity.outputs
+  catalogue_account_roles     = data.terraform_remote_state.accounts_catalogue.outputs
+  data_account_roles          = data.terraform_remote_state.accounts_data.outputs
+  digirati_account_roles      = data.terraform_remote_state.accounts_digirati.outputs
+  digitisation_account_roles  = data.terraform_remote_state.accounts_digitisation.outputs
+  experience_account_roles    = data.terraform_remote_state.accounts_experience.outputs
+  reporting_account_roles     = data.terraform_remote_state.accounts_reporting.outputs
+  storage_account_roles       = data.terraform_remote_state.accounts_storage.outputs
+  workflow_account_roles      = data.terraform_remote_state.accounts_workflow.outputs
+  identity_account_roles      = data.terraform_remote_state.accounts_identity.outputs
+  dam_prototype_account_roles = data.terraform_remote_state.accounts_dam_prototype.outputs
 
   account_ids = {
     platform = local.account_id

--- a/accounts/platform/rolesets.tf
+++ b/accounts/platform/rolesets.tf
@@ -62,6 +62,11 @@ module "super_dev_roleset" {
     local.catalogue_account_roles["read_only_role_arn"],
     local.catalogue_account_roles["admin_role_arn"],
 
+    # DAM Prototype
+    local.dam_prototype_account_roles["developer_role_arn"],
+    local.dam_prototype_account_roles["read_only_role_arn"],
+    local.dam_prototype_account_roles["admin_role_arn"],
+
     # CI Roles
     local.ci_agent_role_arn,
     module.aws_account.publisher_role_arn,
@@ -76,6 +81,7 @@ module "super_dev_roleset" {
     local.identity_account_roles["ci_role_arn"],
     local.digitisation_account_roles["ci_role_arn"],
     local.experience_account_roles["ci_role_arn"],
+    local.dam_prototype_account_roles["ci_role_arn"],
 
     aws_iam_role.s3_scala_releases_read.arn,
     module.s3_releases_scala_sierra_client.role_arn,

--- a/accounts/platform/terraform.tf
+++ b/accounts/platform/terraform.tf
@@ -130,6 +130,18 @@ data "terraform_remote_state" "accounts_identity" {
   }
 }
 
+data "terraform_remote_state" "accounts_dam_prototype" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/platform-infrastructure/accounts/dam_prototype.tfstate"
+    region = "eu-west-1"
+  }
+}
+
 data "aws_caller_identity" "current" {}
 
 data "template_file" "pgp_key" {


### PR DESCRIPTION
## What's changing and why?

In order to support the DAM prototyping work (getting the storage service set up from scratch) this change adds a new AWS account to ringfence those resources.
