### PR TITLE
Don't alert on invalid refresh token errors

### DIFF
--- a/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
+++ b/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
@@ -89,6 +89,7 @@ def should_alert_for_event(log_event):
         "pwd_leak",  # A leaked passwork was used
         "resource_cleanup",  # Refresh token excess warning
         "ublkdu",  # User block released
+        "fertft", # Unknown or invalid refresh token
     ]
     no_alert_generic_failure_description_substrings = [
         "You may have pressed the back button",

--- a/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
+++ b/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
@@ -89,7 +89,7 @@ def should_alert_for_event(log_event):
         "pwd_leak",  # A leaked passwork was used
         "resource_cleanup",  # Refresh token excess warning
         "ublkdu",  # User block released
-        "fertft", # Unknown or invalid refresh token
+        "fertft",  # Unknown or invalid refresh token
     ]
     no_alert_generic_failure_description_substrings = [
         "You may have pressed the back button",


### PR DESCRIPTION
These errors are noisy and are expected behaviour