### PR TITLE
Ignore lb ingress changes and add notes

### DIFF
--- a/monitoring/terraform/README.md
+++ b/monitoring/terraform/README.md
@@ -1,58 +1,5 @@
 # Terraforming the monitoring infrastructure
 
-## Unexpected changes
-
-When running terraform plan, you may see some unexpected changes, reporting that some eu-west-1 resources will
-change to us-east-1 (see below).
-
-Although this is irritating, it appears to have no effect, so is nothing to worry about.  Do not let it block you
-from deploying the changes you actually expect.
-
-```
-# module.experience_cloudfront_alerts.module.lambda_error_alerts.module.lambda_errors_to_slack_alerts.module.lambda.aws_iam_role_policy.cloudwatch_logs will be updated in-place
-
-~ resource "aws_iam_role_policy" "cloudwatch_logs" {
-id     = "lambda_experience_lambda_errors_to_slack_alerts_iam_role:lambda_experience_lambda_errors_to_slack_alerts_iam_role_lambda_cloudwatch_logs"
-name   = "lambda_experience_lambda_errors_to_slack_alerts_iam_role_lambda_cloudwatch_logs"
-~ policy = jsonencode(
-~ {
-~ Statement = [
-~ {
-~ Resource = [
-- "arn:aws:logs:eu-west-1:130871440101:log-group:/aws/lambda/experience_lambda_errors_to_slack_alerts:*",
-- "arn:aws:logs:eu-west-1:130871440101:log-group:/aws/lambda/experience_lambda_errors_to_slack_alerts",
-+ "arn:aws:logs:us-east-1:130871440101:log-group:/aws/lambda/experience_lambda_errors_to_slack_alerts:*",
-+ "arn:aws:logs:us-east-1:130871440101:log-group:/aws/lambda/experience_lambda_errors_to_slack_alerts",
-]
-# (3 unchanged elements hidden)
-},
-]
-# (1 unchanged element hidden)
-}
-)
-# (1 unchanged attribute hidden)
-}
-
-# module.experience_cloudfront_alerts.module.lambda_error_alerts.module.lambda_errors_to_slack_alerts.module.lambda.aws_iam_role_policy.lambda_dlq will be updated in-place
-~ resource "aws_iam_role_policy" "lambda_dlq" {
-id     = "lambda_experience_lambda_errors_to_slack_alerts_iam_role:lambda_experience_lambda_errors_to_slack_alerts_iam_role_lambda_dlq"
-name   = "lambda_experience_lambda_errors_to_slack_alerts_iam_role_lambda_dlq"
-~ policy = jsonencode(
-~ {
-~ Statement = [
-~ {
-~ Resource = "arn:aws:sqs:eu-west-1:130871440101:lambda-experience_lambda_errors_to_slack_alerts_dlq" -> "arn:aws:sqs:us-east-1:130871440101:lambda-experience_lambda_errors_to_slack_alerts_dlq"
-# (3 unchanged elements hidden)
-},
-]
-# (1 unchanged element hidden)
-}
-)
-# (1 unchanged attribute hidden)
-}
-
-```
-
 ## Grafana Loadbalancer Security Group
 
 The Grafana loadbalancer security group is normally maintained manually, so changes are ignored by Terraform.

--- a/monitoring/terraform/README.md
+++ b/monitoring/terraform/README.md
@@ -1,0 +1,59 @@
+# Terraforming the monitoring infrastructure
+
+## Unexpected changes
+
+When running terraform plan, you may see some unexpected changes, reporting that some eu-west-1 resources will
+change to us-east-1 (see below).
+
+Although this is irritating, it appears to have no effect, so is nothing to worry about.  Do not let it block you
+from deploying the changes you actually expect.
+
+```
+# module.experience_cloudfront_alerts.module.lambda_error_alerts.module.lambda_errors_to_slack_alerts.module.lambda.aws_iam_role_policy.cloudwatch_logs will be updated in-place
+
+~ resource "aws_iam_role_policy" "cloudwatch_logs" {
+id     = "lambda_experience_lambda_errors_to_slack_alerts_iam_role:lambda_experience_lambda_errors_to_slack_alerts_iam_role_lambda_cloudwatch_logs"
+name   = "lambda_experience_lambda_errors_to_slack_alerts_iam_role_lambda_cloudwatch_logs"
+~ policy = jsonencode(
+~ {
+~ Statement = [
+~ {
+~ Resource = [
+- "arn:aws:logs:eu-west-1:130871440101:log-group:/aws/lambda/experience_lambda_errors_to_slack_alerts:*",
+- "arn:aws:logs:eu-west-1:130871440101:log-group:/aws/lambda/experience_lambda_errors_to_slack_alerts",
++ "arn:aws:logs:us-east-1:130871440101:log-group:/aws/lambda/experience_lambda_errors_to_slack_alerts:*",
++ "arn:aws:logs:us-east-1:130871440101:log-group:/aws/lambda/experience_lambda_errors_to_slack_alerts",
+]
+# (3 unchanged elements hidden)
+},
+]
+# (1 unchanged element hidden)
+}
+)
+# (1 unchanged attribute hidden)
+}
+
+# module.experience_cloudfront_alerts.module.lambda_error_alerts.module.lambda_errors_to_slack_alerts.module.lambda.aws_iam_role_policy.lambda_dlq will be updated in-place
+~ resource "aws_iam_role_policy" "lambda_dlq" {
+id     = "lambda_experience_lambda_errors_to_slack_alerts_iam_role:lambda_experience_lambda_errors_to_slack_alerts_iam_role_lambda_dlq"
+name   = "lambda_experience_lambda_errors_to_slack_alerts_iam_role_lambda_dlq"
+~ policy = jsonencode(
+~ {
+~ Statement = [
+~ {
+~ Resource = "arn:aws:sqs:eu-west-1:130871440101:lambda-experience_lambda_errors_to_slack_alerts_dlq" -> "arn:aws:sqs:us-east-1:130871440101:lambda-experience_lambda_errors_to_slack_alerts_dlq"
+# (3 unchanged elements hidden)
+},
+]
+# (1 unchanged element hidden)
+}
+)
+# (1 unchanged attribute hidden)
+}
+
+```
+
+## Grafana Loadbalancer Security Group
+
+The Grafana loadbalancer security group is normally maintained manually, so changes are ignored by Terraform.
+To reset it, change the ignore_changes definition in [security_groups.tf](stack/grafana/security_groups.tf).

--- a/monitoring/terraform/stack/grafana/security_groups.tf
+++ b/monitoring/terraform/stack/grafana/security_groups.tf
@@ -62,4 +62,12 @@ resource "aws_security_group" "external_lb_security_group" {
   tags = {
     Name = "${var.namespace}-external-lb"
   }
+
+  # The ingress list of the loadbalancer security group is normally maintained manually,
+  # so changes to the ingress records are to be ignored.
+  # Remove this lifecycle definition to reset them, destroying any manual changes.
+
+  lifecycle {
+    ignore_changes = [ingress]
+  }
 }


### PR DESCRIPTION
## What's changing and why?
I have added the ignore_changes lifecycle to the grafana load balance security group.

That security group is manually maintained, so this prevents Terraform deleting everyones access whenever we deploy.


I have also added a README containing a note about the AWS Region changes to these ([See Slack conversation](https://wellcome.slack.com/archives/C3TQSF63C/p1663921546822319?thread_ts=1663921387.385479&cid=C3TQSF63C), because I spent some time trying to work out what was wrong in my environment that would cause these changes):

* module.experience_cloudfront_alerts.module.lambda_error_alerts.module.lambda_errors_to_slack_alerts.module.lambda.aws_iam_role_policy.cloudwatch_logs
* module.experience_cloudfront_alerts.module.lambda_error_alerts.module.lambda_errors_to_slack_alerts.module.lambda.aws_iam_role_policy.lambda_dlq


## `terraform plan` diff
Without this change, there would be 11 changes for terraform to make.  Instead, there are only 10.
```
Terraform will perform the following actions:

  # module.auth0_log_stream_alerts.module.auth0_log_stream_alerts.module.lambda.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "identity_auth0_log_stream_alerts"
      ~ last_modified                  = "2022-08-18T16:04:22.000+0000" -> (known after apply)
      ~ source_code_hash               = "6vh+/rnB8XdDzx2DfBIgNFyEbPCYw7WUBllF8oMxQ9M=" -> "QvTbH/UX7y3IGCkvF70d4w57tmfae+5baI2lBkQgNRI="
        tags                           = {}
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.catalogue_api_gateway_alerts.module.api_gateway_to_slack_alerts.module.lambda.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "catalogue_api_gateway_to_slack_alerts"
      ~ last_modified                  = "2022-03-28T11:48:01.000+0000" -> (known after apply)
      ~ source_code_hash               = "h52nyQSoF4gCHrSzHGFaEAVhUybV65LLsHVQ9+4uwkc=" -> "pVEKpXqmZxtP1gtT1B6Ubieattj4Kn+T21/7WvaH1tc="
        tags                           = {}
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.catalogue_dlq_to_slack_alerts.module.dlq_to_slack_alerts.module.lambda.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "catalogue_dlq_to_slack_alerts"
      ~ last_modified                  = "2022-03-28T11:47:55.000+0000" -> (known after apply)
      ~ source_code_hash               = "h52nyQSoF4gCHrSzHGFaEAVhUybV65LLsHVQ9+4uwkc=" -> "pVEKpXqmZxtP1gtT1B6Ubieattj4Kn+T21/7WvaH1tc="
        tags                           = {}
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.experience_cloudfront_alerts.module.cloudfront_to_slack_alerts.module.lambda.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "experience_cloudfront_to_slack_alerts"
      ~ last_modified                  = "2022-03-28T11:48:12.000+0000" -> (known after apply)
      ~ source_code_hash               = "h52nyQSoF4gCHrSzHGFaEAVhUybV65LLsHVQ9+4uwkc=" -> "pVEKpXqmZxtP1gtT1B6Ubieattj4Kn+T21/7WvaH1tc="
        tags                           = {}
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.identity_api_gateway_alerts.module.api_gateway_to_slack_alerts.module.lambda.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "identity_api_gateway_to_slack_alerts"
      ~ last_modified                  = "2022-03-28T11:48:16.000+0000" -> (known after apply)
      ~ source_code_hash               = "h52nyQSoF4gCHrSzHGFaEAVhUybV65LLsHVQ9+4uwkc=" -> "pVEKpXqmZxtP1gtT1B6Ubieattj4Kn+T21/7WvaH1tc="
        tags                           = {}
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.platform_dlq_to_slack_alerts.module.dlq_to_slack_alerts.module.lambda.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "platform_dlq_to_slack_alerts"
      ~ last_modified                  = "2022-03-28T11:47:57.000+0000" -> (known after apply)
      ~ source_code_hash               = "h52nyQSoF4gCHrSzHGFaEAVhUybV65LLsHVQ9+4uwkc=" -> "pVEKpXqmZxtP1gtT1B6Ubieattj4Kn+T21/7WvaH1tc="
        tags                           = {}
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.storage_api_gateway_alerts.module.api_gateway_to_slack_alerts.module.lambda.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "storage_api_gateway_to_slack_alerts"
      ~ last_modified                  = "2022-03-28T11:48:01.000+0000" -> (known after apply)
      ~ source_code_hash               = "h52nyQSoF4gCHrSzHGFaEAVhUybV65LLsHVQ9+4uwkc=" -> "pVEKpXqmZxtP1gtT1B6Ubieattj4Kn+T21/7WvaH1tc="
        tags                           = {}
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.storage_dlq_to_slack_alerts.module.dlq_to_slack_alerts.module.lambda.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "storage_dlq_to_slack_alerts"
      ~ last_modified                  = "2022-03-28T11:48:07.000+0000" -> (known after apply)
      ~ source_code_hash               = "h52nyQSoF4gCHrSzHGFaEAVhUybV65LLsHVQ9+4uwkc=" -> "pVEKpXqmZxtP1gtT1B6Ubieattj4Kn+T21/7WvaH1tc="
        tags                           = {}
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.experience_cloudfront_alerts.module.lambda_error_alerts.module.lambda_errors_to_slack_alerts.module.lambda.aws_iam_role_policy.cloudwatch_logs will be updated in-place
  ~ resource "aws_iam_role_policy" "cloudwatch_logs" {
        id     = "lambda_experience_lambda_errors_to_slack_alerts_iam_role:lambda_experience_lambda_errors_to_slack_alerts_iam_role_lambda_cloudwatch_logs"
        name   = "lambda_experience_lambda_errors_to_slack_alerts_iam_role_lambda_cloudwatch_logs"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = [
                          - "arn:aws:logs:eu-west-1:130871440101:log-group:/aws/lambda/experience_lambda_errors_to_slack_alerts:*",
                          - "arn:aws:logs:eu-west-1:130871440101:log-group:/aws/lambda/experience_lambda_errors_to_slack_alerts",
                          + "arn:aws:logs:us-east-1:130871440101:log-group:/aws/lambda/experience_lambda_errors_to_slack_alerts:*",
                          + "arn:aws:logs:us-east-1:130871440101:log-group:/aws/lambda/experience_lambda_errors_to_slack_alerts",
                        ]
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }

  # module.experience_cloudfront_alerts.module.lambda_error_alerts.module.lambda_errors_to_slack_alerts.module.lambda.aws_iam_role_policy.lambda_dlq will be updated in-place
  ~ resource "aws_iam_role_policy" "lambda_dlq" {
        id     = "lambda_experience_lambda_errors_to_slack_alerts_iam_role:lambda_experience_lambda_errors_to_slack_alerts_iam_role_lambda_dlq"
        name   = "lambda_experience_lambda_errors_to_slack_alerts_iam_role_lambda_dlq"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = "arn:aws:sqs:eu-west-1:130871440101:lambda-experience_lambda_errors_to_slack_alerts_dlq" -> "arn:aws:sqs:us-east-1:130871440101:lambda-experience_lambda_errors_to_slack_alerts_dlq"
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 10 to change, 0 to destroy.
```
