### PR TITLE
Allow other accounts to use ecr:DescribeImages on shared images

### DIFF
--- a/images/terraform/repo_policy/main.tf
+++ b/images/terraform/repo_policy/main.tf
@@ -9,6 +9,7 @@ data "aws_iam_policy_document" "get_images" {
       "ecr:GetDownloadUrlForLayer",
       "ecr:BatchGetImage",
       "ecr:BatchCheckLayerAvailability",
+      "ecr:DescribeImages",
     ]
 
     principals {


### PR DESCRIPTION
This is needed for [the ](https://github.com/wellcomecollection/platform/issues/5597)