### PR TITLE
Remove some mirrored ECR repos we no longer need

### DIFF
--- a/images/publish_mirrored_images.py
+++ b/images/publish_mirrored_images.py
@@ -40,20 +40,9 @@ PLATFORM_ROLE_ARN = "arn:aws:iam::760097843905:role/platform-developer"
 
 # These repositories must be provisioned in terraform/ecr.tf
 IMAGE_TAGS = [
-    "amazon/aws-cli",
-    "amazon/dynamodb-local",
-    "hashicorp/terraform:light",
-    "library/mysql:5.6",
     "localstack/localstack",
     "localstack/localstack:0.10.5",
-    "node:12.18.3",
-    "node:14.14.0",
-    "node:14-alpine",
-    "openjdk:11",
-    "python:3.7",
-    "python:3.7-alpine",
-    "python:3.7-slim",
-    "python:3.8.3",
+    "localstack/localstack:0.14.2"
     "scality/s3server:mem-latest",
     "wellcome/build_test_python",
     "wellcome/flake8:latest",

--- a/images/publish_mirrored_images.py
+++ b/images/publish_mirrored_images.py
@@ -42,8 +42,7 @@ PLATFORM_ROLE_ARN = "arn:aws:iam::760097843905:role/platform-developer"
 IMAGE_TAGS = [
     "localstack/localstack",
     "localstack/localstack:0.10.5",
-    "localstack/localstack:0.14.2"
-    "scality/s3server:mem-latest",
+    "localstack/localstack:0.14.2" "scality/s3server:mem-latest",
     "wellcome/build_test_python",
     "wellcome/flake8:latest",
     "wellcome/format_python:112",

--- a/images/terraform/ecr.tf
+++ b/images/terraform/ecr.tf
@@ -111,14 +111,8 @@ module "mirrored_images_policy" {
 
 locals {
   mirrored_images = [
-    "amazon/aws-cli",
-    "amazon/dynamodb-local",
-    "hashicorp/terraform",
     "localstack/localstack",
     "nginx",
-    "node",
-    "openjdk",
-    "python",
     "scality/s3server",
     "wellcome/build_test_python",
     "wellcome/flake8",


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5545

This removes a bunch of repos and mirrored images where we're now pulling from the ECR Public-maintained mirrors of the Docker Hub library images (or we should be), and so we can delete our copies.

This only leaves a handful of mirrored images:

* LocalStack, which we use for simulating AWS services in tests
* scality/s3server and zenko/cloudserver, which we use for simulating S3 and I'd like to eventually replace with LocalStack (see https://github.com/wellcomecollection/platform/issues/5547)

Plus a bunch of Wellcome-specific images, some of which are probably redundant (e.g. `image_builder` has largely been replaced by inline shell scripts or similar).

I haven't applied this yet in case somebody wants to save something, but I think all of these can be safely deleted.