### PR TITLE
Create a Buildkite stack for "nano" jobs

### DIFF
--- a/builds/terraform/buildkite.tf
+++ b/builds/terraform/buildkite.tf
@@ -121,7 +121,6 @@ resource "aws_cloudformation_stack" "buildkite_nano" {
     CostAllocationTagName  = "aws:createdBy"
     CostAllocationTagValue = "buildkite-elasticstack"
 
-    BuildkiteQueue                                            = "default"
     BuildkiteAgentRelease                                     = "stable"
     BuildkiteAgentTimestampLines                              = false
     BuildkiteTerminateInstanceAfterJobDecreaseDesiredCapacity = true

--- a/builds/terraform/buildkite.tf
+++ b/builds/terraform/buildkite.tf
@@ -28,8 +28,6 @@ resource "aws_cloudformation_stack" "buildkite" {
     InstanceCreationTimeout = "PT5M"
     InstanceRoleName        = local.ci_agent_role_name
 
-    BuildkiteAgentTags = "queue=large"
-
     VpcId           = local.ci_vpc_id
     Subnets         = join(",", local.ci_vpc_private_subnets)
     SecurityGroupId = aws_security_group.buildkite.id
@@ -105,7 +103,7 @@ resource "aws_cloudformation_stack" "buildkite_nano" {
     AgentsPerInstance                         = 1
     BuildkiteTerminateInstanceAfterJobTimeout = 1800
 
-    RootVolumeSize = 150
+    RootVolumeSize = 25
     RootVolumeName = "/dev/xvda"
     RootVolumeType = "gp2"
 

--- a/builds/terraform/buildkite.tf
+++ b/builds/terraform/buildkite.tf
@@ -64,6 +64,82 @@ resource "aws_cloudformation_stack" "buildkite" {
   template_body = file("${path.module}/buildkite.yaml")
 }
 
+# This is a separate pool of Buildkite instances specifically meant
+# for long-running, low-compute tasks.
+#
+# e.g. waiting for a weco-deploy build to finish.
+#
+# I picked the name "nano" because they're a catchall group for any sort
+# of small task, rather than for a specific purpose.
+#
+resource "aws_cloudformation_stack" "buildkite_nano" {
+  name = "buildkite-elasticstack-nano"
+
+  capabilities = ["CAPABILITY_NAMED_IAM"]
+
+  parameters = {
+    MinSize = 0
+    MaxSize = 5
+
+    SpotPrice    = 0.01
+    InstanceType = "t3.nano"
+
+    BuildkiteAgentTags = "queue=nano"
+
+    BuildkiteAgentToken = data.aws_secretsmanager_secret_version.example.secret_string
+
+    ScaleDownPeriod     = 300
+    ScaleCooldownPeriod = 60
+
+    ScaleUpAdjustment   = 1
+    ScaleDownAdjustment = -10
+
+    AgentsPerInstance                         = 1
+    BuildkiteTerminateInstanceAfterJobTimeout = 1800
+
+    RootVolumeSize = 150
+    RootVolumeName = "/dev/xvda"
+    RootVolumeType = "gp2"
+
+    InstanceCreationTimeout = "PT5M"
+    InstanceRoleName        = "${local.ci_agent_role_name}-nano"
+
+    VpcId           = local.ci_vpc_id
+    Subnets         = join(",", local.ci_vpc_private_subnets)
+    SecurityGroupId = aws_security_group.buildkite.id
+
+    AssociatePublicIpAddress = true
+
+    KeyName = "wellcomedigitalplatform"
+
+    CostAllocationTagName  = "aws:createdBy"
+    CostAllocationTagValue = "buildkite-elasticstack"
+
+    BuildkiteQueue                                            = "default"
+    BuildkiteAgentRelease                                     = "stable"
+    BuildkiteAgentTimestampLines                              = false
+    BuildkiteTerminateInstanceAfterJobDecreaseDesiredCapacity = true
+
+    # We don't have to terminate an agent after a job completes.  We have
+    # an agent hook (see buildkite_agent_hook.sh) which tries to clean up
+    # any state left over from previous jobs, so each instance will be "fresh",
+    # but already have a local cache of Docker images and Scala libraries.
+    BuildkiteTerminateInstanceAfterJob = false
+
+    EnableExperimentalLambdaBasedAutoscaling = true
+    EnableECRPlugin                          = true
+    EnableSecretsPlugin                      = true
+    EnableDockerLoginPlugin                  = true
+    EnableCostAllocationTags                 = false
+    EnableDockerExperimental                 = false
+    EnableAgentGitMirrorsExperiment          = false
+    EnableDockerUserNamespaceRemap           = false
+
+  }
+
+  template_body = file("${path.module}/buildkite.yaml")
+}
+
 data "aws_iam_role" "ci_agent" {
   name = local.ci_agent_role_name
 }

--- a/builds/terraform/buildkite.tf
+++ b/builds/terraform/buildkite.tf
@@ -101,7 +101,7 @@ resource "aws_cloudformation_stack" "buildkite_nano" {
     ScaleDownAdjustment = -10
 
     AgentsPerInstance                         = 1
-    BuildkiteTerminateInstanceAfterJobTimeout = 1800
+    BuildkiteTerminateInstanceAfterJobTimeout = 300
 
     RootVolumeSize = 25
     RootVolumeName = "/dev/xvda"

--- a/builds/terraform/locals.tf
+++ b/builds/terraform/locals.tf
@@ -5,7 +5,8 @@ locals {
   platform_read_only_role_arn = local.platform_accounts["platform_read_only_role_arn"]
   account_ci_role_arn_map     = local.platform_accounts["ci_role_arn"]
 
-  ci_agent_role_name = "ci-agent"
+  ci_agent_role_name      = "ci-agent"
+  ci_nano_agent_role_name = "${local.ci_agent_role_name}-nano"
 
   ci_vpc_id              = local.platform_vpcs["ci_vpc_id"]
   ci_vpc_private_subnets = local.platform_vpcs["ci_vpc_private_subnets"]


### PR DESCRIPTION
We get a second pool of Buildkite runners which are t3.nano instances instead of r5.large. For long-running or small tasks that don't need a lot of CPU power, we can pick these runners instead, which should make CI quite a bit less spendy.

For https://github.com/wellcomecollection/platform/issues/5289