### PR TITLE
Remove the mirrored Wiremock ECR repository

### DIFF
--- a/images/publish_mirrored_images.py
+++ b/images/publish_mirrored_images.py
@@ -52,7 +52,6 @@ IMAGE_TAGS = [
     "python:3.7-alpine",
     "python:3.7-slim",
     "python:3.8.3",
-    "rodolpheche/wiremock",
     "scality/s3server:mem-latest",
     "s12v/elasticmq",
     "wellcome/build_test_python",

--- a/images/terraform/ecr.tf
+++ b/images/terraform/ecr.tf
@@ -80,7 +80,6 @@ locals {
     "node",
     "peopleperhour/dynamodb",
     "python",
-    "rodolpheche/wiremock",
     "s12v/elasticmq",
     "scality/s3server",
     "wellcome/build_test_python",

--- a/images/terraform/ecr.tf
+++ b/images/terraform/ecr.tf
@@ -78,6 +78,7 @@ locals {
     "localstack/localstack",
     "nginx",
     "node",
+    "openjdk",
     "peopleperhour/dynamodb",
     "python",
     "s12v/elasticmq",

--- a/images/terraform/repo_pair/main.tf
+++ b/images/terraform/repo_pair/main.tf
@@ -9,6 +9,6 @@ resource "aws_ecrpublic_repository" "public" {
 
   catalog_data {
     about_text      = var.description
-    logo_image_blob = filebase64("weco.png")
+    logo_image_blob = filebase64("${path.module}/weco.png")
   }
 }


### PR DESCRIPTION
## What's changing and why?

I'm binning the mirrored ECR Wiremock repository to closed https://github.com/wellcomecollection/platform/issues/5192, because we no longer use Wiremock in our tests.

## `terraform plan` diff

```
Terraform will perform the following actions:

  # aws_ecr_repository.mirrored_images["rodolpheche/wiremock"] will be destroyed
  - resource "aws_ecr_repository" "mirrored_images" {
      - arn                  = "arn:aws:ecr:eu-west-1:760097843905:repository/rodolpheche/wiremock" -> null
      - id                   = "rodolpheche/wiremock" -> null
      - image_tag_mutability = "MUTABLE" -> null
      - name                 = "rodolpheche/wiremock" -> null
      - registry_id          = "760097843905" -> null
      - repository_url       = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/rodolpheche/wiremock" -> null
      - tags                 = {} -> null
      - tags_all             = {} -> null

      - encryption_configuration {
          - encryption_type = "AES256" -> null
        }

      - image_scanning_configuration {
          - scan_on_push = false -> null
        }

      - timeouts {}
    }

  # module.mirrored_images_policy["rodolpheche/wiremock"].aws_ecr_repository_policy.cross_account_policy will be destroyed
  - resource "aws_ecr_repository_policy" "cross_account_policy" {
      - id          = "rodolpheche/wiremock" -> null
      - policy      = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = [
                          - "ecr:GetDownloadUrlForLayer",
                          - "ecr:BatchGetImage",
                          - "ecr:BatchCheckLayerAvailability",
                        ]
                      - Effect    = "Allow"
                      - Principal = {
                          - AWS = [
                              - "arn:aws:iam::760097843905:root",
                              - "arn:aws:iam::756629837203:root",
                              - "arn:aws:iam::653428163053:root",
                              - "arn:aws:iam::975596993436:root",
                              - "arn:aws:iam::130871440101:root",
                              - "arn:aws:iam::770700576653:root",
                              - "arn:aws:iam::299497370133:root",
                            ]
                        }
                      - Sid       = ""
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - registry_id = "760097843905" -> null
      - repository  = "rodolpheche/wiremock" -> null
    }

Plan: 0 to add, 0 to change, 2 to destroy.
```

This change is already applied.