### PR TITLE
Increase client_max_body_size for experience nginx

### DIFF
--- a/images/nginx/experience.nginx.conf
+++ b/images/nginx/experience.nginx.conf
@@ -12,6 +12,8 @@ http {
     gzip_min_length 860;
     gzip_proxied    any;
     
+    # This has been increased from the 1m default to accommodate
+    # large requests to the Lighthouse CI server
     client_max_body_size 2m;
 
     location / {

--- a/images/nginx/experience.nginx.conf
+++ b/images/nginx/experience.nginx.conf
@@ -11,6 +11,8 @@ http {
     gzip_types      text/css application/javascript application/json;
     gzip_min_length 860;
     gzip_proxied    any;
+    
+    client_max_body_size 2m;
 
     location / {
       proxy_set_header Host $host;


### PR DESCRIPTION
This is necessary for the Lighthouse server, which sometimes receives requests that are slightly larger than 1m (the default)