### PR TITLE
Remove the deprecated template provider from the platform accounts

### DIFF
--- a/accounts/modules/account/federated/outputs.tf
+++ b/accounts/modules/account/federated/outputs.tf
@@ -17,5 +17,3 @@ output "list_roles_name" {
 output "list_roles_arn" {
   value = module.list_roles_user.arn
 }
-
-variable "saml_xml" {}

--- a/accounts/modules/account/federated/variables.tf
+++ b/accounts/modules/account/federated/variables.tf
@@ -1,2 +1,5 @@
 variable "prefix" {}
 variable "pgp_key" {}
+variable "saml_xml" {
+  type = string
+}

--- a/accounts/modules/cloudhealth/cloudhealth-role.tf
+++ b/accounts/modules/cloudhealth/cloudhealth-role.tf
@@ -13,8 +13,7 @@ resource "aws_iam_policy" "policy" {
 resource "aws_iam_policy_attachment" "wt-cloudhealth-policy-attachement" {
   name       = "cloudhealth"
   policy_arn = aws_iam_policy.policy.arn
-  roles = [
-  aws_iam_role.role.name]
+  roles = [aws_iam_role.role.name]
 }
 
 output "role_arn" {

--- a/accounts/modules/cloudhealth/cloudhealth-role.tf
+++ b/accounts/modules/cloudhealth/cloudhealth-role.tf
@@ -13,7 +13,7 @@ resource "aws_iam_policy" "policy" {
 resource "aws_iam_policy_attachment" "wt-cloudhealth-policy-attachement" {
   name       = "cloudhealth"
   policy_arn = aws_iam_policy.policy.arn
-  roles = [aws_iam_role.role.name]
+  roles      = [aws_iam_role.role.name]
 }
 
 output "role_arn" {

--- a/accounts/platform/.terraform.lock.hcl
+++ b/accounts/platform/.terraform.lock.hcl
@@ -2,19 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.34.0"
+  version = "4.18.0"
   hashes = [
-    "h1:2xGmnG7UF0iScMGVWBazSYk1sRatXeZYgCGjdGm4A+w=",
-    "zh:003272229bd19bb63d6e77bc3d684268c417a151dfaee01c40b40e21cdd8bb0f",
-    "zh:103cacc1f3d97dfb7e9dd1e1905b075f92d9bd8aed434f811e8111788b648a57",
-    "zh:63a43c6e5fb2e5ad59ea068bede5c6bb54358affd32163d72785473a15440427",
-    "zh:6648af39a318c85eb336e2fb3ec1a01c5ffe8d75cc51686c37e892dd6f6a8974",
-    "zh:71ac8f6d5d61e5dee90099fd4fc1bb5bcd8ccb674eb6e7cd58d20757f7cecd12",
-    "zh:73baae4aa5bc0af12917e3bb17e1086050d25cdf7ba604f7fc422653c99f884c",
-    "zh:7d920ac05c45e77c59c49e0dd0cb010d64202c5a2fdfde6d9efe3dc61e396c97",
-    "zh:8a495e49f8fcbe276a74911f9ca48381533686ff71a9d4f7027bb9109769b639",
-    "zh:8ab9769581dfc1675c645e33e7ab8fea6ad1acc9e232eeda823070447e5ecaf1",
-    "zh:a170ecc560d49c251f4bebb6d6a82ff3637ae16a0f779a53489d4a64ddd1ee6a",
-    "zh:d9178201057b62666691ec206d1fbe09965bcfea532085b4e31f46073bf5898f",
+    "h1:62MWy6fGx/cVk1DnLcc8rUxCCKhi6/R9fi/Af/ph9ag=",
   ]
 }

--- a/accounts/platform/.terraform.lock.hcl
+++ b/accounts/platform/.terraform.lock.hcl
@@ -18,20 +18,3 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:d9178201057b62666691ec206d1fbe09965bcfea532085b4e31f46073bf5898f",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/template" {
-  version = "2.2.0"
-  hashes = [
-    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
-    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
-    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
-    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
-    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
-    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
-    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
-    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
-    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
-    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
-    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
-  ]
-}

--- a/accounts/platform/account.tf
+++ b/accounts/platform/account.tf
@@ -19,7 +19,7 @@ module "account_federation" {
   source = "../modules/account/federated"
 
   saml_xml = data.aws_s3_bucket_object.account_federation_saml.body
-  pgp_key  = data.template_file.pgp_key.rendered
+  pgp_key  = file("${path.module}/wellcomedigitalplatform.pub")
 
   prefix = "azure_sso"
 }

--- a/accounts/platform/account.tf
+++ b/accounts/platform/account.tf
@@ -24,6 +24,32 @@ module "account_federation" {
   prefix = "azure_sso"
 }
 
+# This is the SAML metadata that enables us to log in to AWS using Azure AD
+# and SSO.  It is given to us by D&T, and can also be managed in the
+# "Identity Providers" pane of the IAM console [1].
+#
+# You can upload a new SAML file to the bucket like so:
+#
+#       AWS_PROFILE=platform-dev aws s3 cp \
+#         --content-type 'text/xml' \
+#         /file/from/d_and_t.xml \
+#         s3://wellcomecollection-platform-infra/platform-terraform-objects/saml.xml*/
+#
+# The Content-Type header is significant here: the `aws_s3_bucket_object`
+# data source won't fetch the Body of the object [2].  This will cause the
+# following somewhat non-obvious error:
+#
+#       Error: Missing required argument
+#
+#         with module.account_federation.aws_iam_saml_provider.saml_provider,
+#         on ../modules/account/federated/main.tf line 13, in resource "aws_iam_saml_provider" "saml_provider":
+#         13:   saml_metadata_document = var.saml_xml
+#
+#       The argument "saml_metadata_document" is required, but no definition was found.
+#
+# [1]: https://us-east-1.console.aws.amazon.com/iamv2/home?region=us-east-1#/identity_providers
+# [2]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket_object
+#
 data "aws_s3_bucket_object" "account_federation_saml" {
   bucket = "wellcomecollection-platform-infra"
   key    = "platform-terraform-objects/saml.xml"

--- a/accounts/platform/account.tf
+++ b/accounts/platform/account.tf
@@ -18,7 +18,7 @@ module "aws_account" {
 module "account_federation" {
   source = "../modules/account/federated"
 
-  saml_xml = data.aws_s3_bucket_object.account_federation_saml.body
+  saml_xml = data.aws_s3_object.account_federation_saml.body
   pgp_key  = file("${path.module}/wellcomedigitalplatform.pub")
 
   prefix = "azure_sso"
@@ -35,7 +35,7 @@ module "account_federation" {
 #         /file/from/d_and_t.xml \
 #         s3://wellcomecollection-platform-infra/platform-terraform-objects/saml.xml*/
 #
-# The Content-Type header is significant here: the `aws_s3_bucket_object`
+# The Content-Type header is significant here: the `aws_s3_object`
 # data source won't fetch the Body of the object [2].  This will cause the
 # following somewhat non-obvious error:
 #
@@ -48,9 +48,9 @@ module "account_federation" {
 #       The argument "saml_metadata_document" is required, but no definition was found.
 #
 # [1]: https://us-east-1.console.aws.amazon.com/iamv2/home?region=us-east-1#/identity_providers
-# [2]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket_object
+# [2]: https://registry.terraform.io/providers/hashicorp%20%20/aws/latest/docs/data-sources/s3_object
 #
-data "aws_s3_bucket_object" "account_federation_saml" {
+data "aws_s3_object" "account_federation_saml" {
   bucket = "wellcomecollection-platform-infra"
   key    = "platform-terraform-objects/saml.xml"
 }

--- a/accounts/platform/provider.tf
+++ b/accounts/platform/provider.tf
@@ -10,7 +10,7 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-admin"
   }
-  
+
   default_tags {
     tags = local.default_tags
   }

--- a/accounts/platform/provider.tf
+++ b/accounts/platform/provider.tf
@@ -1,7 +1,17 @@
+locals {
+  default_tags = {
+    TerraformConfigurationURL = "https://github.com/wellcomecollection/platform-infrastructure/tree/main/accounts/platform"
+  }
+}
+
 provider "aws" {
   region = "eu-west-1"
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-admin"
+  }
+  
+  default_tags {
+    tags = local.default_tags
   }
 }

--- a/accounts/platform/s3_editorial_photography.tf
+++ b/accounts/platform/s3_editorial_photography.tf
@@ -1,11 +1,22 @@
 resource "aws_s3_bucket" "editorial_photography" {
   bucket = "wellcomecollection-editorial-photography"
-  acl    = "private"
 
-  lifecycle_rule {
-    id      = "start_ia_move_to_glacier"
-    enabled = true
-    prefix  = ""
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_acl" "editorial_photography" {
+  bucket = aws_s3_bucket.editorial_photography.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "editorial_photography" {
+  bucket = aws_s3_bucket.editorial_photography.id
+
+  rule {
+    id     = "start_ia_move_to_glacier"
+    status = "Enabled"
 
     transition {
       days          = 30
@@ -18,20 +29,21 @@ resource "aws_s3_bucket" "editorial_photography" {
     }
   }
 
-  versioning {
-    enabled = true
-  }
-
-  lifecycle {
-    prevent_destroy = true
-  }
-
-  lifecycle_rule {
-    enabled = true
+  rule {
+    id     = "expire_old_versions"
+    status = "Enabled"
 
     noncurrent_version_expiration {
-      days = 30
+      noncurrent_days = 30
     }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "editorial_photography" {
+  bucket = aws_s3_bucket.editorial_photography.id
+
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 

--- a/accounts/platform/terraform.tf
+++ b/accounts/platform/terraform.tf
@@ -143,7 +143,3 @@ data "terraform_remote_state" "accounts_dam_prototype" {
 }
 
 data "aws_caller_identity" "current" {}
-
-data "template_file" "pgp_key" {
-  template = file("${path.module}/wellcomedigitalplatform.pub")
-}


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5557

I had to change the SAML file yesterday so it's fresh in my mind; I didn't realise it was configured in Terraform or I'd have handled it there.

It took a bit of finagling to let Terraform remove it – I tried removing the resources and running `terraform init`, but it wouldn't budge. Then I used `terraform providers` to see it was being pulled in through the state but not any resources; I ran `terraform apply -refresh-only` and then `terraform init`, and that removed it.