### PR TITLE
allow ci to update lambdas

### DIFF
--- a/accounts/modules/role_policies/ci/policies.tf
+++ b/accounts/modules/role_policies/ci/policies.tf
@@ -24,6 +24,7 @@ data "aws_iam_policy_document" "ci_permissions" {
       "ecr-public:InitiateLayerUpload",
       "ecr-public:UploadLayerPart",
       "ecr-public:CompleteLayerUpload",
+      # Required for updating and checking Lambdas
       "lambda:UpdateFunctionCode",
       "lambda:GetFunctionConfiguration",
       # This is required for uploading to public repositories; see https://docs.aws.amazon.com/AmazonECR/latest/public/public-repository-policy-examples.html

--- a/accounts/modules/role_policies/ci/policies.tf
+++ b/accounts/modules/role_policies/ci/policies.tf
@@ -24,6 +24,8 @@ data "aws_iam_policy_document" "ci_permissions" {
       "ecr-public:InitiateLayerUpload",
       "ecr-public:UploadLayerPart",
       "ecr-public:CompleteLayerUpload",
+      "lambda:UpdateFunctionCode",
+      "lambda:GetFunctionConfiguration",
       # This is required for uploading to public repositories; see https://docs.aws.amazon.com/AmazonECR/latest/public/public-repository-policy-examples.html
       "sts:GetServiceBearerToken",
     ]


### PR DESCRIPTION
## What's changing and why?

Some services in the concepts pipeline will be running on Lambda (this approach might be extended elsewhere), so CI needs to be able to update the lambda code when it changes.

## `terraform plan` diff
```
Terraform will perform the following actions:

  # module.catalogue_account.module.ci_role_policy.aws_iam_role_policy.ci_permissions will be updated in-place
  ~ resource "aws_iam_role_policy" "ci_permissions" {
        id     = "catalogue-ci:terraform-20200713113726102900000001"
        name   = "terraform-20200713113726102900000001"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Action   = [
                            "sts:GetServiceBearerToken",
                          + "lambda:UpdateFunctionCode",
                          + "lambda:GetFunctionConfiguration",
                            "ecr:UploadLayerPart",
                            # (19 unchanged elements hidden)
                        ]
                        # (3 unchanged elements hidden)
                    },
                    {
                        Action   = "s3:*"
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:s3:::wellcomecollection-catalogue-infra-delta/*",
                            "arn:aws:s3:::wellcomecollection-catalogue-infra-delta",
                        ]
                        Sid      = ""
                    },
                    # (8 unchanged elements hidden)
                ]
                # (1 unchanged element hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }
```