### PR TITLE
Make sure we actually filter out 'password too common' errors

### DIFF
--- a/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
+++ b/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
@@ -118,7 +118,7 @@ def should_alert_for_event(log_event):
         ],
         # fs = Failed Signup
         "fs": [
-            "Password is not allowed, it might be too common.",
+            "Password is too common",
             "The user already exists.",
             # This is the error we get from Sierra when it rejects
             # somebody's password.


### PR DESCRIPTION
This is what a log event with this error looks like:

    {
      "type": "fs",
      "description": "Password is too common",
      "details": {
        "description": "Password is not allowed, it might be too common.",
        …
      },
      …
    }

The previous string was matching on `details.description`, but in fact this Lambda receives `description`, so that's what we should be checking.

See https://github.com/wellcomecollection/identity/blob/main/infra/scoped/auth0-logs.tf#L55