### PR TITLE
Remove the template provider from the monitoring stack

### DIFF
--- a/monitoring/terraform/.terraform.lock.hcl
+++ b/monitoring/terraform/.terraform.lock.hcl
@@ -54,10 +54,3 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/template" {
-  version = "2.2.0"
-  hashes = [
-    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
-  ]
-}

--- a/monitoring/terraform/modules/efs_host/main.tf
+++ b/monitoring/terraform/modules/efs_host/main.tf
@@ -10,18 +10,16 @@ module "asg" {
   subnet_list = var.subnets
   vpc_id      = var.vpc_id
   key_name    = var.key_name
-  user_data   = data.template_file.userdata.rendered
+
+  user_data = templatefile(
+    "${path.module}/efs.tpl",
+    {
+      cluster_name  = var.cluster_name
+      efs_fs_id     = var.efs_fs_id
+      efs_host_path = var.efs_host_path
+      region        = var.region
+    }
+  )
 
   instance_type = var.instance_type
-}
-
-data "template_file" "userdata" {
-  template = file("${path.module}/efs.tpl")
-
-  vars = {
-    cluster_name  = var.cluster_name
-    efs_fs_id     = var.efs_fs_id
-    efs_host_path = var.efs_host_path
-    region        = var.region
-  }
 }

--- a/monitoring/terraform/modules/ondemand/asg.tf
+++ b/monitoring/terraform/modules/ondemand/asg.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudformation_stack" "ecs_asg" {
-  name          = var.name
+  name = var.name
   template_body = templatefile(
     "${path.module}/asg.json.template",
     {

--- a/monitoring/terraform/modules/ondemand/asg.tf
+++ b/monitoring/terraform/modules/ondemand/asg.tf
@@ -1,21 +1,18 @@
 resource "aws_cloudformation_stack" "ecs_asg" {
   name          = var.name
-  template_body = data.template_file.cluster_ecs_asg.rendered
+  template_body = templatefile(
+    "${path.module}/asg.json.template",
+    {
+      launch_config_name  = aws_launch_configuration.launch_config.name
+      vpc_zone_identifier = jsonencode(var.subnet_list)
+      asg_min_size        = 1
+      asg_desired_size    = 1
+      asg_max_size        = 2
+      asg_name            = var.name
+    }
+  )
 
   lifecycle {
     create_before_destroy = true
-  }
-}
-
-data "template_file" "cluster_ecs_asg" {
-  template = file("${path.module}/asg.json.template")
-
-  vars = {
-    launch_config_name  = aws_launch_configuration.launch_config.name
-    vpc_zone_identifier = jsonencode(var.subnet_list)
-    asg_min_size        = 1
-    asg_desired_size    = 1
-    asg_max_size        = 2
-    asg_name            = var.name
   }
 }

--- a/monitoring/terraform/stack/grafana/main.tf
+++ b/monitoring/terraform/stack/grafana/main.tf
@@ -27,7 +27,7 @@ locals {
 }
 
 module "task" {
-  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//task_definition/single_container?ref=v1.5.0"
+  source = "./task_definition"
 
   task_name = var.namespace
 

--- a/monitoring/terraform/stack/grafana/task_definition/container_definition.tf
+++ b/monitoring/terraform/stack/grafana/task_definition/container_definition.tf
@@ -1,0 +1,59 @@
+data "template_file" "container_definition" {
+  template = "${file("${path.module}/task_definition.json.tpl")}"
+
+  vars = {
+    use_aws_logs = var.use_awslogs
+
+    log_group_region = var.aws_region
+    log_group_name   = aws_cloudwatch_log_group.log_group.name
+    log_group_prefix = "ecs"
+
+    container_image = var.container_image
+    container_name  = var.container_name
+
+    secrets = module.secrets.env_vars_string
+
+    environment_vars = jsonencode([
+      for key in sort(keys(var.env_vars)) :
+      {
+        name  = key
+        value = lookup(var.env_vars, key)
+      }
+    ])
+
+    command = jsonencode(var.command)
+
+    cpu    = var.cpu
+    memory = var.memory
+
+    mount_points = jsonencode(var.mount_points)
+
+    user = var.user
+
+    port_mappings_defined = var.container_port == "" ? false : true
+
+    port_mappings = jsonencode([
+      {
+        "containerPort" = var.container_port,
+
+        # TODO: I think we can safely drop both these arguments.
+        "hostPort" = var.container_port,
+        "protocol" = "tcp"
+      }
+    ])
+  }
+}
+
+resource "aws_cloudwatch_log_group" "log_group" {
+  name = "ecs/${var.task_name}"
+
+  retention_in_days = 7
+}
+
+module "secrets" {
+  source = "./secrets"
+
+  secret_env_vars = var.secret_env_vars
+
+  execution_role_name = module.task_role.task_execution_role_name
+}

--- a/monitoring/terraform/stack/grafana/task_definition/outputs.tf
+++ b/monitoring/terraform/stack/grafana/task_definition/outputs.tf
@@ -1,0 +1,11 @@
+output "arn" {
+  value = aws_ecs_task_definition.task.arn
+}
+
+output "task_role_name" {
+  value = module.task_role.name
+}
+
+output "task_role_arn" {
+  value = module.task_role.task_role_arn
+}

--- a/monitoring/terraform/stack/grafana/task_definition/secrets/iam.tf
+++ b/monitoring/terraform/stack/grafana/task_definition/secrets/iam.tf
@@ -1,0 +1,50 @@
+# This gives permissions for the execution role to read the necessary
+# parameters and secrets from SSM and KMS.
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  ssm_arn_prefix     = "arn:aws:ssm:eu-west-1:${data.aws_caller_identity.current.account_id}:parameter/aws/reference/secretsmanager"
+  secrets_arn_prefix = "arn:aws:secretsmanager:eu-west-1:${data.aws_caller_identity.current.account_id}:secret"
+
+  # These locals construct a list of ARNs for the SSM and SecretsManager
+  # resources associated with our secret environment variables.
+  #
+  # This allows us to scope the execution role so each app can only read
+  # the secrets that it actually uses.
+  #
+  ssm_resources = formatlist("${local.ssm_arn_prefix}/%s", "${values(var.secret_env_vars)}")
+
+  secrets_resources = formatlist("${local.secrets_arn_prefix}:%s*", "${values(var.secret_env_vars)}")
+}
+
+data "aws_iam_policy_document" "read_secrets" {
+  statement {
+    actions = [
+      "ssm:GetParameters",
+    ]
+
+    resources = local.ssm_resources
+  }
+
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+
+    resources = local.secrets_resources
+  }
+}
+
+locals {
+  secret_env_vars_length = length(var.secret_env_vars)
+}
+
+resource "aws_iam_role_policy" "allow_read_secrets" {
+  # If there aren't any environment variables, the policy document will be
+  # empty and we can skip creating the policy.
+  count = local.secret_env_vars_length > 0 ? 1 : 0
+
+  role   = var.execution_role_name
+  policy = data.aws_iam_policy_document.read_secrets.json
+}

--- a/monitoring/terraform/stack/grafana/task_definition/secrets/main.tf
+++ b/monitoring/terraform/stack/grafana/task_definition/secrets/main.tf
@@ -1,25 +1,9 @@
-data "template_file" "name_val_pair" {
-  # This module constructs a JSON string in the same way as the `env_vars`
-  # module, and has the same issue that requires us to pass the length of
-  # the env_vars map as a variable.
-  count = local.secret_env_vars_length
-
-  template = <<EOF
-  {
-    "name": $${jsonencode(key)},
-    "valueFrom": $${jsonencode(value)}
-  }
-EOF
-
-  vars = {
-    key = element(keys(var.secret_env_vars), count.index)
-
-    # This prefix allows us to access a SecretsManager secret via SSM.
-    # See https://docs.aws.amazon.com/systems-manager/latest/userguide/integration-ps-secretsmanager.html
-    value = "/aws/reference/secretsmanager/${element(values(var.secret_env_vars), count.index)}"
-  }
-}
-
 locals {
-  env_var_string = "[${join(", ", "${data.template_file.name_val_pair.*.rendered}")}]"
+  env_var_string = jsonencode([
+    for key in sort(keys(var.secret_env_vars)) :
+    {
+      name      = key
+      valueFrom = "/aws/reference/secretsmanager/${lookup(var.secret_env_vars, key)}"
+    }
+  ])
 }

--- a/monitoring/terraform/stack/grafana/task_definition/secrets/main.tf
+++ b/monitoring/terraform/stack/grafana/task_definition/secrets/main.tf
@@ -1,0 +1,25 @@
+data "template_file" "name_val_pair" {
+  # This module constructs a JSON string in the same way as the `env_vars`
+  # module, and has the same issue that requires us to pass the length of
+  # the env_vars map as a variable.
+  count = local.secret_env_vars_length
+
+  template = <<EOF
+  {
+    "name": $${jsonencode(key)},
+    "valueFrom": $${jsonencode(value)}
+  }
+EOF
+
+  vars = {
+    key = element(keys(var.secret_env_vars), count.index)
+
+    # This prefix allows us to access a SecretsManager secret via SSM.
+    # See https://docs.aws.amazon.com/systems-manager/latest/userguide/integration-ps-secretsmanager.html
+    value = "/aws/reference/secretsmanager/${element(values(var.secret_env_vars), count.index)}"
+  }
+}
+
+locals {
+  env_var_string = "[${join(", ", "${data.template_file.name_val_pair.*.rendered}")}]"
+}

--- a/monitoring/terraform/stack/grafana/task_definition/secrets/outputs.tf
+++ b/monitoring/terraform/stack/grafana/task_definition/secrets/outputs.tf
@@ -1,0 +1,3 @@
+output "env_vars_string" {
+  value = local.env_var_string
+}

--- a/monitoring/terraform/stack/grafana/task_definition/secrets/variables.tf
+++ b/monitoring/terraform/stack/grafana/task_definition/secrets/variables.tf
@@ -1,0 +1,6 @@
+variable "secret_env_vars" {
+  description = "Secure environment variables to pass to the container"
+  type        = map(string)
+}
+
+variable "execution_role_name" {}

--- a/monitoring/terraform/stack/grafana/task_definition/task_definition.json.tpl
+++ b/monitoring/terraform/stack/grafana/task_definition/task_definition.json.tpl
@@ -1,0 +1,28 @@
+[
+  {
+    "cpu": ${cpu},
+    "memory": ${memory},
+    "essential": true,
+    "image": "${container_image}",
+    "name": "${container_name}",
+    "environment": ${environment_vars},
+    "secrets": ${secrets},
+    "networkMode": "awsvpc",
+    "command": ${command},
+    %{ if port_mappings_defined }
+    "portMappings": ${port_mappings},
+    %{ endif }
+    %{ if use_aws_logs }
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${log_group_name}",
+            "awslogs-region": "${log_group_region}",
+            "awslogs-stream-prefix": "${log_group_prefix}"
+        }
+    },
+    %{ endif }
+    "user": "${user}",
+    "mountPoints": ${mount_points}
+  }
+]

--- a/monitoring/terraform/stack/grafana/task_definition/task_definition.tf
+++ b/monitoring/terraform/stack/grafana/task_definition/task_definition.tf
@@ -1,0 +1,67 @@
+module "task_role" {
+  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition/iam_role/?ref=v3.12.0"
+
+  task_name = var.task_name
+}
+
+resource "aws_ecs_task_definition" "task" {
+  family                = var.task_name
+  container_definitions = data.template_file.container_definition.rendered
+
+  task_role_arn      = module.task_role.task_role_arn
+  execution_role_arn = module.task_role.task_execution_role_arn
+
+  network_mode = "awsvpc"
+
+  requires_compatibilities = [var.launch_type]
+
+  cpu    = var.cpu
+  memory = var.memory
+
+  # This is a slightly obtuse way to make these two blocks conditional.
+  # They should only be created if this task definition is using EBS volume
+  # mounts; otherwise they should be ignored.
+  #
+  # This is a kludge around Terraform's "dynamic blocks".
+  # See https://www.terraform.io/docs/configuration/expressions.html#dynamic-blocks
+  #
+  # There's an open feature request on the Terraform repo to add syntactic
+  # sugar for this sort of conditional block.  If that ever arises, we should
+  # use that instead.  See https://github.com/hashicorp/terraform/issues/21512
+  dynamic "volume" {
+    for_each = var.ebs_volume_name == "" ? [] : [{}]
+
+    content {
+      name      = var.ebs_volume_name
+      host_path = var.ebs_host_path
+    }
+  }
+
+  dynamic "placement_constraints" {
+    for_each = var.ebs_volume_name == "" ? [] : [{}]
+
+    content {
+      type       = "memberOf"
+      expression = "attribute:ebs.volume exists"
+    }
+  }
+
+  # We do the same as above for the EFS volume.
+  dynamic "volume" {
+    for_each = var.efs_volume_name == "" ? [] : [{}]
+
+    content {
+      name      = var.efs_volume_name
+      host_path = var.efs_host_path
+    }
+  }
+
+  dynamic "placement_constraints" {
+    for_each = var.efs_volume_name == "" ? [] : [{}]
+
+    content {
+      type       = "memberOf"
+      expression = "attribute:efs.volume exists"
+    }
+  }
+}

--- a/monitoring/terraform/stack/grafana/task_definition/task_definition.tf
+++ b/monitoring/terraform/stack/grafana/task_definition/task_definition.tf
@@ -6,7 +6,7 @@ module "task_role" {
 
 resource "aws_ecs_task_definition" "task" {
   family                = var.task_name
-  container_definitions = data.template_file.container_definition.rendered
+  container_definitions = local.container_definition
 
   task_role_arn      = module.task_role.task_role_arn
   execution_role_arn = module.task_role.task_execution_role_arn

--- a/monitoring/terraform/stack/grafana/task_definition/variables.tf
+++ b/monitoring/terraform/stack/grafana/task_definition/variables.tf
@@ -16,7 +16,7 @@ variable "mount_points" {
 }
 
 variable "use_awslogs" {
-  type = bool
+  type    = bool
   default = false
 }
 

--- a/monitoring/terraform/stack/grafana/task_definition/variables.tf
+++ b/monitoring/terraform/stack/grafana/task_definition/variables.tf
@@ -1,0 +1,70 @@
+variable "task_name" {}
+
+variable "container_image" {}
+
+variable "cpu" {
+  default = 512
+}
+
+variable "memory" {
+  default = 1024
+}
+
+variable "mount_points" {
+  type    = list(map(string))
+  default = []
+}
+
+variable "use_awslogs" {
+  type = bool
+  default = false
+}
+
+variable "command" {
+  type    = list(string)
+  default = []
+}
+
+variable "env_vars" {
+  description = "Environment variables to pass to the container"
+  type        = map(string)
+  default     = {}
+}
+
+variable "secret_env_vars" {
+  description = "Secure environment variables to pass to the container"
+  type        = map(string)
+  default     = {}
+}
+
+variable "container_port" {}
+
+variable "container_name" {
+  default = "app"
+}
+
+variable "ebs_volume_name" {
+  default = ""
+}
+
+variable "ebs_host_path" {
+  default = ""
+}
+
+variable "efs_volume_name" {
+  default = ""
+}
+
+variable "efs_host_path" {
+  default = ""
+}
+
+variable "user" {
+  default = "root"
+}
+
+variable "launch_type" {
+  default = "FARGATE"
+}
+
+variable "aws_region" {}


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5557

I think this should allow @melanierogan to use Terraform on her M1 MacBook without getting warnings about an unavailable provider. 🤞 I've had to inline the module which defines our Grafana instance, which is v old – tbh we should probably move this to managed Grafana or similar, but it's never been high enough priority.