### PR TITLE
Update identity-ci permissions to deploy universal-login

### DIFF
--- a/accounts/identity/iam_identity_ci.tf
+++ b/accounts/identity/iam_identity_ci.tf
@@ -109,6 +109,7 @@ data "aws_iam_policy_document" "identity_ci" {
 
     resources = [
       "${local.secrets_base_arn}identity/stage/account_management_system/api_key*",
+      "${local.secrets_base_arn}identity/stage/buildkite/credentials*",
       "${local.secrets_base_arn}identity/stage/smoke_test/credentials*",
       "${local.secrets_base_arn}identity/prod/account_management_system/api_key*",
       "${local.secrets_base_arn}identity/prod/smoke_test/credentials*",

--- a/accounts/identity/iam_identity_ci.tf
+++ b/accounts/identity/iam_identity_ci.tf
@@ -119,7 +119,7 @@ data "aws_iam_policy_document" "identity_ci" {
 
   statement {
     actions = [
-      "ssm:GetParameters",
+      "ssm:GetParameter",
     ]
 
     resources = [

--- a/accounts/identity/iam_identity_ci.tf
+++ b/accounts/identity/iam_identity_ci.tf
@@ -112,7 +112,19 @@ data "aws_iam_policy_document" "identity_ci" {
       "${local.secrets_base_arn}identity/stage/buildkite/credentials*",
       "${local.secrets_base_arn}identity/stage/smoke_test/credentials*",
       "${local.secrets_base_arn}identity/prod/account_management_system/api_key*",
+      "${local.secrets_base_arn}identity/prod/buildkite/credentials*",
       "${local.secrets_base_arn}identity/prod/smoke_test/credentials*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ssm:GetParameters",
+    ]
+
+    resources = [
+      "${local.ssm_param_base_arn}identity-auth0_domain-stage",
+      "${local.ssm_param_base_arn}identity-auth0_domain-prod",
     ]
   }
 

--- a/accounts/identity/locals.tf
+++ b/accounts/identity/locals.tf
@@ -6,7 +6,8 @@ locals {
 
   aws_region = "eu-west-1"
 
-  secrets_base_arn = "arn:aws:secretsmanager:${local.aws_region}:${local.account_ids["identity"]}:secret:"
+  secrets_base_arn   = "arn:aws:secretsmanager:${local.aws_region}:${local.account_ids["identity"]}:secret:"
+  ssm_param_base_arn = "arn:aws:ssm:${local.aws_region}:${local.account_ids["identity"]}:parameter/"
 
   account_principals = { for key, value in local.account_ids : key => "arn:aws:iam::${value}:root" }
 }


### PR DESCRIPTION
## What's changing and why?

In order to easily deploy changes the Auth0 universal-login interface, this change adds permissions for identity-ci to deploy universal-login.

**Note:** this is applied