### PR TITLE
Mirror the java11 Docker image into our ECR repositories

### DIFF
--- a/images/publish_mirrored_images.py
+++ b/images/publish_mirrored_images.py
@@ -47,6 +47,7 @@ IMAGE_TAGS = [
     "localstack/localstack:0.10.5",
     "node:12.18.3",
     "node:14.14.0",
+    "openjdk:11",
     "peopleperhour/dynamodb",
     "python:3.7",
     "python:3.7-alpine",

--- a/images/terraform/ecr.tf
+++ b/images/terraform/ecr.tf
@@ -75,10 +75,10 @@ locals {
   mirrored_images = [
     "amazon/aws-cli",
     "hashicorp/terraform",
-    "java11",
     "localstack/localstack",
     "nginx",
     "node",
+    "openjdk",
     "peopleperhour/dynamodb",
     "python",
     "rodolpheche/wiremock",

--- a/images/terraform/ecr.tf
+++ b/images/terraform/ecr.tf
@@ -75,6 +75,7 @@ locals {
   mirrored_images = [
     "amazon/aws-cli",
     "hashicorp/terraform",
+    "java11",
     "localstack/localstack",
     "nginx",
     "node",

--- a/images/terraform/repo_pair/main.tf
+++ b/images/terraform/repo_pair/main.tf
@@ -9,6 +9,6 @@ resource "aws_ecrpublic_repository" "public" {
 
   catalog_data {
     about_text      = var.description
-    logo_image_blob = filebase64("weco.png")
+    logo_image_blob = filebase64("${path.module}/weco.png")
   }
 }


### PR DESCRIPTION
This is part of some work to expunge the typesafe_config_base container: https://github.com/wellcomecollection/platform/issues/4619