### PR TITLE
Enable Elastic APM RUM

### DIFF
--- a/critical/.terraform.lock.hcl
+++ b/critical/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/elastic/ec" {
   version     = "0.1.0-beta"
-  constraints = "0.1.0-beta, 0.1.1"
+  constraints = "0.1.0-beta, 0.2.1"
   hashes = [
     "h1:FeIlgFFtDoVwNJ5sIBWCmuURRopyXXX9DqC7s0AwubQ=",
     "zh:091d59c4ea25a8f9ea4046c7b1eee2fbe9fe107d715b060f2659cf7aebd6d437",

--- a/critical/elastic_logging_cluster.tf
+++ b/critical/elastic_logging_cluster.tf
@@ -52,6 +52,14 @@ locals {
       }
     }
   }
+
+  logging_apm_user_settings = {
+    "apm-server" : {
+      rum : {
+        enabled : true
+      }
+    }
+  }
 }
 
 # IMPORTANT: When deploying fresh you will need to set the following key in Elasticsearch keystore:
@@ -106,6 +114,10 @@ resource "ec_deployment" "logging" {
       size       = "0.5g"
       zone_count = 1
     }
+
+    config {
+      user_settings_yaml = yamlencode(local.logging_apm_user_settings)
+    }
   }
 }
 
@@ -126,7 +138,7 @@ locals {
 }
 
 module "host_secrets" {
-  source = "./modules/secrets/secret"
+  source = "github.com/wellcomecollection/terraform-aws-secrets.git?ref=v1.3.0"
 
   key_value_map = {
     "elasticsearch/logging/username"        = local.logging_elastic_username

--- a/critical/elastic_logging_cluster.tf
+++ b/critical/elastic_logging_cluster.tf
@@ -55,6 +55,7 @@ locals {
 
   logging_apm_user_settings = {
     "apm-server" : {
+      # RUM = Real-User Monitoring
       rum : {
         enabled : true
       }


### PR DESCRIPTION
## What's changing and why?

Real User Monitoring support is not enabled by default in APM - this flicks the switch.

## `terraform plan` diff
```
# ec_deployment.logging will be updated in-place
  ~ resource "ec_deployment" "logging" {
        id                     = "f4c9aca09347dad4c05f35cfbec04cdb"
        name                   = "logging"
        # (7 unchanged attributes hidden)

      ~ apm {
            # (7 unchanged attributes hidden)

          + config {
              + debug_enabled      = false
              + user_settings_yaml = <<-EOT
                    "apm-server":
                      "rum":
                        "enabled": true
                EOT
            }

            # (1 unchanged block hidden)
        }


        # (2 unchanged blocks hidden)
    }
```
