### PR TITLE
Use ECR public repo for python

### DIFF
--- a/cloudfront/api.wellcomecollection.org/tests/Dockerfile
+++ b/cloudfront/api.wellcomecollection.org/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM public.ecr.aws/bitnami/python:3.9
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/cloudfront/iiif.wellcomecollection.org/tests/Dockerfile
+++ b/cloudfront/iiif.wellcomecollection.org/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM public.ecr.aws/bitnami/python:3.9
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt


### PR DESCRIPTION
## What's changing and why?

Docker hub has unfortunate rate limits, ECR public may alleviate that issue while still not requiring authentication.

See https://docs.aws.amazon.com/AmazonECR/latest/public/public-service-quotas.html for quotas. These requests will primarily run from within AWS EC2:

```
10 (images pulls per second) for authenticated pulls or pulls to resources running on Amazon ECS, Fargate, or Amazon EC2
```
