### PR TITLE
Add redirects for alpha.wc.org and blog.wc.org

### DIFF
--- a/cloudfront/wellcomecollection.org/terraform/main.tf
+++ b/cloudfront/wellcomecollection.org/terraform/main.tf
@@ -22,6 +22,8 @@ locals {
 
   # Subdomains that should be redirected to wellcomecollection.org
   redirect_subdomains_to_apex = [
+    "alpha.wellcomecollection.org",
+    "blog.wellcomecollection.org",
     "www.wellcomecollection.org",
   ]
 }


### PR DESCRIPTION
## What's changing and why?

Adding redirects for alpha.wc.org and blog.wc.org, which are both defunct subdomains we want to be redirecting to the new site.

For https://github.com/wellcomecollection/wellcomecollection.org/issues/8273; for https://github.com/wellcomecollection/platform/issues/4462

## `terraform plan` diff

Already applied.
