### PR TITLE
Fix the redirects on search.stage.wl.org

### DIFF
--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/csvFixtures/encoreRedirects.csv
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/csvFixtures/encoreRedirects.csv
@@ -1,0 +1,3 @@
+sourceUrl,targetUrl
+search.wellcomelibrary.org,http://search.wellcomelibrary.org/iii/encore
+search.wellcomelibrary.org/iii/encore/record/C__Rb1234567?lang=eng,https://search.wellcomelibrary.org:443/iii/encore/record/C__Rb1234567?lang=eng

--- a/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/testRedirects.ts
@@ -221,6 +221,17 @@ const collectionBrowseTestSet = {
   checkRedirect: checkMatchingUrl,
 };
 
+const encoreTestSet = {
+  displayName: 'Encore pages',
+  fileLocation: 'src/csvFixtures/encoreRedirects.csv',
+  fileHostPrefix: 'search.wellcomelibrary.org',
+  headers: ['sourceUrl', 'targetUrl'],
+  envs: {
+    stage: 'https://search.stage.wellcomelibrary.org',
+  },
+  checkRedirect: checkMatchingUrl,
+};
+
 const testSets: RedirectTestSet[] = [
   apiTestSet,
   itemTestSet,
@@ -228,6 +239,7 @@ const testSets: RedirectTestSet[] = [
   apexTestSet,
   archiveTestSet,
   collectionBrowseTestSet,
+  encoreTestSet
 ];
 
 const runTests = async (envId: EnvId) => {

--- a/cloudfront/wellcomelibrary.org/terraform/lambdas.tf
+++ b/cloudfront/wellcomelibrary.org/terraform/lambdas.tf
@@ -18,7 +18,7 @@ resource "aws_lambda_function" "wellcome_library_encore_redirect" {
   function_name = "cf_edge_wellcome_library_encore_redirect"
   role          = aws_iam_role.edge_lambda_role.arn
   runtime       = "nodejs12.x"
-  handler       = "wellcomeLibraryencoreRedirect.requestHandler"
+  handler       = "wellcomeLibraryEncoreRedirect.requestHandler"
   publish       = true
 
   s3_bucket         = data.aws_s3_bucket_object.wellcome_library_redirect.bucket


### PR DESCRIPTION
The name of the entrypoint in the Lambda function was wrong, so the Lambda function wasn't running.  I've also added the first bit of a test harness for testing Encore redirects.

For https://github.com/wellcomecollection/platform/issues/4977