### PR TITLE
Use a Node image from ECR Public, not Docker Hub

### DIFF
--- a/cloudfront/invalidation/lambda/Dockerfile
+++ b/cloudfront/invalidation/lambda/Dockerfile
@@ -1,4 +1,4 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:12.18.3
+public.ecr.aws/docker/library/node:12-slim
 
 RUN apt-get update && apt-get install -yq --no-install-recommends zip
 

--- a/cloudfront/invalidation/lambda/Dockerfile
+++ b/cloudfront/invalidation/lambda/Dockerfile
@@ -1,4 +1,4 @@
-public.ecr.aws/docker/library/node:12-slim
+FROM public.ecr.aws/docker/library/node:12-slim
 
 RUN apt-get update && apt-get install -yq --no-install-recommends zip
 


### PR DESCRIPTION
For wellcomecollection/platform#5545, which includes a discussion of the benefits.