### PR TITLE
Add the missing roles to the costs report Lambda

### DIFF
--- a/costs_report/terraform/iam.tf
+++ b/costs_report/terraform/iam.tf
@@ -20,6 +20,9 @@ data "aws_iam_policy_document" "allow_assume_role" {
       module.identity_role.arn,
       module.dam_prototype_role.arn,
       module.digirati_role.arn,
+      module.data_role.arn,
+      module.reporting_role.arn,
+      module.digitisation_role.arn,
     ]
   }
 }


### PR DESCRIPTION
We create roles in each account for the Lambda to assume, so it can fetch the costs associated with that account.  The permissions for the role need to be configured in two places:

1) In the other account ("Anyone in platform can assume role X")
2) In the platform account ("Lambda can assume role X")

But for these three accounts, only (1) was configured.  This patch adds (2).
