### PR TITLE
Disable the experience CloudFront alarms

### DIFF
--- a/monitoring/terraform/modules/slack_alert_on_cloudfront_errors/main.tf
+++ b/monitoring/terraform/modules/slack_alert_on_cloudfront_errors/main.tf
@@ -10,7 +10,7 @@ module "cloudfront_to_slack_alerts" {
   environment_variables = {
     STR_SINGLE_ERROR_MESSAGE   = "1% of requests in CloudFront were 5xx errors"
     STR_MULTIPLE_ERROR_MESSAGE = "{error_count:0.2f}% of requests in CloudFront were 5xx errors"
-    STR_ALARM_SLUG             = "api-gateway-5xx-alarm"
+    STR_ALARM_SLUG             = "cloudfront-5xx-alarm"
     STR_ALARM_LEVEL            = "error"
   }
 

--- a/monitoring/terraform/slack_alert_on_cloudfront.tf
+++ b/monitoring/terraform/slack_alert_on_cloudfront.tf
@@ -1,4 +1,7 @@
-module "experience_cloudfront_alerts" {
+# This alarm is firing repeatedly and we're not fixing it, so disable
+# it until we're able to investigate these errors properly.  Otherwise they're
+# just noise in the Slack channel.
+/*module "experience_cloudfront_alerts" {
   source = "./modules/slack_alert_on_cloudfront_errors"
 
   providers = {
@@ -10,4 +13,4 @@ module "experience_cloudfront_alerts" {
 
 output "experience_cloudfront_alerts_topic_arn" {
   value = module.experience_cloudfront_alerts.alarm_topic_arn
-}
+}*/


### PR DESCRIPTION
Make these alarms stop spamming our Slack channel and hiding real errors.