### PR TITLE
Revert "redirect passthru redirects to wellcomecollection.org"

### DIFF
--- a/cloudfront/wellcomelibrary.org/edge-lambda/passthruRedirects.csv
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/passthruRedirects.csv
@@ -1,2 +1,0 @@
-sourceUrl, targetUrl
-wellcomelibrary.org/link/to/nowhere,https://wellcomecollection.org/

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryPassthru.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryPassthru.test.ts
@@ -34,19 +34,14 @@ test('http requests are redirected to https', () => {
   );
 });
 
-test('redirects wellcomelibrary.org passthrus to wellcomecollection.org', async () => {
-  const request = testRequest('/unknown', undefined, {
+test('rewrites the host header if it exists', async () => {
+  const request = testRequest('/', undefined, {
     host: [{ key: 'host', value: 'www.wellcomelibrary.org' }],
   });
 
   const originRequest = await origin.requestHandler(request, {} as Context);
 
   expect(originRequest.headers).toStrictEqual({
-    location: [{ key: 'Location', value: 'https://wellcomecollection.org/' }],
-    'access-control-allow-origin': [
-      { key: 'Access-Control-Allow-Origin', value: '*' },
-    ],
+    host: [{ key: 'host', value: 'wellcomelibrary.org' }],
   });
-
-  expect(originRequest.status).toEqual('302');
 });

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryPassthru.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryPassthru.ts
@@ -1,10 +1,9 @@
 import { CloudFrontRequestEvent, Context } from 'aws-lambda';
 import { CloudFrontRequest } from 'aws-lambda/common/cloudfront';
-import { wellcomeCollectionRedirect } from './redirectHelpers';
 import { redirectToRoot } from './redirectToRoot';
 
 // This lambda is intended to be added to the default behaviour in CloudFront
-// If there are no behaviour matches then simply pass through to wellcomecollection.org
+// If there are no behaviour matches then simply pass through to wellcomelibrary.org
 export const requestHandler = async (
   event: CloudFrontRequestEvent,
   _: Context
@@ -16,5 +15,7 @@ export const requestHandler = async (
     return rootRedirect;
   }
 
-  return wellcomeCollectionRedirect('/');
+  request.headers.host = [{ key: 'host', value: 'wellcomelibrary.org' }];
+
+  return request;
 };

--- a/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
@@ -212,18 +212,6 @@ const collectionBrowseTestSet = {
   checkResponse: checkMatchingUrl,
 };
 
-const passthruTestSet = {
-  displayName: 'Passthru pages',
-  fileLocation: 'passthruRedirects.csv',
-  fileHostPrefix: 'wellcomelibrary.org',
-  headers: ['sourceUrl', 'targetUrl'],
-  envs: {
-    stage: 'https://stage.wellcomelibrary.org',
-    prod: 'https://wellcomelibrary.org',
-  },
-  checkResponse: checkMatchingUrl,
-};
-
 const testSets: RedirectTestSet[] = [
   apiTestSet,
   itemTestSet,
@@ -231,7 +219,6 @@ const testSets: RedirectTestSet[] = [
   apexTestSet,
   archiveTestSet,
   collectionBrowseTestSet,
-  passthruTestSet,
 ];
 
 const runTests = async (envId: EnvId) => {


### PR DESCRIPTION
I've misunderstood what goes where. 

The passthru was used by [behaviours](https://github.com/wellcomecollection/platform-infrastructure/blob/main/cloudfront/wellcomelibrary.org/terraform/cf_behaviours.tf#L2) that we wanted to passthru to wl.org. We no longer use them and should remove them.

This just get's us back into a state that we were previously, as this code should passthru to wl.org.