### PR TITLE
bump prod archive lambda

### DIFF
--- a/cloudfront/wellcomelibrary.org/terraform/locals.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/locals.tf
@@ -25,7 +25,7 @@ locals {
   wellcome_library_archive_redirect_arn_latest = "${local.wellcome_library_archive_redirect_arn}:${local.wellcome_library_archive_redirect_latest}"
   wellcome_library_archive_redirect_arn_stage  = local.wellcome_library_archive_redirect_arn_latest
   # This should be set manually when a stable prod deploy is established.
-  wellcome_library_archive_redirect_arn_prod = "${local.wellcome_library_archive_redirect_arn}:22"
+  wellcome_library_archive_redirect_arn_prod = "${local.wellcome_library_archive_redirect_arn}:27"
 
   wellcome_library_encore_redirect_arn        = aws_lambda_function.wellcome_library_encore_redirect.arn
   wellcome_library_encore_redirect_latest     = aws_lambda_function.wellcome_library_encore_redirect.version


### PR DESCRIPTION
## What's changing and why?
[This is working](https://archives.stage.wellcomelibrary.org/DServe/dserve.exe?dsqIni=Dserve.ini&dsqApp=Archive&dsqCmd=Show.tcl&dsqDb=Catalog&dsqPos=0&dsqSearch=((AltRefNo=%27MS%27)AND(AltRefNo=%27542%27))), so we're deploying it.

## `terraform plan` diff
```
# module.wellcomelibrary_dserve-prod.aws_cloudfront_distribution.distro will be updated in-place
  ~ resource "aws_cloudfront_distribution" "distro" {
        id                             = "E2ECIIHB6JOYND"
        tags                           = {
            "Managed" = "terraform"
        }
        # (17 unchanged attributes hidden)

      ~ default_cache_behavior {
            # (10 unchanged attributes hidden)


          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:760097843905:function:cf_edge_wellcome_library_archive_redirect:22" -> null
            }
          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = "arn:aws:lambda:us-east-1:760097843905:function:cf_edge_wellcome_library_archive_redirect:27"
            }
            # (1 unchanged block hidden)
        }



        # (3 unchanged blocks hidden)
    }
```
