### PR TITLE
bump ec provisioner and es version on logging cluster

### DIFF
--- a/critical/elastic_logging_cluster.tf
+++ b/critical/elastic_logging_cluster.tf
@@ -63,7 +63,7 @@ resource "ec_deployment" "logging" {
   name = "logging"
 
   region                 = "eu-west-1"
-  version                = "7.11.2"
+  version                = "7.13.3"
   deployment_template_id = "aws-io-optimized-v2"
 
   traffic_filter = [

--- a/critical/terraform.tf
+++ b/critical/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.1.1"
+      version = "0.2.1"
     }
   }
 


### PR DESCRIPTION
## What's changing and why?
Updates the logging clusters terraform provisioner, and elastic version.

The interface is nicer for kibana and a few changes have been made to kibana alerting, and I'd rather be working to the latest than having to update later.

## `terraform plan` diff
<!-- Please make sure you don't paste anything secure that shouldn't be shared here -->
```
# ec_deployment.logging will be updated in-place
  ~ resource "ec_deployment" "logging" {
        id                     = "f4c9aca09347dad4c05f35cfbec04cdb"
        name                   = "logging"
      ~ version                = "7.11.2" -> "7.13.3"
        # (6 unchanged attributes hidden)



        # (3 unchanged blocks hidden)
    }
```