### PR TITLE
Add CNAME record for cardigan chromatic

### DIFF
--- a/cloudfront/wellcomecollection.org/terraform/main.tf
+++ b/cloudfront/wellcomecollection.org/terraform/main.tf
@@ -9,6 +9,18 @@ resource "aws_route53_record" "docs" {
   provider = aws.dns
 }
 
+// This adds a CNAME record for our Chromatic instance of Storybook.
+// It will be up to date with what's in the main branch.
+resource "aws_route53_record" "cardigan" {
+  zone_id = data.aws_route53_zone.weco_zone.id
+  name    = "cardigan.wellcomecollection.org"
+  type    = "CNAME"
+  records = ["domains.chromatic.com"]
+  ttl     = "300"
+
+  provider = aws.dns
+}
+
 resource "aws_route53_record" "rank" {
   zone_id = data.aws_route53_zone.weco_zone.id
   name    = "rank.wellcomecollection.org"


### PR DESCRIPTION
## What's changing and why?
Adding a CNAME record pointing at `domains.chromatic.com` so that whatever version of  Chromatic Storybook is currently in the main branch of `wellcomecollection.org` will available at `cardigan.wellcomecollection.org`.

## `terraform plan` diff
Terraform will perform the following actions:
```
  # aws_route53_record.cardigan will be created
  + resource "aws_route53_record" "cardigan" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "cardigan.wellcomecollection.org"
      + records         = [
          + "domains.chromatic.com",
        ]
      + ttl             = 300
      + type            = "CNAME"
      + zone_id         = "Z0902614YH73JBCZG1MA"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```