### PR TITLE
use identifier search over free text search

### DIFF
--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.ts
@@ -36,7 +36,7 @@ export async function* apiQuery(
   query: string
 ): AsyncGenerator<Work, void, void> {
   const url = `${apiBasePath}/works`;
-  const queryUrl = `${url}?include=identifiers&query=${query}`;
+  const queryUrl = `${url}?include=identifiers&pageSize=100&identifiers=${query}`;
 
   const apiResult = await axios.get(queryUrl);
   const resultList = apiResult.data as CatalogueResultsList;


### PR DESCRIPTION
## What's changing and why?
We are currently seeing lambdas@edge running for more than 3 seconds, thus 503ing to users.

The place where most the time is spent in the lamda is queries with loads of results that [we paginate through all the results](https://github.com/wellcomecollection/platform-infrastructure/blob/main/cloudfront/wellcomelibrary.org/edge-lambda/src/catalogueApi.ts#L66) searching for an ID.

This PR minimises the amount of time spent in a lambda by
* Only search the identifiers field, so queries like `MS 542` [return 0 results](https://api.wellcomecollection.org/catalogue/v2/works?include=identifiers&pageSize=100&identifiers=MS%20542) rather [than hundreds](https://api.wellcomecollection.org/catalogue/v2/works?include=identifiers&pageSize=100&query=MS%20542), and we still have the [ID search work](https://api.wellcomecollection.org/catalogue/v2/works?include=identifiers&pageSize=100&identifiers=MS.542)
* bump the page size on the odd chance there is loads to spend less time networking.

## `terraform plan` diff
No-op until we need to deploy it to prod.
