### PR TITLE
Standardise nginx images

### DIFF
--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -1,0 +1,5 @@
+# Nginx configurations
+
+These are the nginx configurations used across the platform. 
+
+By using `template.Dockerfile` and providing the config file name as the build argument `CONFIG_TEMPLATE`, you can build an image using that config file. Environment variables will be substituted in [as per the docs](https://github.com/docker-library/docs/tree/d7730a64774bdec6cd8cd75756ed60ea10d7b534/nginx#using-environment-variables-in-nginx-configuration-new-in-119).

--- a/images/nginx/apigw.Dockerfile
+++ b/images/nginx/apigw.Dockerfile
@@ -1,7 +1,0 @@
-FROM nginx:1.15.8-alpine
-
-RUN apk update && apk add bash
-
-COPY apigw.nginx.conf /etc/nginx/nginx.conf.template
-
-CMD /bin/bash -c "envsubst '\$APP_HOST \$APP_PORT' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf && nginx -g 'daemon off;'"

--- a/images/nginx/experience.Dockerfile
+++ b/images/nginx/experience.Dockerfile
@@ -1,7 +1,0 @@
-FROM nginx:1.15.8-alpine
-
-RUN apk update && apk add bash
-
-COPY experience.nginx.conf /etc/nginx/nginx.conf.template
-
-CMD /bin/bash -c "envsubst '\$APP_HOST \$APP_PORT' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf && nginx -g 'daemon off;'"

--- a/images/nginx/frontend.nginx.conf
+++ b/images/nginx/frontend.nginx.conf
@@ -16,10 +16,6 @@ http {
     # large requests to the Lighthouse CI server
     client_max_body_size 2m;
 
-    # Users of the image can specify the value of the STS header as they wish
-    # If they don't specify anything, it won't be set
-    add_header Strict-Transport-Security "${STS_HEADER_VALUE}" always;
-
     location / {
       proxy_set_header Host $host;
       proxy_pass http://${APP_HOST}:${APP_PORT}/;

--- a/images/nginx/frontend.nginx.conf
+++ b/images/nginx/frontend.nginx.conf
@@ -11,10 +11,14 @@ http {
     gzip_types      text/css application/javascript application/json;
     gzip_min_length 860;
     gzip_proxied    any;
-    
+
     # This has been increased from the 1m default to accommodate
     # large requests to the Lighthouse CI server
     client_max_body_size 2m;
+
+    # Users of the image can specify the value of the STS header as they wish
+    # If they don't specify anything, it won't be set
+    add_header Strict-Transport-Security "${STS_HEADER_VALUE}" always;
 
     location / {
       proxy_set_header Host $host;

--- a/images/nginx/grafana.Dockerfile
+++ b/images/nginx/grafana.Dockerfile
@@ -1,3 +1,0 @@
-FROM nginx:1.15.8-alpine
-
-COPY grafana.nginx.conf /etc/nginx/nginx.conf

--- a/images/nginx/template.Dockerfile
+++ b/images/nginx/template.Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:1.21.4-alpine
+
+ARG CONFIG_TEMPLATE
+COPY ${CONFIG_TEMPLATE} /etc/nginx/templates/nginx.conf.template


### PR DESCRIPTION
What this does:

- Builds all the Nginx images with the same base Dockerfile
- Renames `experience` to `frontend` to make intentions clearer
- Pushes all images to ECR Public (@alexwlchan is there a reason we were only doing it for apigw?)