### PR TITLE
Expose the CI VPC NAT's EIP

### DIFF
--- a/accounts/modules/vpc/main.tf
+++ b/accounts/modules/vpc/main.tf
@@ -28,6 +28,10 @@ output "private_route_table_id" {
   value = module.vpc.private_route_table_id
 }
 
+output "nat_elastic_ip" {
+  value = module.vpc.nat_elastic_ip
+}
+
 output "vpc_id" {
   value = module.vpc.vpc_id
 }

--- a/accounts/modules/vpc/nat/outputs.tf
+++ b/accounts/modules/vpc/nat/outputs.tf
@@ -1,0 +1,3 @@
+output "elastic_ip" {
+  value = aws_eip.nat.public_ip
+}

--- a/accounts/modules/vpc/public-private-igw/outputs.tf
+++ b/accounts/modules/vpc/public-private-igw/outputs.tf
@@ -17,3 +17,7 @@ output "private_route_table_id" {
 output "vpc_id" {
   value = aws_vpc.vpc.id
 }
+
+output "nat_elastic_ip" {
+  value = module.nat.elastic_ip
+}

--- a/accounts/platform/outputs.tf
+++ b/accounts/platform/outputs.tf
@@ -63,6 +63,10 @@ output "ci_vpc_private_subnets" {
   value = module.ci_vpc.private_subnets
 }
 
+output "ci_vpc_nat_elastic_ip" {
+  value = module.ci_vpc.nat_elastic_ip
+}
+
 output "ci_vpc_public_subnets" {
   value = module.ci_vpc.public_subnets
 }


### PR DESCRIPTION
[Our CI instances are in private subnets within the CI VPC](https://github.com/wellcomecollection/buildkite-infrastructure/blob/main/terraform/buildkite.tf#L227-L229), which is owned by the platform account. This VPC has a (managed) NAT gateway on the route table, and as such all requests made by CI agents come from the NAT's (public) Elastic IP address.

If we want to identify requests made by these agents (for example, so our WAF rules don't block them), we need to know what that EIP is - this PR exposes it as an output which we will then be able to get from remote state.

As an aside, our CI agents do also have their own public IP addresses assigned - I think this is possible because, despite them being in private subnets, the VPC does contain public subnets. Because of the NAT gateway, I don't think these are necessary/used, and we can probably stop assigning them [as this is configurable in the Buildkite Elastic Stack for AWS](https://buildkite.com/docs/agent/v3/elastic-ci-aws/parameters#network-configuration). 
