### PR TITLE
Remove a use of a Node image from our private ECR repos

### DIFF
--- a/cloudfront/api.wellcomecollection.org/tests/Dockerfile
+++ b/cloudfront/api.wellcomecollection.org/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/python:3.9
+FROM public.ecr.aws/docker/library/python:3.9
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/cloudfront/iiif.wellcomecollection.org/edge-lambda/Dockerfile
+++ b/cloudfront/iiif.wellcomecollection.org/edge-lambda/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:12.18.3
+FROM public.ecr.aws/docker/library/node:12-slim
 
 RUN apt-get update && apt-get install -yq --no-install-recommends zip
 

--- a/cloudfront/iiif.wellcomecollection.org/edge-lambda/Dockerfile
+++ b/cloudfront/iiif.wellcomecollection.org/edge-lambda/Dockerfile
@@ -1,4 +1,4 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:12.18.3
+FROM public.ecr.aws/docker/library/node:12.18.3
 
 RUN apt-get update && apt-get install -yq --no-install-recommends zip
 

--- a/cloudfront/iiif.wellcomecollection.org/edge-lambda/package.json
+++ b/cloudfront/iiif.wellcomecollection.org/edge-lambda/package.json
@@ -10,10 +10,9 @@
     "test": "yarn jest",
     "build": "tsc -p tsconfig.build.json && (cd dist && zip -r dlcs_path_rewrite.zip .)",
     "deploy": "yarn build && yarn test && node deploy",
-    "dockerLoginLocal": "aws ecr get-login-password --region eu-west-1 --profile platform | docker login --username AWS --password-stdin 760097843905.dkr.ecr.eu-west-1.amazonaws.com",
-    "dockerBuildLocal": "yarn dockerLoginLocal && docker build . -t weco_cf_lambdas",
-    "dockerTestLocal": "yarn dockerBuildLocal && docker run weco_cf_lambdas yarn test",
-    "dockerDeployLocal": "yarn dockerTestLocal && docker run weco_cf_lambdas -v ~/.aws:/root/.aws yarn deploy"
+    "dockerBuild": "docker build . -t weco_cf_lambdas",
+    "dockerTest": "docker run weco_cf_lambdas yarn test",
+    "dockerDeploy": "docker run weco_cf_lambdas -v ~/.aws:/root/.aws yarn deploy"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.71",

--- a/cloudfront/iiif.wellcomecollection.org/tests/Dockerfile
+++ b/cloudfront/iiif.wellcomecollection.org/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/python:3.9
+FROM public.ecr.aws/docker/library/python:3.9
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt


### PR DESCRIPTION
This fixes the failing tests on #305.