### PR TITLE
Shared secrets for APM params

### DIFF
--- a/critical/elastic_logging_cluster.tf
+++ b/critical/elastic_logging_cluster.tf
@@ -151,7 +151,7 @@ module "host_secrets" {
     "elasticsearch/logging/private_host"    = local.logging_private_host
     "elasticsearch/logging/kibana_endpoint" = local.logging_kibana_endpoint
     "elasticsearch/logging/apm_server_url"  = local.logging_apm_server_url
-    "elasticsearch/logging/apm_secret"      = local.logging_apm_server_url
+    "elasticsearch/logging/apm_secret"      = local.logging_apm_secret
 
     # Duplicated as this is what consumers currently expect
     # The above naming scheme is common to our other ES setups

--- a/critical/elastic_logging_cluster.tf
+++ b/critical/elastic_logging_cluster.tf
@@ -136,6 +136,9 @@ locals {
   # See https://www.elastic.co/guide/en/cloud/current/ec-traffic-filtering-vpc.html
   logging_private_host = "${local.logging_elastic_id}.vpce.${local.logging_elastic_region}.aws.elastic-cloud.com"
   logging_public_host  = "${local.logging_elastic_id}.${local.logging_elastic_region}.aws.found.io"
+
+  logging_apm_server_url = ec_deployment.logging.apm[0].https_endpoint
+  logging_apm_secret     = ec_deployment.logging.apm_secret_token
 }
 
 module "host_secrets" {
@@ -147,6 +150,8 @@ module "host_secrets" {
     "elasticsearch/logging/public_host"     = local.logging_public_host
     "elasticsearch/logging/private_host"    = local.logging_private_host
     "elasticsearch/logging/kibana_endpoint" = local.logging_kibana_endpoint
+    "elasticsearch/logging/apm_server_url"  = local.logging_apm_server_url
+    "elasticsearch/logging/apm_secret"      = local.logging_apm_server_url
 
     # Duplicated as this is what consumers currently expect
     # The above naming scheme is common to our other ES setups

--- a/critical/outputs.tf
+++ b/critical/outputs.tf
@@ -119,6 +119,10 @@ output "shared_secrets_logging" {
   value = local.logging_secrets
 }
 
+output "shared_secrets_apm" {
+  value = local.apm_secrets
+}
+
 # Elastic Cloud
 
 output "ec_public_internet_traffic_filter_id" {

--- a/critical/secrets.tf
+++ b/critical/secrets.tf
@@ -5,9 +5,14 @@ locals {
     ES_HOST         = "shared/logging/es_host"
     ES_PORT         = "shared/logging/es_port"
     ES_HOST_PRIVATE = "shared/logging/es_host_private"
-    APM_SERVER_URL  = "elasticsearch/logging/apm_server_url"
-    APM_SECRET      = "elasticsearch/logging/apm_secret"
   }
+
+  apm_secrets = {
+    APM_SERVER_URL = "elasticsearch/logging/apm_server_url"
+    APM_SECRET     = "elasticsearch/logging/apm_secret"
+  }
+
+  shared_secrets = merge(local.logging_secrets, local.apm_secrets)
 }
 
 module "storage_logging_secrets" {
@@ -17,7 +22,7 @@ module "storage_logging_secrets" {
     aws = aws.storage
   }
 
-  secrets = local.logging_secrets
+  secrets = local.shared_secrets
 }
 
 module "catalogue_logging_secrets" {
@@ -27,7 +32,7 @@ module "catalogue_logging_secrets" {
     aws = aws.catalogue
   }
 
-  secrets = local.logging_secrets
+  secrets = local.shared_secrets
 }
 
 module "experience_logging_secrets" {
@@ -37,7 +42,7 @@ module "experience_logging_secrets" {
     aws = aws.experience
   }
 
-  secrets = local.logging_secrets
+  secrets = local.shared_secrets
 }
 
 module "workflow_logging_secrets" {
@@ -47,7 +52,7 @@ module "workflow_logging_secrets" {
     aws = aws.workflow
   }
 
-  secrets = local.logging_secrets
+  secrets = local.shared_secrets
 }
 
 module "digirati_logging_secrets" {
@@ -57,7 +62,7 @@ module "digirati_logging_secrets" {
     aws = aws.digirati
   }
 
-  secrets = local.logging_secrets
+  secrets = local.shared_secrets
 }
 
 module "identity_logging_secrets" {
@@ -67,5 +72,5 @@ module "identity_logging_secrets" {
     aws = aws.identity
   }
 
-  secrets = local.logging_secrets
+  secrets = local.shared_secrets
 }

--- a/critical/secrets.tf
+++ b/critical/secrets.tf
@@ -5,6 +5,8 @@ locals {
     ES_HOST         = "shared/logging/es_host"
     ES_PORT         = "shared/logging/es_port"
     ES_HOST_PRIVATE = "shared/logging/es_host_private"
+    APM_SERVER_URL  = "elasticsearch/logging/apm_server_url"
+    APM_SECRET      = "elasticsearch/logging/apm_secret"
   }
 }
 


### PR DESCRIPTION
This exposes the APM server URL and secret token using the existing mechanisms for shared secrets

## `terraform plan` diff

Note: this plan does not include the shared secrets (ie using `modules/secrets/distributed`) because they are dependent on the initial secrets.


```
  # module.host_secrets.aws_secretsmanager_secret.secret["elasticsearch/logging/apm_secret"] will be created
  + resource "aws_secretsmanager_secret" "secret" {
      + arn                     = (known after apply)
      + id                      = (known after apply)
      + name                    = "elasticsearch/logging/apm_secret"
      + name_prefix             = (known after apply)
      + policy                  = (known after apply)
      + recovery_window_in_days = 30
      + rotation_enabled        = (known after apply)
      + rotation_lambda_arn     = (known after apply)
      + tags_all                = {
          + "TerraformConfigurationURL" = "https://github.com/wellcomecollection/platform-infrastructure/tree/main/critical"
        }

      + rotation_rules {
          + automatically_after_days = (known after apply)
        }
    }

  # module.host_secrets.aws_secretsmanager_secret.secret["elasticsearch/logging/apm_server_url"] will be created
  + resource "aws_secretsmanager_secret" "secret" {
      + arn                     = (known after apply)
      + id                      = (known after apply)
      + name                    = "elasticsearch/logging/apm_server_url"
      + name_prefix             = (known after apply)
      + policy                  = (known after apply)
      + recovery_window_in_days = 30
      + rotation_enabled        = (known after apply)
      + rotation_lambda_arn     = (known after apply)
      + tags_all                = {
          + "TerraformConfigurationURL" = "https://github.com/wellcomecollection/platform-infrastructure/tree/main/critical"
        }

      + rotation_rules {
          + automatically_after_days = (known after apply)
        }
    }

  # module.host_secrets.aws_secretsmanager_secret_version.secret["elasticsearch/logging/apm_secret"] will be created
  + resource "aws_secretsmanager_secret_version" "secret" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + secret_id      = (known after apply)
      + secret_string  = (sensitive value)
      + version_id     = (known after apply)
      + version_stages = (known after apply)
    }

  # module.host_secrets.aws_secretsmanager_secret_version.secret["elasticsearch/logging/apm_server_url"] will be created
  + resource "aws_secretsmanager_secret_version" "secret" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + secret_id      = (known after apply)
      + secret_string  = (sensitive value)
      + version_id     = (known after apply)
      + version_stages = (known after apply)
    }
```