### PR TITLE
Exclude PIN-triviality errors

### DIFF
--- a/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
+++ b/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
@@ -91,7 +91,8 @@ def should_alert_for_event(log_event):
         "ublkdu",  # User block released
     ]
     no_alert_generic_failure_description_substrings = [
-        "You may have pressed the back button"
+        "You may have pressed the back button",
+        "PIN is not valid : PIN is trivial"
     ]
 
     if any(event_type.startswith(prefix) for prefix in no_alert_prefixes):

--- a/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
+++ b/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
@@ -92,7 +92,7 @@ def should_alert_for_event(log_event):
     ]
     no_alert_generic_failure_description_substrings = [
         "You may have pressed the back button",
-        "PIN is not valid : PIN is trivial"
+        "PIN is not valid : PIN is trivial",
     ]
 
     if any(event_type.startswith(prefix) for prefix in no_alert_prefixes):


### PR DESCRIPTION
These are now covered by our error messaging