### PR TITLE
Allow CI to get auth for ECR Public

### DIFF
--- a/accounts/modules/role_policies/ci/policies.tf
+++ b/accounts/modules/role_policies/ci/policies.tf
@@ -25,6 +25,9 @@ data "aws_iam_policy_document" "ci_permissions" {
       "ecr-public:CompleteLayerUpload",
       # This is required for uploading to public repositories; see https://docs.aws.amazon.com/AmazonECR/latest/public/public-repository-policy-examples.html
       "sts:GetServiceBearerToken",
+      # We need this to use "aws ecr-public get-login-password" when uploading
+      # ECR Public images from CI.
+      "ecr-public:GetAuthorizationToken",
     ]
 
     resources = [


### PR DESCRIPTION
## What's changing and why?

We need to run `aws ecr-public get-login-password` in CI so we can publish images to ECR Public. This extends that permission to all CI accounts. For https://github.com/wellcomecollection/platform/issues/5226

## `terraform plan` diff

Here's an example plan:

```
Terraform will perform the following actions:

  # module.catalogue_account.module.ci_role_policy.aws_iam_role_policy.ci_permissions will be updated in-place
  ~ resource "aws_iam_role_policy" "ci_permissions" {
        id     = "catalogue-ci:terraform-20200713113726102900000001"
        name   = "terraform-20200713113726102900000001"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Action   = [
                            # (15 unchanged elements hidden)
                            "ecr-public:InitiateLayerUpload",
                          + "ecr-public:GetAuthorizationToken",
                            "ecr-public:Get*",
                            # (3 unchanged elements hidden)
                        ]
                        # (3 unchanged elements hidden)
                    },
                    {
                        Action   = "s3:*"
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:s3:::wellcomecollection-catalogue-infra-delta/*",
                            "arn:aws:s3:::wellcomecollection-catalogue-infra-delta",
                        ]
                        Sid      = ""
                    },
                    # (7 unchanged elements hidden)
                ]
                # (1 unchanged element hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
