### PR TITLE
Create redirections for the known Encore URL patterns

### DIFF
--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/csvFixtures/encoreRedirects.csv
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/csvFixtures/encoreRedirects.csv
@@ -5,3 +5,4 @@ search.wellcomelibrary.org/iii/encore/search/C__Srosalind%20paget,https://wellco
 search.wellcomelibrary.org/iii/encore/record/C__Rb2475299,https://wellcomecollection.org/works/tsayk6g3
 search.wellcomelibrary.org/iii/encore/record/C__Rb3185463?lang=eng,https://wellcomecollection.org/works/jg6dqsx4
 search.wellcomelibrary.org/iii/encore/record/C__Rb3153458__Sdrugscope__P0%2C1__Orightresult__U__X7?lang=eng&suite=cobalt,https://wellcomecollection.org/works/psspw62x
+search.wellcomelibrary.org/iii/encore/myaccount?lang=eng&suite=cobalt,https://wellcomecollection.org/account

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/csvFixtures/encoreRedirects.csv
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/csvFixtures/encoreRedirects.csv
@@ -1,3 +1,7 @@
 sourceUrl,targetUrl
-search.wellcomelibrary.org,http://search.wellcomelibrary.org/iii/encore
-search.wellcomelibrary.org/iii/encore/record/C__Rb1234567?lang=eng,https://search.wellcomelibrary.org:443/iii/encore/record/C__Rb1234567?lang=eng
+search.wellcomelibrary.org,https://wellcomecollection.org/collections
+search.wellcomelibrary.org/iii/encore/search?target=erythromelalgia&submit=Search,https://wellcomecollection.org/works?page=1&query=erythromelalgia
+search.wellcomelibrary.org/iii/encore/search/C__Srosalind%20paget,https://wellcomecollection.org/works?query=rosalind%20paget&page=1
+search.wellcomelibrary.org/iii/encore/record/C__Rb2475299,https://wellcomecollection.org/works/tsayk6g3
+search.wellcomelibrary.org/iii/encore/record/C__Rb3185463?lang=eng,https://wellcomecollection.org/works/jg6dqsx4
+search.wellcomelibrary.org/iii/encore/record/C__Rb3153458__Sdrugscope__P0%2C1__Orightresult__U__X7?lang=eng&suite=cobalt,https://wellcomecollection.org/works/psspw62x

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/csvFixtures/encoreRedirects.csv
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/csvFixtures/encoreRedirects.csv
@@ -1,7 +1,7 @@
 sourceUrl,targetUrl
-search.wellcomelibrary.org,https://wellcomecollection.org/collections
-search.wellcomelibrary.org/iii/encore/search?target=erythromelalgia&submit=Search,https://wellcomecollection.org/works?page=1&query=erythromelalgia
-search.wellcomelibrary.org/iii/encore/search/C__Srosalind%20paget,https://wellcomecollection.org/works?query=rosalind%20paget&page=1
+search.wellcomelibrary.org,https://wellcomecollection.org/collections/
+search.wellcomelibrary.org/iii/encore/search?target=erythromelalgia&submit=Search,https://wellcomecollection.org/works?query=erythromelalgia
+search.wellcomelibrary.org/iii/encore/search/C__Srosalind%20paget,https://wellcomecollection.org/works?query=rosalind%20paget
 search.wellcomelibrary.org/iii/encore/record/C__Rb2475299,https://wellcomecollection.org/works/tsayk6g3
 search.wellcomelibrary.org/iii/encore/record/C__Rb3185463?lang=eng,https://wellcomecollection.org/works/jg6dqsx4
 search.wellcomelibrary.org/iii/encore/record/C__Rb3153458__Sdrugscope__P0%2C1__Orightresult__U__X7?lang=eng&suite=cobalt,https://wellcomecollection.org/works/psspw62x

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.ts
@@ -44,7 +44,7 @@ export function getBnumberFromPath(path: string): GetBNumberResult {
     return Error(`b number in ${path} does not match ${sierraIdRegexp}`);
   }
 
-  const sierraIdentifier = splitPath[2].toLowerCase().substr(1, 7);
+  const sierraIdentifier = splitPath[2].toLowerCase().substring(1, 8);
   const sierraSystemNumber = `b${sierraIdentifier}${calcCheckDigit(
     parseInt(sierraIdentifier)
   )}`;

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/paths.ts
@@ -6,7 +6,7 @@ export type SierraIdentifier = {
 export type GetBNumberResult = SierraIdentifier | Error;
 
 // Copied from https://github.com/SydneyUniLibrary/sierra-record-check-digit/blob/master/index.js#L21
-function calcCheckDigit(recordNumber: number) {
+export function calcCheckDigit(recordNumber: number) {
   let m = 2;
   let x = 0;
   let i = Number(recordNumber);

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/redirectHelpers.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/redirectHelpers.ts
@@ -1,4 +1,6 @@
 import { CloudFrontResultResponse } from 'aws-lambda/common/cloudfront';
+import { getWork } from './bnumberToWork';
+import { GetBNumberResult } from './paths';
 
 const wellcomeCollectionHost = 'https://wellcomecollection.org';
 
@@ -44,4 +46,23 @@ export function createServerError(error: Error) {
     status: '500',
     statusDescription: error.message,
   } as CloudFrontResultResponse;
+}
+
+export async function getSierraIdentifierRedirect(
+  sierraIdentifier: GetBNumberResult 
+): Promise<CloudFrontResultResponse> {
+  if (sierraIdentifier instanceof Error) {
+    console.error(sierraIdentifier);
+    return wellcomeCollectionNotFoundRedirect;
+  }
+
+  // Find corresponding work id
+  const work = await getWork(sierraIdentifier);
+
+  if (work instanceof Error) {
+    console.error(work);
+    return wellcomeCollectionNotFoundRedirect;
+  }
+
+  return wellcomeCollectionRedirect(`/works/${work.id}`);
 }

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/tests/wellcomeLibraryEncoreRedirect.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/tests/wellcomeLibraryEncoreRedirect.test.ts
@@ -36,7 +36,7 @@ const encoreTests = [
     },
   ],
   [
-    'single search page',
+    'single record page',
     {
       path: '/iii/encore/record/C__Rb2475299',
       qs: '',
@@ -47,7 +47,7 @@ const encoreTests = [
     },
   ],
   [
-    'single search page (with check digit on the Sierra ID)',
+    'single record page (with check digit on the Sierra ID in the catalogue API)',
     {
       path: '/iii/encore/record/C__Rb2475299',
       qs: '',
@@ -58,7 +58,7 @@ const encoreTests = [
     },
   ],
   [
-    'Encore URL with language query string',
+    'single record page with language in query string',
     {
       path: '/iii/encore/record/C__Rb3185463',
       qs: 'lang=eng',
@@ -69,7 +69,7 @@ const encoreTests = [
     }
   ],
   [
-    'Longer Encore paths',
+    'single record page with extra information in the path',
     {
       path: '/iii/encore/record/C__Rb3153458__Sdrugscope__P0%2C1__Orightresult__U__X7',
       qs: 'lang=eng&suite=cobalt',
@@ -80,7 +80,7 @@ const encoreTests = [
     }
   ],
   [
-    'Account pages in Encore',
+    'account page',
     {
       path: '/iii/encore/myaccount',
       qs: 'lang=eng&suite=cobalt',

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/tests/wellcomeLibraryEncoreRedirect.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/tests/wellcomeLibraryEncoreRedirect.test.ts
@@ -79,6 +79,15 @@ const encoreTests = [
       resolvedUri: 'https://wellcomecollection.org/works/psspw62x'
     }
   ],
+  [
+    'Account pages in Encore',
+    {
+      path: '/iii/encore/myaccount',
+      qs: 'lang=eng&suite=cobalt',
+      results: results([]),
+      resolvedUri: 'https://wellcomecollection.org/account'
+    }
+  ],
 ] as [string, Test][];
 
 test.each(encoreTests)('%s', (name: string, test: Test) => {

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/tests/wellcomeLibraryEncoreRedirect.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/tests/wellcomeLibraryEncoreRedirect.test.ts
@@ -21,7 +21,7 @@ const encoreHeaders = {
 
 type Test = {
   path: string;
-  qs: string;
+  qs?: string;
   results?: CatalogueResultsList;
   resolvedUri: string;
 };
@@ -30,7 +30,6 @@ const encoreTests = [
     'root URL',
     {
       path: '',
-      qs: '',
       resolvedUri: 'https://wellcomecollection.org/collections/',
     },
   ],
@@ -38,7 +37,6 @@ const encoreTests = [
     'single record page',
     {
       path: '/iii/encore/record/C__Rb2475299',
-      qs: '',
       results: results([
         resultWithIdentifier('tsayk6g3', 'sierra-identifier', '2475299'),
       ]),
@@ -49,7 +47,6 @@ const encoreTests = [
     'single record page (with check digit on the Sierra ID in the catalogue API)',
     {
       path: '/iii/encore/record/C__Rb2475299',
-      qs: '',
       results: results([
         resultWithIdentifier('tsayk6g3', 'sierra-system-number', 'b2475299x'),
       ]),
@@ -89,7 +86,7 @@ const encoreTests = [
 ] as [string, Test][];
 
 test.each(encoreTests)('%s', (name: string, test: Test) => {
-  const request = testRequest(test.path, test.qs, encoreHeaders);
+  const request = testRequest(test.path, test.qs ?? '', encoreHeaders);
 
   test.results && mockedAxios.get.mockResolvedValue({
     data: test.results,

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/tests/wellcomeLibraryEncoreRedirect.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/tests/wellcomeLibraryEncoreRedirect.test.ts
@@ -57,6 +57,28 @@ const encoreTests = [
       resolvedUri: 'https://wellcomecollection.org/works/tsayk6g3'
     },
   ],
+  [
+    'Encore URL with language query string',
+    {
+      path: '/iii/encore/record/C__Rb3185463',
+      qs: 'lang=eng',
+      results: results([
+        resultWithIdentifier('jg6dqsx4', 'sierra-identifier', '3185463'),
+      ]),
+      resolvedUri: 'https://wellcomecollection.org/works/jg6dqsx4'
+    }
+  ],
+  [
+    'Longer Encore paths',
+    {
+      path: '/iii/encore/record/C__Rb3153458__Sdrugscope__P0%2C1__Orightresult__U__X7',
+      qs: 'lang=eng&suite=cobalt',
+      results: results([
+        resultWithIdentifier('psspw62x', 'sierra-identifier', '3153458'),
+      ]),
+      resolvedUri: 'https://wellcomecollection.org/works/psspw62x'
+    }
+  ],
 ] as [string, Test][];
 
 test.each(encoreTests)('%s', (name: string, test: Test) => {

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/tests/wellcomeLibraryEncoreRedirect.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/tests/wellcomeLibraryEncoreRedirect.test.ts
@@ -22,7 +22,7 @@ const encoreHeaders = {
 type Test = {
   path: string;
   qs: string;
-  results: CatalogueResultsList;
+  results?: CatalogueResultsList;
   resolvedUri: string;
 };
 const encoreTests = [
@@ -31,7 +31,6 @@ const encoreTests = [
     {
       path: '',
       qs: '',
-      results: results([]),
       resolvedUri: 'https://wellcomecollection.org/collections/',
     },
   ],
@@ -84,7 +83,6 @@ const encoreTests = [
     {
       path: '/iii/encore/myaccount',
       qs: 'lang=eng&suite=cobalt',
-      results: results([]),
       resolvedUri: 'https://wellcomecollection.org/account'
     }
   ],
@@ -92,7 +90,8 @@ const encoreTests = [
 
 test.each(encoreTests)('%s', (name: string, test: Test) => {
   const request = testRequest(test.path, test.qs, encoreHeaders);
-  mockedAxios.get.mockResolvedValue({
+
+  test.results && mockedAxios.get.mockResolvedValue({
     data: test.results,
   });
 

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/tests/wellcomeLibraryEncoreRedirect.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/tests/wellcomeLibraryEncoreRedirect.test.ts
@@ -83,6 +83,21 @@ const encoreTests = [
       resolvedUri: 'https://wellcomecollection.org/account'
     }
   ],
+  [
+    'search page with search terms in the query parameters',
+    {
+      path: '/iii/encore/search',
+      qs: 'target=erythromelalgia&submit=Search',
+      resolvedUri: 'https://wellcomecollection.org/works?query=erythromelalgia',
+    }
+  ],
+  [
+    'search page with search terms in the path',
+    {
+      path: '/iii/encore/search/C__Srosalind%20paget',
+      resolvedUri: 'https://wellcomecollection.org/works?query=rosalind%20paget'
+    }
+  ],
 ] as [string, Test][];
 
 test.each(encoreTests)('%s', (name: string, test: Test) => {

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/tests/wellcomeLibraryEncoreRedirect.test.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/tests/wellcomeLibraryEncoreRedirect.test.ts
@@ -1,0 +1,72 @@
+import * as origin from '../wellcomeLibraryEncoreRedirect';
+import testRequest from './testEventRequest';
+import { Context } from 'aws-lambda';
+import { results, resultWithIdentifier } from './catalogueApiFixtures';
+import { expectedRedirect } from './testHelpers';
+import axios from 'axios';
+import { expect, jest, test } from '@jest/globals';
+import { CatalogueResultsList } from '../catalogueApi';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const encoreHeaders = {
+  host: [
+    { key: 'host', value: 'search.wellcomelibrary.org' }
+  ],
+  'cloudfront-forwarded-proto': [
+    { key: 'cloudfront-forwarded-proto', value: 'https' },
+  ],
+};
+
+type Test = {
+  path: string;
+  qs: string;
+  results: CatalogueResultsList;
+  resolvedUri: string;
+};
+const encoreTests = [
+  [
+    'root URL',
+    {
+      path: '',
+      qs: '',
+      results: results([]),
+      resolvedUri: 'https://wellcomecollection.org/collections/',
+    },
+  ],
+  [
+    'single search page',
+    {
+      path: '/iii/encore/record/C__Rb2475299',
+      qs: '',
+      results: results([
+        resultWithIdentifier('tsayk6g3', 'sierra-identifier', '2475299'),
+      ]),
+      resolvedUri: 'https://wellcomecollection.org/works/tsayk6g3'
+    },
+  ],
+  [
+    'single search page (with check digit on the Sierra ID)',
+    {
+      path: '/iii/encore/record/C__Rb2475299',
+      qs: '',
+      results: results([
+        resultWithIdentifier('tsayk6g3', 'sierra-system-number', 'b2475299x'),
+      ]),
+      resolvedUri: 'https://wellcomecollection.org/works/tsayk6g3'
+    },
+  ],
+] as [string, Test][];
+
+test.each(encoreTests)('%s', (name: string, test: Test) => {
+  const request = testRequest(test.path, test.qs, encoreHeaders);
+  mockedAxios.get.mockResolvedValue({
+    data: test.results,
+  });
+
+  const resultPromise = origin.requestHandler(request, {} as Context);
+  return expect(resultPromise).resolves.toEqual(
+    expectedRedirect(test.resolvedUri)
+  );
+});

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryEncoreRedirect.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryEncoreRedirect.ts
@@ -65,7 +65,7 @@ export function getBnumberFromEncorePath(path: string): GetBNumberResult {
 
   // If defined, this will be something like '1234567'
   const bnumber = components
-    .filter(c => c.letter == 'R')
+    .filter(c => c.letter === 'R')
     .find(c => c.contents && sierraBibRegexp.test(c.contents))
     ?.contents?.substring(1, );
 
@@ -105,7 +105,7 @@ function getSearchRedirect(
   const components = parseEncorePathComponents(finalPathPart);
 
   const searchTerms = components
-    .find(c => c.letter == 'S')
+    .find(c => c.letter === 'S')
     ?.contents;
 
   if (searchTerms) {

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryEncoreRedirect.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryEncoreRedirect.ts
@@ -10,26 +10,72 @@ import {
 import { calcCheckDigit, GetBNumberResult } from './paths';
 import querystring from 'querystring';
 
+type EncorePathComponent = {
+  letter: string;
+  contents?: string;
+};
+
+// Parses the final path part of an Encore URL into 'components'.
+//
+// I'm having to guess at how Encore URLs work here -- it looks like the
+// final part is a collection of components separated by a double underscore, and
+// the first letter of each component tells you waht that component is.
+// e.g. if we look at a more complex URL:
+//
+//    /iii/encore/record/C__Rb3153458__Sdrugscope__P0%2C1__Orightresult__U__X7
+//
+// Then we have:
+//
+//    R = record = b3153458
+//    S = search = drugscope
+//    P = ???    = 0,1
+//    O = ???    = rightresult
+//    U = ???    = <empty>
+//    X = ???    = 7
+//
+// and for these URLs, we want the component that starts with 'S'.
+//
+// This function takes the part after the final slash.
+//
+// Note: components are returned as they appear in the URL; this function does *not*
+// do any URL decoding.
+//
+function parseEncorePathComponents(finalPathPart: string): EncorePathComponent[] {
+  return finalPathPart.split('__')
+    .map(component => {
+      const letter = component.substring(0, 1);
+      const contents = component.substring(1, );
+      
+      return {
+        letter: letter,
+        contents: contents.length > 0 ? contents : undefined,
+      };
+    })
+}
+
 export function getBnumberFromEncorePath(path: string): GetBNumberResult {
   if (!path.startsWith('/iii/encore/record/')) {
     return Error(`Path ${path} does not start with /iii/encore/record/`);
   }
-  const pathPath = path.split('/')[4];
 
-  const sierraIdRegexp = /^C__Rb([0-9]{7})/;
+  const finalPathPart = path.split('/')[4];
+  const components = parseEncorePathComponents(finalPathPart);
+  
+  const sierraBibRegexp = /^b([0-9]{7})$/;
 
-  if (!sierraIdRegexp.test(pathPath)) {
-    return Error(`b number in ${path} (${pathPath}) does not match ${sierraIdRegexp}`);
+  // If defined, this will be something like '1234567'
+  const bnumber = components
+    .filter(c => c.letter == 'R')
+    .find(c => c.contents && sierraBibRegexp.test(c.contents))
+    ?.contents?.substring(1, );
+
+  if (!bnumber) {
+    return Error(`Could not find bib identifier in path ${path}`);
   }
 
-  const sierraIdentifier = pathPath.toLowerCase().substring(5, 12);
-  const sierraSystemNumber = `b${sierraIdentifier}${calcCheckDigit(
-    parseInt(sierraIdentifier)
-  )}`;
-
   return {
-    sierraIdentifier: sierraIdentifier,
-    sierraSystemNumber: sierraSystemNumber,
+    sierraIdentifier: bnumber,
+    sierraSystemNumber: `b${bnumber}${calcCheckDigit(parseInt(bnumber))}`,
   };
 }
 
@@ -55,38 +101,15 @@ function getSearchRedirect(
   }
 
   // For URLs like /iii/encore/search/C__Srosalind%20paget
-  //
-  // I'm having to guess at how Encore URLs work here -- it looks like the
-  // final part is a collection of components separated by a double underscore, and
-  // the first letter of each component tells you waht that component is.
-  // e.g. if we look at a more complex URL:
-  //
-  //    /iii/encore/record/C__Rb3153458__Sdrugscope__P0%2C1__Orightresult__U__X7
-  //
-  // Then we have:
-  //
-  //    R = record = b3153458
-  //    S = search = drugscope
-  //    P = ???    = 0,1
-  //    O = ???    = rightresult
-  //    U = ???    = <empty>
-  //    X = ???    = 7
-  //
-  // and for these URLs, we want the component that starts with 'S'.
-  const parts = path.split('/');
-  if (parts.length === 5) {
-    const finalPart = parts[4];
-    const searchComponent =
-      finalPart
-        .split('__')
-        .find(c => c.startsWith('S'));
+  const finalPathPart = path.split('/')[4];
+  const components = parseEncorePathComponents(finalPathPart);
 
-    // Remember to strip the leading 'S'
-    const searchTerms = searchComponent?.substring(1, );
+  const searchTerms = components
+    .find(c => c.letter == 'S')
+    ?.contents;
 
-    if (searchTerms) {
-      return wellcomeCollectionRedirect(`/works?query=${searchTerms}`);
-    }
+  if (searchTerms) {
+    return wellcomeCollectionRedirect(`/works?query=${searchTerms}`);
   }
 
   // If we've matched nothing we redirect to the top-level collections page

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryEncoreRedirect.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryEncoreRedirect.ts
@@ -21,7 +21,7 @@ export function getBnumberFromPath(path: string): GetBNumberResult {
     return Error(`b number in ${path} (${pathPath}) does not match ${sierraIdRegexp}`);
   }
 
-  const sierraIdentifier = pathPath.toLowerCase().substr(5, 11);
+  const sierraIdentifier = pathPath.toLowerCase().substring(5, 12);
   const sierraSystemNumber = `b${sierraIdentifier}${calcCheckDigit(
     parseInt(sierraIdentifier)
   )}`;

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryEncoreRedirect.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryEncoreRedirect.ts
@@ -1,5 +1,44 @@
 import { CloudFrontRequestEvent, Context } from 'aws-lambda';
-import { CloudFrontRequest } from 'aws-lambda/common/cloudfront';
+import {
+  CloudFrontRequest,
+  CloudFrontResultResponse,
+} from 'aws-lambda/common/cloudfront';
+import { 
+  getSierraIdentifierRedirect,
+  wellcomeCollectionRedirect
+} from './redirectHelpers';
+import { calcCheckDigit, GetBNumberResult } from './paths';
+
+export function getBnumberFromPath(path: string): GetBNumberResult {
+  if (!path.startsWith('/iii/encore/record/')) {
+    return Error(`Path ${path} does not start with /iii/encore/record/`);
+  }
+  const pathPath = path.split('/')[4];
+
+  const sierraIdRegexp = /^C__Rb([0-9]{7})/;
+
+  if (!sierraIdRegexp.test(pathPath)) {
+    return Error(`b number in ${path} (${pathPath}) does not match ${sierraIdRegexp}`);
+  }
+
+  const sierraIdentifier = pathPath.toLowerCase().substr(5, 11);
+  const sierraSystemNumber = `b${sierraIdentifier}${calcCheckDigit(
+    parseInt(sierraIdentifier)
+  )}`;
+
+  return {
+    sierraIdentifier: sierraIdentifier,
+    sierraSystemNumber: sierraSystemNumber,
+  };
+}
+
+async function getWorksRedirect(
+  uri: string
+): Promise<CloudFrontResultResponse> {
+  const sierraIdentifier = getBnumberFromPath(uri);
+
+  return getSierraIdentifierRedirect(sierraIdentifier);
+}
 
 export const requestHandler = async (
   event: CloudFrontRequestEvent,
@@ -9,5 +48,16 @@ export const requestHandler = async (
 
   request.headers.host = [{ key: 'host', value: 'search.wellcomelibrary.org' }];
 
-  return request;
+  const uri = request.uri;
+
+  // URLs like https://search.wellcomelibrary.org/iii/encore/record/C__Rb2475299
+  const bibPathRegExp: RegExp = /\/iii\/encore\/record\/C__Rb[0-9]{7}.*/;
+
+  if (uri.match(bibPathRegExp)) {
+    return getWorksRedirect(uri);
+  }
+
+  // If we've matched nothing we redirect to wellcomecollection.org/collections/
+  console.warn(`Unable to redirect request ${JSON.stringify(event.Records[0].cf.request)}`);
+  return wellcomeCollectionRedirect('/collections/');
 };

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryEncoreRedirect.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryEncoreRedirect.ts
@@ -53,8 +53,13 @@ export const requestHandler = async (
   // URLs like https://search.wellcomelibrary.org/iii/encore/record/C__Rb2475299
   const bibPathRegExp: RegExp = /\/iii\/encore\/record\/C__Rb[0-9]{7}.*/;
 
+  // URLs like https://search.wellcomelibrary.org/iii/encore/myaccount?suite=cobalt&lang=eng
+  const accountPathRegExp: RegExp = /\/iii\/encore\/myaccount.*/;
+
   if (uri.match(bibPathRegExp)) {
     return getWorksRedirect(uri);
+  } else if (uri.match(accountPathRegExp)) {
+    return wellcomeCollectionRedirect('/account');
   }
 
   // If we've matched nothing we redirect to wellcomecollection.org/collections/

--- a/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.ts
+++ b/cloudfront/wellcomelibrary.org/edge-lambda/src/wellcomeLibraryRedirect.ts
@@ -4,9 +4,9 @@ import {
   CloudFrontResultResponse,
 } from 'aws-lambda/common/cloudfront';
 import { getBnumberFromPath } from './paths';
-import { getWork } from './bnumberToWork';
 import {
   createRedirect,
+  getSierraIdentifierRedirect,
   wellcomeCollectionNotFoundRedirect,
   wellcomeCollectionRedirect,
 } from './redirectHelpers';
@@ -20,23 +20,9 @@ const staticRedirects = rawStaticRedirects as Record<string, string>;
 async function getWorksRedirect(
   uri: string
 ): Promise<CloudFrontResultResponse> {
-  // Try and find b-number in item path
   const sierraIdentifier = getBnumberFromPath(uri);
 
-  if (sierraIdentifier instanceof Error) {
-    console.error(sierraIdentifier);
-    return wellcomeCollectionNotFoundRedirect;
-  }
-
-  // Find corresponding work id
-  const work = await getWork(sierraIdentifier);
-
-  if (work instanceof Error) {
-    console.error(work);
-    return wellcomeCollectionNotFoundRedirect;
-  }
-
-  return wellcomeCollectionRedirect(`/works/${work.id}`);
+  return getSierraIdentifierRedirect(sierraIdentifier);
 }
 
 async function getApiRedirects(
@@ -96,8 +82,7 @@ export const requestHandler = async (
     return requestRedirect;
   }
 
-  console.warn(`Unable to redirect request ${JSON.stringify(event.Records[0].cf.request)}`);
-
   // If we've matched nothing we redirect to wellcomecollection.org
+  console.warn(`Unable to redirect request ${JSON.stringify(event.Records[0].cf.request)}`);
   return wellcomeCollectionRedirect('/');
 };


### PR DESCRIPTION
This adds the redirects described in wellcomecollection/platform#5056; follows #276

It's not deployed anywhere yet (either stage or prod), but the business logic is there. We'll also get logs about any paths we aren't redirecting successfully, so we can add more later if necessary.