### PR TITLE
add superplural criteria to dlq alerts

### DIFF
--- a/monitoring/slack_alerts/metric_to_slack_alert/src/metric_to_slack_alert.py
+++ b/monitoring/slack_alerts/metric_to_slack_alert/src/metric_to_slack_alert.py
@@ -179,9 +179,7 @@ def create_message(alarm_info):
             else "STR_MULTIPLE_ERROR_MESSAGE"
         ]
 
-        lines.append(
-            error_template.format(error_count=error_count)
-        )
+        lines.append(error_template.format(error_count=error_count))
 
     context_url = create_context_url(alarm_info)
     if context_url is not None:
@@ -206,7 +204,9 @@ def get_alarm_level(alarm_info, environ):
     >>> get_alarm_level({"count": 11.5}, {"STR_ALARM_LEVEL": "warning", "INT_SUPERPLURAL_THRESHOLD": "10"})
     (':rotating_light:', 'danger')
     """
-    if environ["STR_ALARM_LEVEL"] == "error" or is_alarm_count_very_big(alarm_info["count"], environ):
+    if environ["STR_ALARM_LEVEL"] == "error" or is_alarm_count_very_big(
+        alarm_info["count"], environ
+    ):
         icon_emoji = ":rotating_light:"
         color = "danger"
     else:

--- a/monitoring/slack_alerts/metric_to_slack_alert/src/metric_to_slack_alert.py
+++ b/monitoring/slack_alerts/metric_to_slack_alert/src/metric_to_slack_alert.py
@@ -21,6 +21,12 @@ Plus optionally:
     CONTEXT_URL_TEMPLATE
     = select the template to use in create_context_url
 
+    INT_SUPERPLURAL_THRESHOLD
+    = The number above which this alarm can be considered "very big", triggering a different message and
+    causing this alarm to become an error (if it is not already).
+
+    STR_SUPERPLURAL_ERROR_MESSAGE
+    = The message to use if the superplural threshold is exceeded.
 """
 
 import datetime
@@ -167,8 +173,14 @@ def create_message(alarm_info):
         else:
             error_count = alarm_info["count"]
 
+        error_template = os.environ[
+            "STR_SUPERPLURAL_ERROR_MESSAGE"
+            if is_alarm_count_very_big(error_count, os.environ)
+            else "STR_MULTIPLE_ERROR_MESSAGE"
+        ]
+
         lines.append(
-            os.environ["STR_MULTIPLE_ERROR_MESSAGE"].format(error_count=error_count)
+            error_template.format(error_count=error_count)
         )
 
     context_url = create_context_url(alarm_info)
@@ -176,6 +188,36 @@ def create_message(alarm_info):
         lines.append(f"👉 <{context_url['url']}|{context_url['label']}>")
 
     return "\n".join(lines)
+
+
+def get_alarm_level(alarm_info, environ):
+    """
+    Determine the values for conveying the severity of this alarm in Slack.
+
+    In most cases, the severity is defined at setup.  A given alarm, whenever triggered
+    is either a warning or an error:
+    >>> get_alarm_level({"count": 1}, {"STR_ALARM_LEVEL": "error"})
+    (':rotating_light:', 'danger')
+    >>> get_alarm_level({"count": 2}, {"STR_ALARM_LEVEL": "warning"})
+    ('warning', 'warning')
+
+    However, a "warning" can become an "error" if the scale of the problem is great enough
+
+    >>> get_alarm_level({"count": 11.5}, {"STR_ALARM_LEVEL": "warning", "INT_SUPERPLURAL_THRESHOLD": "10"})
+    (':rotating_light:', 'danger')
+    """
+    if environ["STR_ALARM_LEVEL"] == "error" or is_alarm_count_very_big(alarm_info["count"], environ):
+        icon_emoji = ":rotating_light:"
+        color = "danger"
+    else:
+        icon_emoji = "warning"
+        color = "warning"
+    return icon_emoji, color
+
+
+def is_alarm_count_very_big(alarm_count, environ):
+    superplural_threshold = environ.get("INT_SUPERPLURAL_THRESHOLD")
+    return superplural_threshold and alarm_count > int(superplural_threshold)
 
 
 @log_on_error
@@ -186,13 +228,7 @@ def main(event, _ctxt=None):
     alarm_info = get_alarm_info(alarm)
 
     webhook_url = get_secret_string(secret_id="monitoring/critical_slack_webhook")
-
-    if os.environ["STR_ALARM_LEVEL"] == "error":
-        icon_emoji = ":rotating_light:"
-        color = "danger"
-    else:
-        icon_emoji = "warning"
-        color = "warning"
+    (icon_emoji, color) = get_alarm_level(alarm_info, os.environ)
 
     slack_payload = {
         "username": f"{account}-{os.environ['STR_ALARM_SLUG']}",

--- a/monitoring/terraform/modules/slack_alert_on_sqs_dlq/main.tf
+++ b/monitoring/terraform/modules/slack_alert_on_sqs_dlq/main.tf
@@ -13,6 +13,8 @@ module "dlq_to_slack_alerts" {
     STR_ALARM_SLUG             = "sqs-dlq-not-empty"
     STR_ALARM_LEVEL            = "warning"
     CONTEXT_URL_TEMPLATE       = "${var.account_name}-dlq-alerts"
+    INT_SUPERPLURAL_THRESHOLD  = 10000
+    STR_SUPERPLURAL_ERROR_MESSAGE = "There is a very large number of messages ({error_count}) on the DLQ. See https://github.com/wellcomecollection/catalogue-pipeline/tree/main/docs/troubleshooting for help"
   }
 
   secrets = [

--- a/monitoring/terraform/modules/slack_alert_on_sqs_dlq/main.tf
+++ b/monitoring/terraform/modules/slack_alert_on_sqs_dlq/main.tf
@@ -8,12 +8,12 @@ module "dlq_to_slack_alerts" {
   topic_name  = "dlq_non_empty_alarm"
 
   environment_variables = {
-    STR_SINGLE_ERROR_MESSAGE   = "There is 1 message on the DLQ"
-    STR_MULTIPLE_ERROR_MESSAGE = "There are {error_count} messages on the DLQ"
-    STR_ALARM_SLUG             = "sqs-dlq-not-empty"
-    STR_ALARM_LEVEL            = "warning"
-    CONTEXT_URL_TEMPLATE       = "${var.account_name}-dlq-alerts"
-    INT_SUPERPLURAL_THRESHOLD  = 10000
+    STR_SINGLE_ERROR_MESSAGE      = "There is 1 message on the DLQ"
+    STR_MULTIPLE_ERROR_MESSAGE    = "There are {error_count} messages on the DLQ"
+    STR_ALARM_SLUG                = "sqs-dlq-not-empty"
+    STR_ALARM_LEVEL               = "warning"
+    CONTEXT_URL_TEMPLATE          = "${var.account_name}-dlq-alerts"
+    INT_SUPERPLURAL_THRESHOLD     = 10000
     STR_SUPERPLURAL_ERROR_MESSAGE = "There is a very large number of messages ({error_count}) on the DLQ. See https://github.com/wellcomecollection/catalogue-pipeline/tree/main/docs/troubleshooting for help"
   }
 


### PR DESCRIPTION
## What's changing and why?

Until now, DLQ alerts are triggered when there is something on the DLQ, whether this is 1 or 1 million.

Having a few missed records is not a significant problem and can be dealt with at leisure, so the alerts are just a warning.

However, when the number of messages on a DLQ gets really big, it can indicate that something is very wrong with the pipeline.

With this change, an alert that was just a warning before, becomes an error with a different message once the number of failed messages breaches a threshold (10,000)

## `terraform plan` diff

```
Terraform will perform the following actions:

  # module.monitoring-271118.module.grafana.aws_security_group.external_lb_security_group will be updated in-place
  ~ resource "aws_security_group" "external_lb_security_group" {
        id                     = "sg-0c372a2ddc3f9e09d"
      ~ ingress                = (sensitive)
        name                   = "monitoring-271118-grafana_external_lb_security_group"
        tags                   = {
            "Name" = "monitoring-271118-grafana-external-lb"
        }
        # (8 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # module.auth0_log_stream_alerts.module.auth0_log_stream_alerts.module.lambda.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "identity_auth0_log_stream_alerts"
      ~ last_modified                  = "2022-08-18T16:04:22.000+0000" -> (known after apply)
      ~ source_code_hash               = "6vh+/rnB8XdDzx2DfBIgNFyEbPCYw7WUBllF8oMxQ9M=" -> "QvTbH/UX7y3IGCkvF70d4w57tmfae+5baI2lBkQgNRI="
        tags                           = {}
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.catalogue_api_gateway_alerts.module.api_gateway_to_slack_alerts.module.lambda.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "catalogue_api_gateway_to_slack_alerts"
      ~ last_modified                  = "2022-03-28T11:48:01.000+0000" -> (known after apply)
      ~ source_code_hash               = "h52nyQSoF4gCHrSzHGFaEAVhUybV65LLsHVQ9+4uwkc=" -> "/t3YUbBJ/sJNVQXJ8la5GBG7aneaZ89HplEocilaYqg="
        tags                           = {}
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.catalogue_dlq_to_slack_alerts.module.dlq_to_slack_alerts.module.lambda.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "catalogue_dlq_to_slack_alerts"
      ~ last_modified                  = "2022-03-28T11:47:55.000+0000" -> (known after apply)
      ~ source_code_hash               = "h52nyQSoF4gCHrSzHGFaEAVhUybV65LLsHVQ9+4uwkc=" -> "/t3YUbBJ/sJNVQXJ8la5GBG7aneaZ89HplEocilaYqg="
        tags                           = {}
        # (18 unchanged attributes hidden)

      ~ environment {
          ~ variables = {
              + "INT_SUPERPLURAL_THRESHOLD"     = "10000"
              + "STR_SUPERPLURAL_ERROR_MESSAGE" = "There is a very large number of messages ({error_count}) on the DLQ. See https://github.com/wellcomecollection/catalogue-pipeline/tree/main/docs/troubleshooting for help"
                # (6 unchanged elements hidden)
            }
        }

        # (2 unchanged blocks hidden)
    }

  # module.experience_cloudfront_alerts.module.cloudfront_to_slack_alerts.module.lambda.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "experience_cloudfront_to_slack_alerts"
      ~ last_modified                  = "2022-03-28T11:48:12.000+0000" -> (known after apply)
      ~ source_code_hash               = "h52nyQSoF4gCHrSzHGFaEAVhUybV65LLsHVQ9+4uwkc=" -> "/t3YUbBJ/sJNVQXJ8la5GBG7aneaZ89HplEocilaYqg="
        tags                           = {}
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.identity_api_gateway_alerts.module.api_gateway_to_slack_alerts.module.lambda.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "identity_api_gateway_to_slack_alerts"
      ~ last_modified                  = "2022-03-28T11:48:16.000+0000" -> (known after apply)
      ~ source_code_hash               = "h52nyQSoF4gCHrSzHGFaEAVhUybV65LLsHVQ9+4uwkc=" -> "/t3YUbBJ/sJNVQXJ8la5GBG7aneaZ89HplEocilaYqg="
        tags                           = {}
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.platform_dlq_to_slack_alerts.module.dlq_to_slack_alerts.module.lambda.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "platform_dlq_to_slack_alerts"
      ~ last_modified                  = "2022-03-28T11:47:57.000+0000" -> (known after apply)
      ~ source_code_hash               = "h52nyQSoF4gCHrSzHGFaEAVhUybV65LLsHVQ9+4uwkc=" -> "/t3YUbBJ/sJNVQXJ8la5GBG7aneaZ89HplEocilaYqg="
        tags                           = {}
        # (18 unchanged attributes hidden)

      ~ environment {
          ~ variables = {
              + "INT_SUPERPLURAL_THRESHOLD"     = "10000"
              + "STR_SUPERPLURAL_ERROR_MESSAGE" = "There is a very large number of messages ({error_count}) on the DLQ. See https://github.com/wellcomecollection/catalogue-pipeline/tree/main/docs/troubleshooting for help"
                # (6 unchanged elements hidden)
            }
        }

        # (2 unchanged blocks hidden)
    }

  # module.storage_api_gateway_alerts.module.api_gateway_to_slack_alerts.module.lambda.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "storage_api_gateway_to_slack_alerts"
      ~ last_modified                  = "2022-03-28T11:48:01.000+0000" -> (known after apply)
      ~ source_code_hash               = "h52nyQSoF4gCHrSzHGFaEAVhUybV65LLsHVQ9+4uwkc=" -> "/t3YUbBJ/sJNVQXJ8la5GBG7aneaZ89HplEocilaYqg="
        tags                           = {}
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.storage_dlq_to_slack_alerts.module.dlq_to_slack_alerts.module.lambda.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "storage_dlq_to_slack_alerts"
      ~ last_modified                  = "2022-03-28T11:48:07.000+0000" -> (known after apply)
      ~ source_code_hash               = "h52nyQSoF4gCHrSzHGFaEAVhUybV65LLsHVQ9+4uwkc=" -> "/t3YUbBJ/sJNVQXJ8la5GBG7aneaZ89HplEocilaYqg="
        tags                           = {}
        # (18 unchanged attributes hidden)

      ~ environment {
          ~ variables = {
              + "INT_SUPERPLURAL_THRESHOLD"     = "10000"
              + "STR_SUPERPLURAL_ERROR_MESSAGE" = "There is a very large number of messages ({error_count}) on the DLQ. See https://github.com/wellcomecollection/catalogue-pipeline/tree/main/docs/troubleshooting for help"
                # (6 unchanged elements hidden)
            }
        }

        # (2 unchanged blocks hidden)
    }

  # module.experience_cloudfront_alerts.module.lambda_error_alerts.module.lambda_errors_to_slack_alerts.module.lambda.aws_iam_role_policy.cloudwatch_logs will be updated in-place
  ~ resource "aws_iam_role_policy" "cloudwatch_logs" {
        id     = "lambda_experience_lambda_errors_to_slack_alerts_iam_role:lambda_experience_lambda_errors_to_slack_alerts_iam_role_lambda_cloudwatch_logs"
        name   = "lambda_experience_lambda_errors_to_slack_alerts_iam_role_lambda_cloudwatch_logs"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = [
                          - "arn:aws:logs:eu-west-1:130871440101:log-group:/aws/lambda/experience_lambda_errors_to_slack_alerts:*",
                          - "arn:aws:logs:eu-west-1:130871440101:log-group:/aws/lambda/experience_lambda_errors_to_slack_alerts",
                          + "arn:aws:logs:us-east-1:130871440101:log-group:/aws/lambda/experience_lambda_errors_to_slack_alerts:*",
                          + "arn:aws:logs:us-east-1:130871440101:log-group:/aws/lambda/experience_lambda_errors_to_slack_alerts",
                        ]
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }

  # module.experience_cloudfront_alerts.module.lambda_error_alerts.module.lambda_errors_to_slack_alerts.module.lambda.aws_iam_role_policy.lambda_dlq will be updated in-place
  ~ resource "aws_iam_role_policy" "lambda_dlq" {
        id     = "lambda_experience_lambda_errors_to_slack_alerts_iam_role:lambda_experience_lambda_errors_to_slack_alerts_iam_role_lambda_dlq"
        name   = "lambda_experience_lambda_errors_to_slack_alerts_iam_role_lambda_dlq"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = "arn:aws:sqs:eu-west-1:130871440101:lambda-experience_lambda_errors_to_slack_alerts_dlq" -> "arn:aws:sqs:us-east-1:130871440101:lambda-experience_lambda_errors_to_slack_alerts_dlq"
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 11 to change, 0 to destroy.
```