### PR TITLE
redirect passthru redirects to wellcomecollection.org

### DIFF
--- a/cloudfront/wellcomelibrary.org/edge-lambda/passthruRedirects.csv
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/passthruRedirects.csv
@@ -1,0 +1,2 @@
+sourceUrl, targetUrl
+wellcomelibrary.org/link/to/nowhere,https://wellcomecollection.org/

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryPassthru.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryPassthru.test.ts
@@ -47,4 +47,6 @@ test('redirects wellcomelibrary.org passthrus to wellcomecollection.org', async 
       { key: 'Access-Control-Allow-Origin', value: '*' },
     ],
   });
+
+  expect(originRequest.status).toEqual('302');
 });

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryPassthru.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryPassthru.test.ts
@@ -34,14 +34,17 @@ test('http requests are redirected to https', () => {
   );
 });
 
-test('rewrites the host header if it exists', async () => {
-  const request = testRequest('/', undefined, {
+test('redirects wellcomelibrary.org passthrus to wellcomecollection.org', async () => {
+  const request = testRequest('/unknown', undefined, {
     host: [{ key: 'host', value: 'www.wellcomelibrary.org' }],
   });
 
   const originRequest = await origin.requestHandler(request, {} as Context);
 
   expect(originRequest.headers).toStrictEqual({
-    host: [{ key: 'host', value: 'wellcomelibrary.org' }],
+    location: [{ key: 'Location', value: 'https://wellcomecollection.org/' }],
+    'access-control-allow-origin': [
+      { key: 'Access-Control-Allow-Origin', value: '*' },
+    ],
   });
 });

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryPassthru.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryPassthru.ts
@@ -1,9 +1,10 @@
 import { CloudFrontRequestEvent, Context } from 'aws-lambda';
 import { CloudFrontRequest } from 'aws-lambda/common/cloudfront';
+import { wellcomeCollectionRedirect } from './redirectHelpers';
 import { redirectToRoot } from './redirectToRoot';
 
 // This lambda is intended to be added to the default behaviour in CloudFront
-// If there are no behaviour matches then simply pass through to wellcomelibrary.org
+// If there are no behaviour matches then simply pass through to wellcomecollection.org
 export const requestHandler = async (
   event: CloudFrontRequestEvent,
   _: Context
@@ -15,7 +16,5 @@ export const requestHandler = async (
     return rootRedirect;
   }
 
-  request.headers.host = [{ key: 'host', value: 'wellcomelibrary.org' }];
-
-  return request;
+  return wellcomeCollectionRedirect('/');
 };

--- a/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
@@ -212,6 +212,18 @@ const collectionBrowseTestSet = {
   checkResponse: checkMatchingUrl,
 };
 
+const passthruTestSet = {
+  displayName: 'Passthru pages',
+  fileLocation: 'passthruRedirects.csv',
+  fileHostPrefix: 'wellcomelibrary.org',
+  headers: ['sourceUrl', 'targetUrl'],
+  envs: {
+    stage: 'https://stage.wellcomelibrary.org',
+    prod: 'https://wellcomelibrary.org',
+  },
+  checkResponse: checkMatchingUrl,
+};
+
 const testSets: RedirectTestSet[] = [
   apiTestSet,
   itemTestSet,
@@ -219,6 +231,7 @@ const testSets: RedirectTestSet[] = [
   apexTestSet,
   archiveTestSet,
   collectionBrowseTestSet,
+  passthruTestSet,
 ];
 
 const runTests = async (envId: EnvId) => {


### PR DESCRIPTION
## What's changing and why?
Anything that passes though from wl.org will be redirected to wc.org. This will allow us to decommission the esrvers serving the apex domain.

This was the least amount of change to get what we want. There will be further tidy up PRs as with any far reaching redirect.

## `terraform plan` diff
no-op until lambdas are buildt
