### PR TITLE
Restrict identity access to platform-superdev

### DIFF
--- a/accounts/platform/rolesets.tf
+++ b/accounts/platform/rolesets.tf
@@ -139,7 +139,6 @@ module "dev_roleset" {
     aws_iam_role.s3_scala_releases_read.arn,
 
     # CI Roles
-    local.ci_agent_role_arn,
     module.aws_account.publisher_role_arn,
     module.aws_account.ci_role_arn,
     local.catalogue_account_roles["ci_role_arn"],

--- a/accounts/platform/rolesets.tf
+++ b/accounts/platform/rolesets.tf
@@ -331,11 +331,6 @@ module "digirati_dev_roleset" {
     local.digirati_account_roles["read_only_role_arn"],
     local.digirati_account_roles["ci_role_arn"],
 
-    # Identity
-    local.experience_account_roles["developer_role_arn"],
-    local.experience_account_roles["read_only_role_arn"],
-    local.experience_account_roles["ci_role_arn"],
-
     # Workflow
     local.workflow_account_roles["read_only_role_arn"],
 

--- a/accounts/platform/rolesets.tf
+++ b/accounts/platform/rolesets.tf
@@ -103,10 +103,6 @@ module "dev_roleset" {
     module.aws_account.developer_role_arn,
     module.aws_account.read_only_role_arn,
 
-    # Identity
-    local.identity_account_roles["developer_role_arn"],
-    local.identity_account_roles["read_only_role_arn"],
-
     # Digirati
     local.digirati_account_roles["developer_role_arn"],
     local.digirati_account_roles["read_only_role_arn"],
@@ -335,12 +331,6 @@ module "digirati_dev_roleset" {
     local.digirati_account_roles["developer_role_arn"],
     local.digirati_account_roles["read_only_role_arn"],
     local.digirati_account_roles["ci_role_arn"],
-
-    # Identity
-    local.identity_account_roles["admin_role_arn"],
-    local.identity_account_roles["developer_role_arn"],
-    local.identity_account_roles["read_only_role_arn"],
-    local.identity_account_roles["ci_role_arn"],
 
     # Identity
     local.experience_account_roles["developer_role_arn"],


### PR DESCRIPTION
## What's changing and why?

This change removes access to the Identity AWS account for "dev" roleset, and from Digirati developers.

## `terraform plan` diff

```
Terraform will perform the following actions:

  # module.dev_roleset.module.role_policy.aws_iam_role_policy.role_assumer will be updated in-place
  ~ resource "aws_iam_role_policy" "role_assumer" {
        id     = "platform-dev:terraform-20190701095808272400000001"
        name   = "terraform-20190701095808272400000001"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = [
                            # (5 unchanged elements hidden)
                            "arn:aws:iam::964279923020:role/data-ci",
                          - "arn:aws:iam::770700576653:role/identity-read_only",
                          - "arn:aws:iam::770700576653:role/identity-developer",
                            "arn:aws:iam::760097843905:role/terraform-20210811133135108800000001",
                            # (3 unchanged elements hidden)
                            "arn:aws:iam::760097843905:role/platform-ci",
                          - "arn:aws:iam::760097843905:role/ci-agent",
                            "arn:aws:iam::756629837203:role/catalogue-read_only",
                            # (17 unchanged elements hidden)
                        ]
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }

  # module.digirati_dev_roleset.module.role_policy.aws_iam_role_policy.role_assumer will be updated in-place
  ~ resource "aws_iam_role_policy" "role_assumer" {
        id     = "digirati-dev:terraform-20200629102952590300000001"
        name   = "terraform-20200629102952590300000001"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = [
                            "arn:aws:iam::975596993436:role/storage-read_only",
                          - "arn:aws:iam::770700576653:role/identity-read_only",
                          - "arn:aws:iam::770700576653:role/identity-developer",
                          - "arn:aws:iam::770700576653:role/identity-ci",
                          - "arn:aws:iam::770700576653:role/identity-admin",
                            "arn:aws:iam::760097843905:role/platform-read_only",
                            # (8 unchanged elements hidden)
                        ]
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```
