### PR TITLE
Wait until autoformat is done before running tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,8 @@
 steps:
   - command: .buildkite/scripts/run_autoformat.py
     label: "autoformat"
+    
+  - wait
 
   - label: "test invalidation lambda"
     plugins:


### PR DESCRIPTION
This is what we do in all our other repos – it means that if autoformat pushes a commit, we're not wasting build time on tests with unformatted code.