### PR TITLE
Separate the Lambda that alerts on us-east-1 Lambda errors

### DIFF
--- a/monitoring/terraform/modules/slack_alert_on_cloudfront_errors/main.tf
+++ b/monitoring/terraform/modules/slack_alert_on_cloudfront_errors/main.tf
@@ -43,5 +43,7 @@ module "slack_secrets" {
 module "lambda_error_alerts" {
   source = "../slack_alert_on_lambda_error"
 
-  account_name = var.account_name
+  # We need to add a suffix here, so this doesn't conflict with the
+  # "alert on Lambda errors" Lambda that lives in eu-west-1 in this account.
+  account_name = "${var.account_name}_useast1"
 }


### PR DESCRIPTION
The issue with Terraform wanting to update IAM permissions indicates a bug in the way we've set up these Lambdas; in particular:

*   We have a Lambda to catch Lambda errors in experience/eu-west-1
    (which is where most of our Lambdas live)

*   We have a Lambda to catch Lambda errors in experience/us-east-1
    (which is where our CloudFront Lambdas live)

This Lambda includes an IAM role which allows them to write to their own DLQ (so they can report on their own errors), and IAM roles are globally unique.  Before this patch, both Lambdas had roles with the same name, so they were fighting over whose queue they'd be allowed to write to.

This tweaks the names so the Lambda in us-east-1 has a different name, which means it has a different IAM role.  This means they're no longer blatting each other's changes, and Terraform plans cleanly.

This means we don't need the explanation in https://github.com/wellcomecollection/platform-infrastructure/pull/331, because the error should no longer occur – I've been ignoring it, but explaining it to @paul-butcher today reminded me we should fix it, not continue to ignore it.