### PR TITLE
Elastic serverless forwarder

### DIFF
--- a/.buildkite/scripts/run_autoformat.sh
+++ b/.buildkite/scripts/run_autoformat.sh
@@ -33,10 +33,10 @@ else
 
   git config user.name "Buildkite on behalf of Wellcome Collection"
   git config user.email wellcomedigitalplatform@wellcome.ac.uk
-  git remote add ssh-origin "$BUILDKITE_REPO"
+  git remote add ssh-origin "$BUILDKITE_REPO" || echo "(remote repo already configured)"
 
   git fetch ssh-origin
-  git checkout --track "ssh-origin/$BUILDKITE_BRANCH"
+  git checkout --track "ssh-origin/$BUILDKITE_BRANCH" || echo "(branch already checked out)"
 
   git add --verbose --update
   git commit -m "Apply auto-formatting rules"

--- a/accounts/modules/elastic_log_forwarder/config.yml.tftpl
+++ b/accounts/modules/elastic_log_forwarder/config.yml.tftpl
@@ -7,6 +7,3 @@ inputs:
           elasticsearch_url: "${es_url_secret_arn}"
           api_key: "${api_key_secret_arn}"
           es_datastream_name: "${es_data_stream_name}"
-
-
-

--- a/accounts/modules/elastic_log_forwarder/config.yml.tftpl
+++ b/accounts/modules/elastic_log_forwarder/config.yml.tftpl
@@ -6,7 +6,7 @@ inputs:
         args:
           elasticsearch_url: "${es_url_secret_arn}"
           api_key: "${api_key_secret_arn}"
-          es_datastream_name: "service-logs-esf"
+          es_datastream_name: "${es_data_stream_name}"
 
 
 

--- a/accounts/modules/elastic_log_forwarder/config.yml.tftpl
+++ b/accounts/modules/elastic_log_forwarder/config.yml.tftpl
@@ -1,0 +1,12 @@
+inputs:
+  - type: "kinesis-data-stream"
+    id: "${kinesis_stream_arn}"
+    outputs:
+      - type: "elasticsearch"
+        args:
+          elasticsearch_url: "${es_url_secret_arn}"
+          api_key: "${api_key_secret_arn}"
+          es_datastream_name: "service-logs-esf"
+
+
+

--- a/accounts/modules/elastic_log_forwarder/main.tf
+++ b/accounts/modules/elastic_log_forwarder/main.tf
@@ -1,0 +1,43 @@
+data "aws_serverlessapplicationrepository_application" "esf_sar" {
+  application_id = "arn:aws:serverlessrepo:eu-central-1:267093732750:applications/elastic-serverless-forwarder"
+}
+
+resource "aws_serverlessapplicationrepository_cloudformation_stack" "esf_cf_stak" {
+  name             = "elastic-serverless-forwarder"
+  application_id   = data.aws_serverlessapplicationrepository_application.esf_sar.application_id
+  semantic_version = data.aws_serverlessapplicationrepository_application.esf_sar.semantic_version
+  capabilities     = data.aws_serverlessapplicationrepository_application.esf_sar.required_capabilities
+
+  parameters = {
+    ElasticServerlessForwarderS3ConfigFile  = "s3://${aws_s3_object.esf_config.bucket}/${aws_s3_object.esf_config.key}"
+    ElasticServerlessForwarderSSMSecrets    = join(",", [local.host_secret_arn, local.api_key_secret_arn])
+    ElasticServerlessForwarderKinesisEvents = var.log_stream_arn
+  }
+}
+
+resource "aws_s3_object" "esf_config" {
+  bucket = "wellcomecollection-platform-infra"
+  key    = "platform-terraform-objects/elastic-serverless-forwarder-config.yml"
+
+  content = templatefile(
+    "${path.module}/config.yml.tftpl",
+    {
+      kinesis_stream_arn = var.log_stream_arn
+      es_url_secret_arn = data.aws_secretsmanager_secret.logging_es_public_host.arn
+      api_key_secret_arn = data.aws_secretsmanager_secret.logging_es_api_key.arn
+    }
+  )
+}
+
+locals {
+  host_secret_arn = data.aws_secretsmanager_secret.logging_es_public_host.arn
+  api_key_secret_arn = data.aws_secretsmanager_secret.logging_es_api_key.arn
+}
+
+data "aws_secretsmanager_secret" "logging_es_public_host" {
+  name = "elasticsearch/logging/public_host"
+}
+
+data "aws_secretsmanager_secret" "logging_es_api_key" {
+  name = "elasticsearch/logging/log_forwarder_api_key"
+}

--- a/accounts/modules/elastic_log_forwarder/main.tf
+++ b/accounts/modules/elastic_log_forwarder/main.tf
@@ -42,5 +42,5 @@ data "aws_secretsmanager_secret" "logging_es_public_host" {
 }
 
 data "aws_secretsmanager_secret" "logging_es_api_key" {
-  name = "elasticsearch/logging/esf/api_key"
+  name = var.es_api_key_secret
 }

--- a/accounts/modules/elastic_log_forwarder/main.tf
+++ b/accounts/modules/elastic_log_forwarder/main.tf
@@ -25,9 +25,9 @@ resource "aws_s3_object" "esf_config" {
     "${path.module}/config.yml.tftpl",
     {
       kinesis_stream_arn  = var.kinesis_log_stream_arn
+      es_data_stream_name = var.es_data_stream
       es_url_secret_arn   = local.host_secret_arn
       api_key_secret_arn  = local.api_key_secret_arn
-      es_data_stream_name = "service-logs-esf"
     }
   )
 }

--- a/accounts/modules/elastic_log_forwarder/main.tf
+++ b/accounts/modules/elastic_log_forwarder/main.tf
@@ -1,3 +1,5 @@
+// This application is documented here:
+// https://github.com/elastic/elastic-serverless-forwarder/blob/main/docs/README-AWS.md
 data "aws_serverlessapplicationrepository_application" "esf_sar" {
   application_id = "arn:aws:serverlessrepo:eu-central-1:267093732750:applications/elastic-serverless-forwarder"
 }

--- a/accounts/modules/elastic_log_forwarder/main.tf
+++ b/accounts/modules/elastic_log_forwarder/main.tf
@@ -2,7 +2,7 @@ data "aws_serverlessapplicationrepository_application" "esf_sar" {
   application_id = "arn:aws:serverlessrepo:eu-central-1:267093732750:applications/elastic-serverless-forwarder"
 }
 
-resource "aws_serverlessapplicationrepository_cloudformation_stack" "esf_cf_stak" {
+resource "aws_serverlessapplicationrepository_cloudformation_stack" "esf_cf_stack" {
   name             = "elastic-serverless-forwarder"
   application_id   = data.aws_serverlessapplicationrepository_application.esf_sar.application_id
   semantic_version = data.aws_serverlessapplicationrepository_application.esf_sar.semantic_version
@@ -11,7 +11,7 @@ resource "aws_serverlessapplicationrepository_cloudformation_stack" "esf_cf_stak
   parameters = {
     ElasticServerlessForwarderS3ConfigFile  = "s3://${aws_s3_object.esf_config.bucket}/${aws_s3_object.esf_config.key}"
     ElasticServerlessForwarderSSMSecrets    = join(",", [local.host_secret_arn, local.api_key_secret_arn])
-    ElasticServerlessForwarderKinesisEvents = var.log_stream_arn
+    ElasticServerlessForwarderKinesisEvents = var.kinesis_log_stream_arn
   }
 }
 
@@ -22,9 +22,10 @@ resource "aws_s3_object" "esf_config" {
   content = templatefile(
     "${path.module}/config.yml.tftpl",
     {
-      kinesis_stream_arn = var.log_stream_arn
-      es_url_secret_arn = data.aws_secretsmanager_secret.logging_es_public_host.arn
-      api_key_secret_arn = data.aws_secretsmanager_secret.logging_es_api_key.arn
+      kinesis_stream_arn = var.kinesis_log_stream_arn
+      es_url_secret_arn = local.host_secret_arn
+      api_key_secret_arn = local.api_key_secret_arn
+      es_data_stream_name = "service-logs-esf"
     }
   )
 }
@@ -39,5 +40,5 @@ data "aws_secretsmanager_secret" "logging_es_public_host" {
 }
 
 data "aws_secretsmanager_secret" "logging_es_api_key" {
-  name = "elasticsearch/logging/log_forwarder_api_key"
+  name = "elasticsearch/logging/esf/api_key"
 }

--- a/accounts/modules/elastic_log_forwarder/main.tf
+++ b/accounts/modules/elastic_log_forwarder/main.tf
@@ -22,16 +22,16 @@ resource "aws_s3_object" "esf_config" {
   content = templatefile(
     "${path.module}/config.yml.tftpl",
     {
-      kinesis_stream_arn = var.kinesis_log_stream_arn
-      es_url_secret_arn = local.host_secret_arn
-      api_key_secret_arn = local.api_key_secret_arn
+      kinesis_stream_arn  = var.kinesis_log_stream_arn
+      es_url_secret_arn   = local.host_secret_arn
+      api_key_secret_arn  = local.api_key_secret_arn
       es_data_stream_name = "service-logs-esf"
     }
   )
 }
 
 locals {
-  host_secret_arn = data.aws_secretsmanager_secret.logging_es_public_host.arn
+  host_secret_arn    = data.aws_secretsmanager_secret.logging_es_public_host.arn
   api_key_secret_arn = data.aws_secretsmanager_secret.logging_es_api_key.arn
 }
 

--- a/accounts/modules/elastic_log_forwarder/variables.tf
+++ b/accounts/modules/elastic_log_forwarder/variables.tf
@@ -1,0 +1,3 @@
+variable "log_stream_arn" {
+  type = string
+}

--- a/accounts/modules/elastic_log_forwarder/variables.tf
+++ b/accounts/modules/elastic_log_forwarder/variables.tf
@@ -1,3 +1,3 @@
-variable "log_stream_arn" {
+variable "kinesis_log_stream_arn" {
   type = string
 }

--- a/accounts/modules/elastic_log_forwarder/variables.tf
+++ b/accounts/modules/elastic_log_forwarder/variables.tf
@@ -5,3 +5,7 @@ variable "kinesis_log_stream_arn" {
 variable "es_data_stream" {
   type = string
 }
+
+variable "es_api_key_secret" {
+  type = string
+}

--- a/accounts/modules/elastic_log_forwarder/variables.tf
+++ b/accounts/modules/elastic_log_forwarder/variables.tf
@@ -1,3 +1,7 @@
 variable "kinesis_log_stream_arn" {
   type = string
 }
+
+variable "es_data_stream" {
+  type = string
+}

--- a/accounts/platform/logging.tf
+++ b/accounts/platform/logging.tf
@@ -15,4 +15,5 @@ module "elastic_log_forwarder" {
 
   kinesis_log_stream_arn = aws_kinesis_stream.logs_for_esf.arn
   es_data_stream         = "service-logs-esf"
+  es_api_key_secret      = "elasticsearch/logging/esf/api_key"
 }

--- a/accounts/platform/logging.tf
+++ b/accounts/platform/logging.tf
@@ -1,0 +1,16 @@
+resource "aws_kinesis_stream" "logs_for_esf" {
+  name = "logs-for-elastic-serverless-forwarder"
+
+  enforce_consumer_deletion = true
+  encryption_type = "NONE"
+  retention_period = 3 * 24 // Give us 3 days to deal with issues ingesting logs
+
+  stream_mode_details {
+    stream_mode = "ON_DEMAND"
+  }
+}
+
+module "elastic_log_forwarder" {
+  source = "../modules/elastic_log_forwarder"
+  kinesis_log_stream_arn = aws_kinesis_stream.logs_for_esf.arn
+}

--- a/accounts/platform/logging.tf
+++ b/accounts/platform/logging.tf
@@ -11,6 +11,8 @@ resource "aws_kinesis_stream" "logs_for_esf" {
 }
 
 module "elastic_log_forwarder" {
-  source                 = "../modules/elastic_log_forwarder"
+  source = "../modules/elastic_log_forwarder"
+
   kinesis_log_stream_arn = aws_kinesis_stream.logs_for_esf.arn
+  es_data_stream         = "service-logs-esf"
 }

--- a/accounts/platform/logging.tf
+++ b/accounts/platform/logging.tf
@@ -2,8 +2,8 @@ resource "aws_kinesis_stream" "logs_for_esf" {
   name = "logs-for-elastic-serverless-forwarder"
 
   enforce_consumer_deletion = true
-  encryption_type = "NONE"
-  retention_period = 3 * 24 // Give us 3 days to deal with issues ingesting logs
+  encryption_type           = "NONE"
+  retention_period          = 3 * 24 // Give us 3 days to deal with issues ingesting logs
 
   stream_mode_details {
     stream_mode = "ON_DEMAND"
@@ -11,6 +11,6 @@ resource "aws_kinesis_stream" "logs_for_esf" {
 }
 
 module "elastic_log_forwarder" {
-  source = "../modules/elastic_log_forwarder"
+  source                 = "../modules/elastic_log_forwarder"
   kinesis_log_stream_arn = aws_kinesis_stream.logs_for_esf.arn
 }

--- a/accounts/platform/logging.tf
+++ b/accounts/platform/logging.tf
@@ -14,6 +14,10 @@ module "elastic_log_forwarder" {
   source = "../modules/elastic_log_forwarder"
 
   kinesis_log_stream_arn = aws_kinesis_stream.logs_for_esf.arn
-  es_data_stream         = "service-logs-esf"
+  es_data_stream         = local.es_data_stream
   es_api_key_secret      = "elasticsearch/logging/esf/api_key"
+}
+
+locals {
+  es_data_stream = data.terraform_remote_state.platform_infra_shared.outputs["esf_data_stream_name"]
 }

--- a/accounts/platform/terraform.tf
+++ b/accounts/platform/terraform.tf
@@ -142,4 +142,16 @@ data "terraform_remote_state" "accounts_dam_prototype" {
   }
 }
 
+data "terraform_remote_state" "platform_infra_shared" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/platform-infrastructure/shared.tfstate"
+    region = "eu-west-1"
+  }
+}
+
 data "aws_caller_identity" "current" {}

--- a/critical/elastic_logging_cluster.tf
+++ b/critical/elastic_logging_cluster.tf
@@ -179,9 +179,9 @@ module "esf_data_stream" {
     elasticstack = elasticstack.logging
   }
 
-  stream_name = "service-logs-esf"
+  stream_name            = "service-logs-esf"
   index_rollover_max_age = "1d"
-  index_delete_after = "30d"
+  index_delete_after     = "30d"
 }
 
 resource "elasticstack_elasticsearch_security_api_key" "esf" {
@@ -193,7 +193,7 @@ resource "elasticstack_elasticsearch_security_api_key" "esf" {
     write-to-stream = {
       indices = [
         {
-          names = [module.esf_data_stream.name],
+          names      = [module.esf_data_stream.name],
           privileges = ["create_index", "index", "create"]
         }
       ]

--- a/critical/elastic_logging_cluster.tf
+++ b/critical/elastic_logging_cluster.tf
@@ -125,6 +125,8 @@ locals {
 
   logging_apm_server_url = ec_deployment.logging.apm[0].https_endpoint
   logging_apm_secret     = ec_deployment.logging.apm_secret_token
+
+  logging_esf_api_key = elasticstack_elasticsearch_security_api_key.esf.api_key
 }
 
 module "host_secrets" {
@@ -138,6 +140,8 @@ module "host_secrets" {
     "elasticsearch/logging/kibana_endpoint" = local.logging_kibana_endpoint
     "elasticsearch/logging/apm_server_url"  = local.logging_apm_server_url
     "elasticsearch/logging/apm_secret"      = local.logging_apm_secret
+
+    "elasticsearch/logging/esf/api_key" = local.logging_esf_api_key
 
     # Duplicated as this is what consumers currently expect
     # The above naming scheme is common to our other ES setups
@@ -167,4 +171,32 @@ resource "elasticstack_elasticsearch_security_role_mapping" "logging" {
     }
   })
   metadata = jsonencode({ version = 1 })
+}
+
+module "esf_data_stream" {
+  source = "./modules/elasticsearch_data_stream"
+  providers = {
+    elasticstack = elasticstack.logging
+  }
+
+  stream_name = "service-logs-esf"
+  index_rollover_max_age = "1d"
+  index_delete_after = "30d"
+}
+
+resource "elasticstack_elasticsearch_security_api_key" "esf" {
+  provider = elasticstack.logging
+
+  name = "Elastic Serverless Forwarder"
+
+  role_descriptors = jsonencode({
+    write-to-stream = {
+      indices = [
+        {
+          names = [module.esf_data_stream.name],
+          privileges = ["create_index", "index", "create"]
+        }
+      ]
+    }
+  })
 }

--- a/critical/modules/elasticsearch_data_stream/main.tf
+++ b/critical/modules/elasticsearch_data_stream/main.tf
@@ -17,7 +17,7 @@ resource "elasticstack_elasticsearch_index_template" "stream_template" {
   name = "${var.stream_name}-template"
 
   index_patterns = ["${var.stream_name}*"]
-  priority = 1
+  priority       = 1
 
   template {
     settings = jsonencode({

--- a/critical/modules/elasticsearch_data_stream/main.tf
+++ b/critical/modules/elasticsearch_data_stream/main.tf
@@ -1,0 +1,36 @@
+resource "elasticstack_elasticsearch_index_lifecycle" "stream_lifecycle" {
+  name = "${var.stream_name}-ilm"
+
+  hot {
+    rollover {
+      max_age = var.index_rollover_max_age
+    }
+  }
+
+  delete {
+    min_age = var.index_delete_after
+    delete {}
+  }
+}
+
+resource "elasticstack_elasticsearch_index_template" "stream_template" {
+  name = "${var.stream_name}-template"
+
+  index_patterns = ["${var.stream_name}*"]
+  priority = 1
+
+  template {
+    settings = jsonencode({
+      "lifecycle.name" = elasticstack_elasticsearch_index_lifecycle.stream_lifecycle.name
+    })
+  }
+
+  data_stream {}
+}
+
+resource "elasticstack_elasticsearch_data_stream" "stream" {
+  name = var.stream_name
+  depends_on = [
+    elasticstack_elasticsearch_index_template.stream_template
+  ]
+}

--- a/critical/modules/elasticsearch_data_stream/outputs.tf
+++ b/critical/modules/elasticsearch_data_stream/outputs.tf
@@ -1,0 +1,3 @@
+output "name" {
+  value = elasticstack_elasticsearch_data_stream.stream.name
+}

--- a/critical/modules/elasticsearch_data_stream/provider.tf
+++ b/critical/modules/elasticsearch_data_stream/provider.tf
@@ -1,0 +1,13 @@
+# Although we've declared the provider at the top level, we need to redeclare it in
+# the module.  Otherwise, Terraform defaults to "hashicorp/{provider}"
+# See https://github.com/hashicorp/terraform/issues/25172#issuecomment-641284286
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    elasticstack = {
+      source = "elastic/elasticstack"
+    }
+  }
+}

--- a/critical/modules/elasticsearch_data_stream/variables.tf
+++ b/critical/modules/elasticsearch_data_stream/variables.tf
@@ -3,11 +3,11 @@ variable "stream_name" {
 }
 
 variable "index_rollover_max_age" {
-  type = string
+  type    = string
   default = "1d"
 }
 
 variable "index_delete_after" {
-  type = string
+  type    = string
   default = "30d"
 }

--- a/critical/modules/elasticsearch_data_stream/variables.tf
+++ b/critical/modules/elasticsearch_data_stream/variables.tf
@@ -1,0 +1,13 @@
+variable "stream_name" {
+  type = string
+}
+
+variable "index_rollover_max_age" {
+  type = string
+  default = "1d"
+}
+
+variable "index_delete_after" {
+  type = string
+  default = "30d"
+}

--- a/critical/outputs.tf
+++ b/critical/outputs.tf
@@ -99,6 +99,10 @@ output "shared_secrets_apm" {
   value = local.apm_secrets
 }
 
+output "esf_data_stream_name" {
+  value = module.esf_data_stream.name
+}
+
 # Elastic Cloud
 
 output "ec_public_internet_traffic_filter_id" {


### PR DESCRIPTION
This provisions (a) an [Elastic serverless forwarder](https://github.com/elastic/elastic-serverless-forwarder), (b) a data stream in the logging cluster for it to put logs into, and (c) a Kinesis stream that it subscribes to.

It's kind of non-trivial to test this, as there is a bit of an IAM dance for sending logs from a Lambda to the Kinesis stream. I'll build a module to do this separately, and then probably need to come back here to tweak. 