### PR TITLE
Create an nginx Docker image that redacts PII in query parameters

### DIFF
--- a/images/dockerfiles/nginx/frontend.nginx.conf
+++ b/images/dockerfiles/nginx/frontend.nginx.conf
@@ -19,21 +19,6 @@ http {
     location / {
       proxy_set_header Host $host;
       proxy_pass http://${APP_HOST}:${APP_PORT}/;
-
-      # Session cookies for the identity app on wc.org are large (~3.5kb) because they need
-      # to contain an access token, ID token, refresh token, and some associated metadata.
-      #
-      # This makes full response sizes for setting these cookies (ie the Auth0 callbacks)
-      # large as well (~4.5kb). The default proxy buffer size is 4k, so it needs to be increased.
-      # Otherwise, we get an error like:
-      #
-      # > upstream sent too big header while reading response header from upstream
-      #
-      # See the docs for the specific meanings of these incantations:
-      # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size
-      proxy_buffer_size        8k;
-      proxy_buffers            8 8k;
-      proxy_busy_buffers_size  16k;
     }
 
     location /management/healthcheck {

--- a/images/dockerfiles/nginx/frontend_identity.nginx.conf
+++ b/images/dockerfiles/nginx/frontend_identity.nginx.conf
@@ -1,0 +1,44 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+  server {
+    listen 80;
+    server_tokens off;
+
+    gzip            on;
+    gzip_types      text/css application/javascript application/json;
+    gzip_min_length 860;
+    gzip_proxied    any;
+
+    # This has been increased from the 1m default to accommodate
+    # large requests to the Lighthouse CI server
+    client_max_body_size 2m;
+
+    location / {
+      proxy_set_header Host $host;
+      proxy_pass http://${APP_HOST}:${APP_PORT}/;
+
+      # Session cookies for the identity app on wc.org are large (~3.5kb) because they need
+      # to contain an access token, ID token, refresh token, and some associated metadata.
+      #
+      # This makes full response sizes for setting these cookies (ie the Auth0 callbacks)
+      # large as well (~4.5kb). The default proxy buffer size is 4k, so it needs to be increased.
+      # Otherwise, we get an error like:
+      #
+      # > upstream sent too big header while reading response header from upstream
+      #
+      # See the docs for the specific meanings of these incantations:
+      # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size
+      proxy_buffer_size        8k;
+      proxy_buffers            8 8k;
+      proxy_busy_buffers_size  16k;
+    }
+
+    location /management/healthcheck {
+      add_header Content-Type text/plain;
+      return 200 'OK';
+    }
+  }
+}

--- a/images/dockerfiles/nginx/frontend_identity.nginx.conf
+++ b/images/dockerfiles/nginx/frontend_identity.nginx.conf
@@ -3,6 +3,22 @@ worker_processes 1;
 events { worker_connections 1024; }
 
 http {
+  # This redacts PII in the nginx logs.
+  #
+  #   - session_token is a JWT passed around in the sign-up flow that
+  #     encodes PII, including user email addresses
+  #   - email is a query parameter used in the sign-up flow when the
+  #     user is redirected to the /success page
+  #
+  # Based on https://serverfault.com/q/1046249/206273
+  log_format  main  '$remote_addr - $remote_user [$time_local] $host "$customrequest" '
+                    '$status $body_bytes_sent $request_time "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+  map $request $customrequest {
+          ~^(.*)(session_token|email)(.*)$   "$1***$3";
+          default                 $request;
+  }
+
   server {
     listen 80;
     server_tokens off;

--- a/images/dockerfiles/nginx/frontend_identity.nginx.conf
+++ b/images/dockerfiles/nginx/frontend_identity.nginx.conf
@@ -10,14 +10,25 @@ http {
   #   - email is a query parameter used in the sign-up flow when the
   #     user is redirected to the /success page
   #
-  # Based on https://serverfault.com/q/1046249/206273
+  # Note: we deliberately omit the referrer from the nginx log to avoid
+  # logging the email/session_token when calling the /account/api/auth/me
+  # endpoint from a URL with PII.
+  #
+  # Based on https://serverfault.com/q/1046302/206273
   log_format  main  '$remote_addr - $remote_user [$time_local] $host "$customrequest" '
-                    '$status $body_bytes_sent $request_time "$http_referer" '
+                    '$status $body_bytes_sent $request_time '
                     '"$http_user_agent" "$http_x_forwarded_for"';
-  map $request $customrequest {
-          ~^(.*)(session_token|email)(.*)$   "$1***$3";
-          default                 $request;
+
+  map $request $custom1 {
+      ~^(?<prefix1>.*[\?&]email=)([^&]*)(?<suffix1>.*)$  "${prefix1}[redacted]$suffix1";
+      default                                               $request;
   }
+  map $custom1 $customrequest {
+      ~^(?<prefix2>.*[\?&]session_token=)([^&]*)(?<suffix2>.*)$ "${prefix2}[redacted]$suffix2";
+      default                                               $custom1;
+  }
+
+  access_log /dev/stdout main;
 
   server {
     listen 80;

--- a/images/dockerfiles/publish_nginx_images.sh
+++ b/images/dockerfiles/publish_nginx_images.sh
@@ -8,7 +8,7 @@ ROOT=$(git rev-parse --show-toplevel)
 ECR_PRIVATE_PREFIX="760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome"
 ECR_PUBLIC_PREFIX="public.ecr.aws/l7a1d1z4"
 
-SERVICE_IDS="apigw frontend frontend_identity grafana"
+SERVICE_IDS="frontend_identity"
 
 echo ""
 echo "*** WARNING! ***"

--- a/images/dockerfiles/publish_nginx_images.sh
+++ b/images/dockerfiles/publish_nginx_images.sh
@@ -8,7 +8,7 @@ ROOT=$(git rev-parse --show-toplevel)
 ECR_PRIVATE_PREFIX="760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome"
 ECR_PUBLIC_PREFIX="public.ecr.aws/l7a1d1z4"
 
-SERVICE_IDS="apigw frontend grafana"
+SERVICE_IDS="apigw frontend frontend_identity grafana"
 
 echo ""
 echo "*** WARNING! ***"

--- a/images/terraform/ecr.tf
+++ b/images/terraform/ecr.tf
@@ -97,6 +97,13 @@ module "nginx_frontend" {
   repo_name   = module.ecr_nginx_frontend.private_repo_name
 }
 
+module "nginx_frontend_identity" {
+  source = "./repo_policy"
+
+  account_ids = local.account_ids
+  repo_name   = module.ecr_nginx_frontend_identity.private_repo_name
+}
+
 module "fluentbit" {
   source = "./repo_policy"
 

--- a/images/terraform/ecr.tf
+++ b/images/terraform/ecr.tf
@@ -36,6 +36,19 @@ module "ecr_nginx_frontend" {
   }
 }
 
+module "ecr_nginx_frontend_identity" {
+  source = "./repo_pair"
+
+  namespace = local.namespace
+  repo_name = "nginx_frontend_identity"
+
+  description = "An nginx image for reverse proxying in the identity web app"
+
+  providers = {
+    aws.ecr_public = aws.ecr_public
+  }
+}
+
 module "ecr_nginx_grafana" {
   source = "./repo_pair"
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/8121

This creates a new nginx image solely for use by the identity web app, which redacts certain query parameters which we know will contain PII.

Before:

> 172.19.82.22 - - [04/Jul/2022:12:55:50 +0000] "GET /account/success?email=**alex@alexwlchan.net** HTTP/1.1" 200 47350 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Safari/605.1.15"

After:

> 172.19.12.51 - - [04/Jul/2022:13:17:16 +0000] www-stage.wellcomecollection.org "GET /account/success?email=**[redacted]**" 200 47351 0.535 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Safari/605.1.15" "79.68.63.8, 64.252.152.81"

