### PR TITLE
Allow the platform-ci role to get pipeline-storage secrets

### DIFF
--- a/accounts/platform/iam_platform_ci.tf
+++ b/accounts/platform/iam_platform_ci.tf
@@ -33,4 +33,15 @@ data "aws_iam_policy_document" "platform_ci" {
       "arn:aws:s3:::releases.mvn-repo.wellcomecollection.org/weco/source_model_typesafe_2.12/*",
     ]
   }
+
+  # Secrets required for diff_tool to run
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+
+    resources = [
+      "${local.secrets_base_arn}elasticsearch/pipeline_storage*",
+    ]
+  }
 }

--- a/monitoring/slack_alerts/metric_to_slack_alert/src/metric_to_slack_alert.py
+++ b/monitoring/slack_alerts/metric_to_slack_alert/src/metric_to_slack_alert.py
@@ -109,7 +109,9 @@ def create_context_url(alarm_info):
             "label": "View logs in Kibana",
         }
 
-    if os.environ.get("CONTEXT_URL_TEMPLATE") == "platform-dlq-alerts" and alarm_info["name"].startswith("catalogue-"):
+    if os.environ.get("CONTEXT_URL_TEMPLATE") == "platform-dlq-alerts" and alarm_info[
+        "name"
+    ].startswith("catalogue-"):
         # The alarm name will be something like:
         #
         #     catalogue-2022-03-10_id_minter_input_dlq_not_empty
@@ -163,9 +165,7 @@ def create_message(alarm_info):
             error_count = alarm_info["count"]
 
         lines.append(
-            os.environ["STR_MULTIPLE_ERROR_MESSAGE"].format(
-                error_count=error_count
-            )
+            os.environ["STR_MULTIPLE_ERROR_MESSAGE"].format(error_count=error_count)
         )
 
     context_url = create_context_url(alarm_info)


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5481

This allows the catalogue API diff tool to query the per-pipeline clusters, rather than going to the API cluster.