### PR TITLE
SBT wrapper should not be verbose

### DIFF
--- a/images/dockerfiles/sbt_wrapper/run_sbt.sh
+++ b/images/dockerfiles/sbt_wrapper/run_sbt.sh
@@ -2,7 +2,6 @@
 
 set -o errexit
 set -o nounset
-set -o verbose
 
 source ~/.env.sh
 


### PR DESCRIPTION
This verbosity is a pain when you want piped command output, and doesn't add much value