### PR TITLE
bump tf redirect lambda

### DIFF
--- a/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
@@ -191,7 +191,7 @@ const apexTestSet = {
 const archiveTestSet = {
   displayName: 'Archive search',
   fileLocation: 'archiveRedirects.csv',
-  fileHostPrefix: 'archive.wellcomecollection.org',
+  fileHostPrefix: 'archives.wellcomelibrary.org',
   headers: ['sourceUrl', 'targetUrl'],
   envs: {
     stage: 'https://archives.stage.wellcomelibrary.org',

--- a/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
@@ -182,8 +182,8 @@ const apexTestSet = {
   fileHostPrefix: staticRedirectsHost,
   headers: staticRedirectHeaders,
   envs: {
-    stage: 'https://blog.stage.wellcomelibrary.org/',
-    prod: 'https://blog.wellcomelibrary.org/',
+    stage: 'https://stage.wellcomelibrary.org/',
+    prod: 'https://wellcomelibrary.org/',
   },
   checkResponse: checkMatchingUrl,
 };

--- a/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
@@ -170,8 +170,8 @@ const blogTestSet = {
   fileHostPrefix: 'blog.wellcomelibrary.org',
   headers: ['sourceUrl', 'targetUrl'],
   envs: {
-    stage: 'https://blog.stage.wellcomelibrary.org/',
-    prod: 'https://blog.wellcomelibrary.org/',
+    stage: 'https://blog.stage.wellcomelibrary.org',
+    prod: 'https://blog.wellcomelibrary.org',
   },
   checkResponse: checkMatchingBlogUrl,
 };
@@ -182,8 +182,8 @@ const apexTestSet = {
   fileHostPrefix: staticRedirectsHost,
   headers: staticRedirectHeaders,
   envs: {
-    stage: 'https://stage.wellcomelibrary.org/',
-    prod: 'https://wellcomelibrary.org/',
+    stage: 'https://stage.wellcomelibrary.org',
+    prod: 'https://wellcomelibrary.org',
   },
   checkResponse: checkMatchingUrl,
 };

--- a/cloudfront/wellcomelibrary.org/terraform/locals.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/locals.tf
@@ -4,7 +4,7 @@ locals {
   wellcome_library_redirect_arn_latest = "${local.wellcome_library_redirect_arn}:${local.wellcome_library_redirect_latest}"
   wellcome_library_redirect_arn_stage  = local.wellcome_library_redirect_arn_latest
   # This should be set manually when a stable prod deploy is established.
-  wellcome_library_redirect_arn_prod = "${local.wellcome_library_redirect_arn}:73"
+  wellcome_library_redirect_arn_prod = "${local.wellcome_library_redirect_arn}:76"
 
   wellcome_library_passthru_arn        = aws_lambda_function.wellcome_library_passthru.arn
   wellcome_library_passthru_latest     = aws_lambda_function.wellcome_library_passthru.version


### PR DESCRIPTION
## What's changing and why?
Bumps the redirect lambda

YOu can see a change here: stage.wellcomelibrary.org/things/not-here

## `terraform plan` diff
```
# module.wellcomelibrary-prod.aws_cloudfront_distribution.distro will be updated in-place
  ~ resource "aws_cloudfront_distribution" "distro" {
        id                             = "EHUBCZTWBQL8L"
        tags                           = {
            "Managed" = "terraform"
        }
        # (17 unchanged attributes hidden)

      ~ default_cache_behavior {
            # (10 unchanged attributes hidden)


          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:760097843905:function:cf_edge_wellcome_library_redirect:73" -> null
            }
          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = "arn:aws:lambda:us-east-1:760097843905:function:cf_edge_wellcome_library_redirect:76"
            }
            # (1 unchanged block hidden)
        }




        # (10 unchanged blocks hidden)
    }
```