### PR TITLE
Allow Buildkite to deploy into the i.wellcomecollection.org bucket

### DIFF
--- a/builds/terraform/buildkite.tf
+++ b/builds/terraform/buildkite.tf
@@ -245,9 +245,7 @@ data "aws_iam_policy_document" "ci_permissions" {
   # See https://github.com/wellcomecollection/wellcomecollection.org/tree/main/assets
   statement {
     actions = [
-      "s3:ListObject*",
-      "s3:GetObject*",
-      "s3:PutObject*",
+      "s3:*",
     ]
 
     resources = [


### PR DESCRIPTION
## What's changing and why?

Giving the Buildkite CI agents permission to do things in s3://i.wellcomecollection.org. For https://github.com/wellcomecollection/wellcomecollection.org/issues/7069, for https://github.com/wellcomecollection/wellcomecollection.org/pull/7126

## `terraform plan` diff

Something like:

```
  # aws_iam_role_policy.ci_agent will be updated in-place
  ~ resource "aws_iam_role_policy" "ci_agent" {
        id     = "ci-agent:terraform-20200924163608352700000001"
        name   = "terraform-20200924163608352700000001"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                    # (4 unchanged elements hidden)
                    {
                        Action   = "s3:*"
                        Effect   = "Allow"
                        Resource = "arn:aws:s3:::wellcomecollection-platform-infra/lambdas/*"
                        Sid      = ""
                    },
                  ~ {
                      ~ Action   = [
                          - "s3:PutObject*",
                          - "s3:ListObject*",
                          - "s3:GetObject*",
                        ] -> "s3:*"
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }
```

Although I've already applied and tested it as working, and this is the last in several incremental plans.