### PR TITLE
Double the number of Buildkite instances at peak; reduce disk usage

### DIFF
--- a/builds/terraform/buildkite.tf
+++ b/builds/terraform/buildkite.tf
@@ -7,7 +7,7 @@ resource "aws_cloudformation_stack" "buildkite" {
     BuildkiteAgentToken = data.aws_secretsmanager_secret_version.example.secret_string
 
     MinSize = 0
-    MaxSize = 30
+    MaxSize = 60
 
     ScaleDownPeriod     = 300
     ScaleCooldownPeriod = 60
@@ -20,7 +20,7 @@ resource "aws_cloudformation_stack" "buildkite" {
     AgentsPerInstance                         = 1
     BuildkiteTerminateInstanceAfterJobTimeout = 1800
 
-    RootVolumeSize = 150
+    RootVolumeSize = 50
     RootVolumeName = "/dev/xvda"
     RootVolumeType = "gp2"
 


### PR DESCRIPTION
Last month we spent ~$75 on r5.large instances and ~$100 on gp2 volumes. Our BuildKite setup is also imbalanced:

* It's possible to max out our 30 workers. At peak build times, you can be waiting 20m+ for your build to start. Slow!
* 150GB is massive, a quick spin through our current worker pool suggests they have ~144GB or so free with a warm cache (this is logged as part of our pre-job hook). Wasteful!

This change tries to rebalance that spending: take some of the money we're spending on gp2 volumes, and spend it on running more workers instead. I don't expect it to impact the bill much, but it should avoid our builds getting throttled because too many people are building at once.