### PR TITLE
redirect apex domain to wc.org

### DIFF
--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.ts
@@ -96,9 +96,6 @@ export const requestHandler = async (
     return requestRedirect;
   }
 
-  // If we've matched nothing so far then set the host header for Wellcome Library
-  // In future we may want to redirect to wellcomecollection.org if we find no match
-  request.headers.host = [{ key: 'host', value: 'wellcomelibrary.org' }];
-
-  return request;
+  // If we've matched nothing we redirect to wellcomecollection.org
+  return wellcomeCollectionRedirect('/');
 };

--- a/cloudfront/wellcomelibrary.org/edge-lambda/staticRedirects.csv
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/staticRedirects.csv
@@ -269,3 +269,4 @@ Wellcome Library [home],wellcomelibrary.org/,https://wellcomecollection.org/,Col
 databases a-z,wellcomelibrary.org/using-the-library/how-to/databases-a-z/,https://wellcomecollection.org/pages/YDaP2BMAACUAT7DS#databases-only-accessible-in-the-library,Databases ,Using the Library
 printed catalogues,wellcomelibrary.org/using-the-library/how-to/printed-catalogues/,https://wellcomecollection.org/collections,Collections section,Using the Library
 searching archives and manuscripts,wellcomelibrary.org/using-the-library/how-to/searching-archives-and-manuscripts/,https://wellcomecollection.org/collections,Collections section,Using the Library
+404,wellcomelibrary.org/nothing/to-see/here,https://wellcomecollection.org/,Homepage,Homepage


### PR DESCRIPTION
## What's changing and why?
Redirects all uncaught URLs on the apex domain and redirects them to wellcomecollection.org

## `terraform plan` diff
No-op until the lambdas are deployed.
