### PR TITLE
Allow CI to publish Scala libraries to the weco namesapce

### DIFF
--- a/accounts/platform/iam_platform_ci.tf
+++ b/accounts/platform/iam_platform_ci.tf
@@ -27,10 +27,10 @@ data "aws_iam_policy_document" "platform_ci" {
     ]
 
     resources = [
-      "arn:aws:s3:::releases.mvn-repo.wellcomecollection.org/uk/ac/wellcome/internal_model_2.12/*",
-      "arn:aws:s3:::releases.mvn-repo.wellcomecollection.org/uk/ac/wellcome/internal_model_typesafe_2.12/*",
-      "arn:aws:s3:::releases.mvn-repo.wellcomecollection.org/uk/ac/wellcome/source_model_2.12/*",
-      "arn:aws:s3:::releases.mvn-repo.wellcomecollection.org/uk/ac/wellcome/source_model_typesafe_2.12/*",
+      "arn:aws:s3:::releases.mvn-repo.wellcomecollection.org/weco/internal_model_2.12/*",
+      "arn:aws:s3:::releases.mvn-repo.wellcomecollection.org/weco/internal_model_typesafe_2.12/*",
+      "arn:aws:s3:::releases.mvn-repo.wellcomecollection.org/weco/source_model_2.12/*",
+      "arn:aws:s3:::releases.mvn-repo.wellcomecollection.org/weco/source_model_typesafe_2.12/*",
     ]
   }
 

--- a/builds/terraform/buildkite.tf
+++ b/builds/terraform/buildkite.tf
@@ -135,7 +135,7 @@ data "aws_iam_policy_document" "ci_permissions" {
       resources = [
         "${aws_s3_bucket.releases.arn}/uk/ac/wellcome/${statement.value}_2.12/*",
         "${aws_s3_bucket.releases.arn}/uk/ac/wellcome/${statement.value}_typesafe_2.12/*",
-        
+
         "${aws_s3_bucket.releases.arn}/weco/${statement.value}_2.12/*",
         "${aws_s3_bucket.releases.arn}/weco/${statement.value}_typesafe_2.12/*",
       ]

--- a/builds/terraform/buildkite.tf
+++ b/builds/terraform/buildkite.tf
@@ -135,6 +135,9 @@ data "aws_iam_policy_document" "ci_permissions" {
       resources = [
         "${aws_s3_bucket.releases.arn}/uk/ac/wellcome/${statement.value}_2.12/*",
         "${aws_s3_bucket.releases.arn}/uk/ac/wellcome/${statement.value}_typesafe_2.12/*",
+        
+        "${aws_s3_bucket.releases.arn}/weco/${statement.value}_2.12/*",
+        "${aws_s3_bucket.releases.arn}/weco/${statement.value}_typesafe_2.12/*",
       ]
     }
   }


### PR DESCRIPTION
## What's changing and why?

Allowing BuildKite to publish to `weco` instead of `uk/ac/wellcome`. For wellcomecollection/platform#4690

## `terraform plan` diff
<!-- Please make sure you don't paste anything secure that shouldn't be shared here -->
