### PR TITLE
Replace our sbt_wrapper Docker image with a smaller, faster one

### DIFF
--- a/images/dockerfiles/sbt_wrapper/Dockerfile
+++ b/images/dockerfiles/sbt_wrapper/Dockerfile
@@ -1,0 +1,22 @@
+FROM openjdk:11.0-jre-slim
+
+LABEL maintainer = "Wellcome Collection <dev@wellcomecollection.org>"
+LABEL description "A Docker image for running SBT"
+
+ENV SBT_VERSION 1.4.1
+ENV SBT_HOME /usr/local/sbt
+ENV PATH ${PATH}:${SBT_HOME}/bin
+
+COPY install_docker_compose.sh /
+RUN /install_docker_compose.sh
+
+COPY install_sbt.sh /
+RUN /install_sbt.sh
+
+VOLUME /repo
+WORKDIR /repo
+
+COPY run_sbt.sh /
+COPY populate_sbt_cache.py /
+
+ENTRYPOINT ["/run_sbt.sh"]

--- a/images/dockerfiles/sbt_wrapper/README.md
+++ b/images/dockerfiles/sbt_wrapper/README.md
@@ -1,0 +1,59 @@
+# sbt_wrapper
+
+This image is the wrapper around [sbt] that we use when running build tasks for our Scala apps.
+
+This image also includes Docker Compose, which we use to run mocks of certain services.
+
+[sbt]: https://www.scala-sbt.org/
+
+
+
+## Building and publishing the image
+
+To build the image:
+
+```console
+$ docker build -t sbt_wrapper .
+```
+
+To publish the image to ECR:
+
+```console
+$ # log in to ECR
+$ eval $(AWS_PROFILE=platform-dev aws ecr get-login --no-include-email)
+
+$ # push the image
+$ docker tag sbt_wrapper 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper
+$ docker push 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper
+```
+
+All our Scala builds pull the `latest` tag; you may want to test with a different tag if you're making major changes to the image.
+
+
+
+## How the image is built
+
+Most of the image is a standard Dockerfile build.
+The `install_*.sh` scripts install the major dependencies, and remove stuff we don't need in the final image to reduce the time it takes to pull the image from ECR (because we pull this image hundreds of times a week).
+
+
+
+## How we cache the sbt installation
+
+If you run sbt with no cache, you see something like:
+
+```
+getting org.scala-sbt sbt 1.4.1  (this may take some time)...
+```
+
+The exact time varies, but either way we don't want to do this on every Scala build, so we fetch sbt as part of the Docker image (see `install_sbt.sh`).
+This gets saved in the `~/.sbt` folder.
+
+When we run the image, we mount the `~/.ivy2` and `~/.sbt` caches from persistent folders on the host -- so if we run multiple sbt tasks on the same host, they use the same cache and don't have to redownload dependencies each time.
+But this overwrites whatever was in those folders in the image – so the cached version of sbt in `~/.sbt` would be lost.
+
+To get around this, we move the in-image cache to `~/.ivy2.image` and `~/.sbt.image` as part of building the Docker image.
+Then, when the image is run, it moves those files back into `~/.ivy2` and `~/.sbt`, so we don't have to redownload sbt.
+
+This is handled by the scripts `install_sbt.sh` and `run_sbt.sh`.
+It should be completely transparent to end users, but does seem to speed up builds slightly.

--- a/images/dockerfiles/sbt_wrapper/install_docker_compose.sh
+++ b/images/dockerfiles/sbt_wrapper/install_docker_compose.sh
@@ -14,6 +14,15 @@ apt-get install --yes \
     python3-pip \
     python3-setuptools
 
+# We follow the instructions for running Docker from https://docs.docker.com/engine/install/ubuntu/
+#
+# Note: those instructions mention "docker-ce" and "containerd.io", but
+# we don't install those because we don't need them.  They provide a
+# container runtime, but we don't need a runtime inside a container --
+# we use the container runtime from the build host, by mounting the
+# Docker socket inside the container.
+#
+# This shaves ~400MB off the size of the final Docker image!
 curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
 
 add-apt-repository \
@@ -22,7 +31,7 @@ add-apt-repository \
    stable"
 
 apt-get update
-apt-get install --yes docker-ce docker-ce-cli containerd.io
+apt-get install --yes docker-ce-cli
 pip3 install docker-compose
 
 # Remove some packages we no longer need once docker-compose is installed.

--- a/images/dockerfiles/sbt_wrapper/install_docker_compose.sh
+++ b/images/dockerfiles/sbt_wrapper/install_docker_compose.sh
@@ -31,7 +31,9 @@ apt-get remove --yes \
     apt-transport-https \
     ca-certificates \
     curl \
-    python3-pip
+    libffi-dev \
+    python3-pip \
+    software-properties-common
 
 # This is to ensure you haven't deleted a critical package for running
 # Docker Compose.  In particular, when trying to create this container,

--- a/images/dockerfiles/sbt_wrapper/install_docker_compose.sh
+++ b/images/dockerfiles/sbt_wrapper/install_docker_compose.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+apt-get update
+apt-get install --yes \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    libffi-dev \
+    software-properties-common \
+    python3 \
+    python3-pip \
+    python3-setuptools
+
+curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+
+add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/debian \
+   $(lsb_release -cs) \
+   stable"
+
+apt-get update
+apt-get install --yes docker-ce docker-ce-cli containerd.io
+pip3 install docker-compose
+
+# Remove some packages we no longer need once docker-compose is installed.
+# This reduces the size of the final Docker image.
+apt-get remove --yes \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    python3-pip
+
+# This is to ensure you haven't deleted a critical package for running
+# Docker Compose.  In particular, when trying to create this container,
+# it would build successfully but fail when it tried to run Docker Compose:
+#
+#     Traceback (most recent call last):
+#       File "/usr/local/bin/docker-compose", line 5, in <module>
+#         from compose.cli.main import main
+#       File "/usr/local/lib/python3.9/dist-packages/compose/cli/main.py", line 9, in <module>
+#         from distutils.spawn import find_executable
+#     ModuleNotFoundError: No module named 'distutils.spawn'
+#
+# The distutils library is installed by python3-setuptools, which is a
+# dependency of python3-pip.  We don't need all of pip and its dependencies
+# in the final image (which is nearly 300MB extra!), but we do need setuptools.
+docker-compose --version
+
+apt-get clean
+apt-get autoremove --yes

--- a/images/dockerfiles/sbt_wrapper/install_sbt.sh
+++ b/images/dockerfiles/sbt_wrapper/install_sbt.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+apt-get update
+apt-get install --yes curl
+
+curl --location "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" \
+  | gunzip \
+  | tar -x -C /usr/local
+
+# This flag is to avoid getting an error from sbt if this script is
+# executed from the root directory:
+#
+#     java.lang.IllegalStateException: cannot run sbt from root directory
+#     without -Dsbt.rootdir=true; see sbt/sbt#1458
+#
+# We're not doing anything useful with sbt here except fetching it once
+# so it's added to the cache that's baked in the image, so we get it on
+# image pull rather than fetching it each time.
+#
+# In particular, we want to avoid the dreaded:
+#
+#     getting org.scala-sbt sbt 1.4.1  (this may take some time)...
+#
+/usr/local/sbt/bin/sbt -Dsbt.rootdir=true sbtVersion
+
+# When we run the Docker image, we mount ~/.sbt and ~/.ivy2 inside the
+# container.  To avoid clobbering the version of sbt that's downloaded
+# as part of the image, move the in-image caches off to the side.
+#
+# We'll move them back into place before running any sbt commands,
+# and after we've mounted the host caches.
+mv ~/.sbt ~/.sbt.image
+mv ~/.ivy2 ~/.ivy2.image
+
+apt-get remove --yes curl
+
+apt-get clean
+apt-get autoremove --yes

--- a/images/dockerfiles/sbt_wrapper/populate_sbt_cache.py
+++ b/images/dockerfiles/sbt_wrapper/populate_sbt_cache.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import os
+
+
+def get_file_paths_under(root=".", *, suffix=""):
+    """Generates the paths to every file under ``root``."""
+    if not os.path.isdir(root):
+        raise ValueError(f"Cannot find files under non-existent directory: {root!r}")
+
+    for dirpath, _, filenames in os.walk(root):
+        for f in filenames:
+            if os.path.isfile(os.path.join(dirpath, f)) and f.lower().endswith(suffix):
+                yield os.path.join(dirpath, f)
+
+
+def homedir(name):
+    return os.path.join(os.environ['HOME'], name)
+
+
+def sync_dir(src, dst):
+    should_sync = bool(os.listdir(dst))
+
+    for src_f in get_file_paths_under(src):
+        dst_f = os.path.join(
+            dst, os.path.relpath(src_f, src)
+        )
+        if should_sync:
+            os.makedirs(os.path.dirname(dst_f), exist_ok=True)
+            os.rename(src_f, dst_f)
+
+
+if __name__ == '__main__':
+    sync_dir(src=homedir('.sbt.image'), dst=homedir('.sbt'))
+    sync_dir(src=homedir('.ivy2.image'), dst=homedir('.ivy2'))

--- a/images/dockerfiles/sbt_wrapper/populate_sbt_cache.py
+++ b/images/dockerfiles/sbt_wrapper/populate_sbt_cache.py
@@ -16,19 +16,17 @@ def get_file_paths_under(root=".", *, suffix=""):
 
 
 def homedir(name):
-    return os.path.join(os.environ['HOME'], name)
+    return os.path.join(os.environ["HOME"], name)
 
 
 def sync_dir(src, dst):
     for src_f in get_file_paths_under(src):
-        dst_f = os.path.join(
-            dst, os.path.relpath(src_f, src)
-        )
+        dst_f = os.path.join(dst, os.path.relpath(src_f, src))
         if not os.path.exists(dst_f):
             os.makedirs(os.path.dirname(dst_f), exist_ok=True)
             shutil.move(src_f, dst_f)
 
 
-if __name__ == '__main__':
-    sync_dir(src=homedir('.sbt.image'), dst=homedir('.sbt'))
-    sync_dir(src=homedir('.ivy2.image'), dst=homedir('.ivy2'))
+if __name__ == "__main__":
+    sync_dir(src=homedir(".sbt.image"), dst=homedir(".sbt"))
+    sync_dir(src=homedir(".ivy2.image"), dst=homedir(".ivy2"))

--- a/images/dockerfiles/sbt_wrapper/populate_sbt_cache.py
+++ b/images/dockerfiles/sbt_wrapper/populate_sbt_cache.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import shutil
 
 
 def get_file_paths_under(root=".", *, suffix=""):
@@ -19,15 +20,13 @@ def homedir(name):
 
 
 def sync_dir(src, dst):
-    should_sync = bool(os.listdir(dst))
-
     for src_f in get_file_paths_under(src):
         dst_f = os.path.join(
             dst, os.path.relpath(src_f, src)
         )
-        if should_sync:
+        if not os.path.exists(dst_f):
             os.makedirs(os.path.dirname(dst_f), exist_ok=True)
-            os.rename(src_f, dst_f)
+            shutil.move(src_f, dst_f)
 
 
 if __name__ == '__main__':

--- a/images/dockerfiles/sbt_wrapper/run_sbt.sh
+++ b/images/dockerfiles/sbt_wrapper/run_sbt.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o verbose
+
+python3 /populate_sbt_cache.py
+
+# -J-Xss: Stack size (used to hold return addresses, function/method call arguments)
+# This is by default in the order of KB, we have experienced OOM & Thread allocation exceptions with lower values
+# as some services process large structures via recursive algorithms
+# -J-Xms: Minimum (and starting) heap size
+# -J-Xmx: Maximum heap size
+# The Java heap is the amount of memory allocated to applications running in the JVM.
+# Setting maximum and minimum heap size is a shortcut to avoid OOM on startup.
+# We've determined the value by experimentation (note containers must be provided at least this much memory).
+# -J-XX:MaxMetaspaceSize: Sets the amount of memory used to store compilation metadata (by default unbounded)
+# Our use of scala & libraries that use macros means this value can cause OOM errors if a maximum is unset
+/usr/local/sbt/bin/sbt \
+  -batch \
+  -J-Xss6M \
+  -J-Xms4G \
+  -J-Xmx4G \
+  -J-XX:MaxMetaspaceSize=2G \
+  "$@"


### PR DESCRIPTION
Working with Paul this week, I've been acutely aware of how slow our Scala builds still are. I remember the bad old days of multi-hour builds, and while our current ~15m build times are fast*er*, they're still not *fast*.

All of our Scala builds invoke sbt through an `sbt_wrapper` image (previously defined in [our dockerfiles repo](https://github.com/wellcomecollection/dockerfiles/blob/main/sbt_wrapper/Dockerfile), which has become very stale). Since it's on the hot path, I decided to see if I could make it faster.

I've done this in two ways:

1.  The final image is smaller: <s>~1.15GB</s> ~770MB compared to ~2GB.

    Still not small, but smaller.  This is achieved by starting from a smaller base image and removing dependencies that are only used for building the image, not running it. Although EC2 networking is fast, it's not instant, and reducing the image size will reduce Docker image pull times.

2.  The sbt version is cached properly.

    If you look at our builds, you pretty regularly see this message:

        getting org.scala-sbt sbt 1.4.1  (this may take some time)...

    But the whole point of using a Docker image is to cache this sort of thing, so we don't have to install it on the fly!

    It turns out we were caching sbt in a slightly suboptimal way, and having to redownload it on every build host.  Now that's fixed, which is explained in the README, because it's quite fiddly.

This image is already deployed, and should be picked up on your next Scala build. ✨ 

Part of https://github.com/wellcomecollection/platform/issues/5370 and https://github.com/wellcomecollection/platform/issues/5359