### PR TITLE
Don't alert on failed signup if it's for a known reason

### DIFF
--- a/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
+++ b/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
@@ -12,6 +12,8 @@ The contents of the messages looks like:
 
 It sends alerts to Slack which link back to the log event in Auth0.
 
+This Lambda is deployed by running a Terraform plan/apply.
+
 """
 
 import functools
@@ -97,7 +99,7 @@ def should_alert_for_event(log_event):
         "PIN is not valid : PIN is trivial",
     ]
     no_alert_sign_up_descriptions = {
-        "Password is too common",
+        "Password is not allowed, it might be too common.",
     }
 
     if any(event_type.startswith(prefix) for prefix in no_alert_prefixes):

--- a/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
+++ b/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
@@ -98,9 +98,7 @@ def should_alert_for_event(log_event):
         "You may have pressed the back button",
         "PIN is not valid : PIN is trivial",
     ]
-    no_alert_sign_up_descriptions = {
-        "Password is not allowed, it might be too common.",
-    }
+    no_alert_sign_up_descriptions = {"Password is not allowed, it might be too common."}
 
     if any(event_type.startswith(prefix) for prefix in no_alert_prefixes):
         return False
@@ -116,7 +114,7 @@ def should_alert_for_event(log_event):
         return False
 
     # Event type 'fs' = failed signup
-    if event_type == 'fs' and description in no_alert_sign_up_descriptions:
+    if event_type == "fs" and description in no_alert_sign_up_descriptions:
         return False
 
     return True

--- a/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
+++ b/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
@@ -96,6 +96,9 @@ def should_alert_for_event(log_event):
         "You may have pressed the back button",
         "PIN is not valid : PIN is trivial",
     ]
+    no_alert_sign_up_descriptions = {
+        "Password is too common",
+    }
 
     if any(event_type.startswith(prefix) for prefix in no_alert_prefixes):
         return False
@@ -108,6 +111,10 @@ def should_alert_for_event(log_event):
         substring in description
         for substring in no_alert_generic_failure_description_substrings
     ):
+        return False
+
+    # Event type 'fs' = failed signup
+    if event_type == 'fs' and description in no_alert_sign_up_descriptions:
         return False
 
     return True

--- a/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
+++ b/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
@@ -103,6 +103,7 @@ def should_alert_for_event(log_event):
     if event_type in no_alert_codes:
         return False
 
+    # Event type 'f' = failed login
     if event_type == "f" and any(
         substring in description
         for substring in no_alert_generic_failure_description_substrings


### PR DESCRIPTION
If users try to sign up with a common password, we don't need to know about it in the alerts channel.
