### PR TITLE
Always run at least one t3.nano so builds are less likely to start cold

### DIFF
--- a/builds/terraform/buildkite.tf
+++ b/builds/terraform/buildkite.tf
@@ -89,7 +89,12 @@ resource "aws_cloudformation_stack" "buildkite_nano" {
     #
     # We want all of these to run simultaneously and leave room for other
     # nano tasks, so we need >6 instances.
-    MinSize = 0
+    #
+    # We always run at least one nano instance because nano instances are
+    # extremely cheap, and this means the initial "pipeline upload" step
+    # is always warm.  An on-demand t3.nano costs ~$4 a month, and we use
+    # spot pricing, so this is unlikely to be an issue.
+    MinSize = 1
     MaxSize = 10
 
     SpotPrice    = 0.01


### PR DESCRIPTION
## What's changing and why?

## `terraform plan` diff
<!-- Please make sure you don't paste anything secure that shouldn't be shared here -->
