### PR TITLE
Initial cloudfront config for iiif-stage-new

### DIFF
--- a/.buildkite/pipeline.redirectsTest.yml
+++ b/.buildkite/pipeline.redirectsTest.yml
@@ -19,6 +19,16 @@ steps:
     retry:
       automatic: true
 
+  - label: "IIIF STAGE-NEW Redirects"
+    plugins:
+      - ecr#v2.1.1:
+          login: true
+      - docker-compose#v3.5.0:
+          run: iiif_tests
+          command: ["--env", "stage-new"]
+    retry:
+      automatic: true
+
   - label: "IIIF PROD Redirects"
     plugins:
       - ecr#v2.1.1:

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cert.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cert.tf
@@ -7,6 +7,7 @@ module "cert" {
     "iiif-test.wellcomecollection.org",
     "iiif-prod.wellcomecollection.org",
     "iiif-stage.wellcomecollection.org",
+    "iiif-stage-new.wellcomecollection.org",
   ]
 
   zone_id = data.aws_route53_zone.zone.id

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cert.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cert.tf
@@ -7,8 +7,22 @@ module "cert" {
     "iiif-test.wellcomecollection.org",
     "iiif-prod.wellcomecollection.org",
     "iiif-stage.wellcomecollection.org",
-    "iiif-stage-new.wellcomecollection.org",
   ]
+
+  zone_id = data.aws_route53_zone.zone.id
+
+  providers = {
+    aws     = aws.us_east_1
+    aws.dns = aws.dns
+  }
+}
+
+# rather than alter the current, prod cert create a new one
+# for temporary environment
+module "cert_stagenew" {
+  source = "../../modules/certificate"
+
+  domain_name = "iiif-stage-new.wellcomecollection.org"
 
   zone_id = data.aws_route53_zone.zone.id
 

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
@@ -103,8 +103,8 @@ locals {
         }
       ]
 
-      min_ttl     = 7 * 24 * 60 * 60
-      default_ttl = 24 * 60 * 60
+      min_ttl     = 24 * 60 * 60
+      default_ttl = 7 * 24 * 60 * 60
       max_ttl     = 365 * 24 * 60 * 60
     }
   ]
@@ -122,8 +122,8 @@ locals {
         }
       ]
 
-      min_ttl     = 7 * 24 * 60 * 60
-      default_ttl = 24 * 60 * 60
+      min_ttl     = 24 * 60 * 60
+      default_ttl = 7 * 24 * 60 * 60
       max_ttl     = 365 * 24 * 60 * 60
     }
   ]

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
@@ -21,6 +21,10 @@ module "dashboard_origin_set" {
     domain_name : "dash-test.wellcomecollection.digirati.io"
     origin_path : null
   }
+  stage_new = {
+    domain_name : "dash-stage-new.wellcomecollection.digirati.io"
+    origin_path : null
+  }
 }
 
 module "iiif_origin_set" {
@@ -39,6 +43,10 @@ module "iiif_origin_set" {
     domain_name : "dds-test.wellcomecollection.digirati.io"
     origin_path : null
   }
+  stage_new = {
+    domain_name : "dds-stage-new.wellcomecollection.digirati.io"
+    origin_path : null
+  }
 }
 
 module "dlcs_origin_set" {
@@ -55,6 +63,10 @@ module "dlcs_origin_set" {
   }
   test = {
     domain_name : "dlcs.io"
+    origin_path : null
+  }
+  stage_new = {
+    domain_name : "neworchestrator.dlcs.io"
     origin_path : null
   }
 }
@@ -80,6 +92,10 @@ module "dlcs_wellcome_images_origin_set" {
     domain_name : "dlcs.io"
     origin_path : "/iiif-img/wellcome/8"
   }
+  stage_new = {
+    domain_name : "neworchestrator.dlcs.io"
+    origin_path : "/iiif-img/wellcome/8"
+  }
 }
 
 // These are the set of all other images served by DLCS
@@ -103,6 +119,10 @@ module "dlcs_images_origin_set" {
     domain_name : "dlcs.io"
     origin_path : "/iiif-img/wellcome/6"
   }
+  stage_new = {
+    domain_name : "neworchestrator.dlcs.io"
+    origin_path : "/iiif-img/wellcome/6"
+  }
 }
 
 // Corresponding to DLCS "Space 8"
@@ -122,6 +142,10 @@ module "dlcs_wellcome_thumbs_origin_set" {
   }
   test = {
     domain_name : "dlcs.io"
+    origin_path : "/thumbs/wellcome/8"
+  }
+  stage_new = {
+    domain_name : "neworchestrator.dlcs.io"
     origin_path : "/thumbs/wellcome/8"
   }
 }
@@ -144,6 +168,10 @@ module "dlcs_thumbs_origin_set" {
     domain_name : "dlcs.io"
     origin_path : "/thumbs/wellcome/6"
   }
+  stage_new = {
+    domain_name : "neworchestrator.dlcs.io"
+    origin_path : "/thumbs/wellcome/6"
+  }
 }
 
 module "dlcs_av_origin_set" {
@@ -164,6 +192,10 @@ module "dlcs_av_origin_set" {
     domain_name : "dlcs.io"
     origin_path : "/iiif-av/wellcome/6"
   }
+  stage_new = {
+    domain_name : "neworchestrator.dlcs.io"
+    origin_path : "/iiif-av/wellcome/6"
+  }
 }
 
 module "dlcs_pdf_origin_set" {
@@ -180,6 +212,10 @@ module "dlcs_pdf_origin_set" {
   }
   test = {
     domain_name : "dlcs.io"
+    origin_path : "/pdf/wellcome/pdf/6"
+  }
+  stage_new = {
+    domain_name : "neworchestrator.dlcs.io"
     origin_path : "/pdf/wellcome/pdf/6"
   }
 }
@@ -200,6 +236,10 @@ module "dlcs_file_origin_set" {
     domain_name : "dlcs.io"
     origin_path : "/file/wellcome/6"
   }
+  stage_new = {
+    domain_name : "neworchestrator.dlcs.io"
+    origin_path : "/file/wellcome/6"
+  }
 }
 
 module "dlcs_pdf_cover_origin_set" {
@@ -216,6 +256,10 @@ module "dlcs_pdf_cover_origin_set" {
   }
   test = {
     domain_name : "pdf-stage.wellcomecollection.digirati.io"
+    origin_path : null
+  }
+  stage_new = {
+    domain_name : "pdf-stage-new.wellcomecollection.digirati.io"
     origin_path : null
   }
 }
@@ -236,6 +280,10 @@ module "dlcs_auth_origin_set" {
   }
   test = {
     domain_name : "dlcs.io"
+    origin_path : "/auth/2"
+  }
+  stage_new = {
+    domain_name : "neworchestrator.dlcs.io"
     origin_path : "/auth/2"
   }
 }
@@ -285,5 +333,20 @@ locals {
     module.dlcs_file_origin_set.origins["test"],
     module.dlcs_pdf_cover_origin_set.origins["test"],
     module.dlcs_auth_origin_set.origins["test"]
+  ]
+
+  stage_new_origins = [
+    module.dashboard_origin_set.origins["stage_new"],
+    module.iiif_origin_set.origins["stage_new"],
+    module.dlcs_origin_set.origins["stage_new"],
+    module.dlcs_wellcome_images_origin_set.origins["stage_new"],
+    module.dlcs_wellcome_thumbs_origin_set.origins["stage_new"],
+    module.dlcs_images_origin_set.origins["stage_new"],
+    module.dlcs_thumbs_origin_set.origins["stage_new"],
+    module.dlcs_av_origin_set.origins["stage_new"],
+    module.dlcs_pdf_origin_set.origins["stage_new"],
+    module.dlcs_file_origin_set.origins["stage_new"],
+    module.dlcs_pdf_cover_origin_set.origins["stage_new"],
+    module.dlcs_auth_origin_set.origins["stage_new"]
   ]
 }

--- a/cloudfront/iiif.wellcomecollection.org/terraform/main.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/main.tf
@@ -40,7 +40,7 @@ module "iiif-stage-new" {
   environment         = "stage-new"
   acm_certificate_arn = module.cert_stagenew.arn
 
-  origins    = local.test_origins
+  origins    = local.stage_new_origins
   behaviours = local.test_behaviours
 
   default_target_origin_id = "iiif"

--- a/cloudfront/iiif.wellcomecollection.org/terraform/main.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/main.tf
@@ -38,7 +38,7 @@ module "iiif-stage-new" {
   source = "./cloudfront_distro"
 
   environment         = "stage-new"
-  acm_certificate_arn = module.cert.arn
+  acm_certificate_arn = module.cert_stagenew.arn
 
   origins    = local.test_origins
   behaviours = local.test_behaviours

--- a/cloudfront/iiif.wellcomecollection.org/terraform/main.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/main.tf
@@ -33,3 +33,15 @@ module "iiif-test" {
 
   default_target_origin_id = "iiif"
 }
+
+module "iiif-stage-new" {
+  source = "./cloudfront_distro"
+
+  environment         = "stage-new"
+  acm_certificate_arn = module.cert.arn
+
+  origins    = local.test_origins
+  behaviours = local.test_behaviours
+
+  default_target_origin_id = "iiif"
+}

--- a/cloudfront/iiif.wellcomecollection.org/terraform/origin_sets/origin_set.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/origin_sets/origin_set.tf
@@ -25,6 +25,12 @@ variable "test" {
     origin_path : string
   })
 }
+variable "stage_new" {
+  type = object({
+    domain_name : string
+    origin_path : string
+  })
+}
 
 output "origins" {
   value = {
@@ -44,6 +50,12 @@ output "origins" {
       origin_id    = var.id
       domain_name  = var.test.domain_name
       origin_path  = var.test.origin_path
+      forward_host = var.forward_host
+    },
+    stage_new : {
+      origin_id    = var.id
+      domain_name  = var.stage_new.domain_name
+      origin_path  = var.stage_new.origin_path
       forward_host = var.forward_host
     }
   }

--- a/cloudfront/iiif.wellcomecollection.org/terraform/outputs.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/outputs.tf
@@ -18,3 +18,7 @@ output "iiif_stage_distribution_id" {
 output "iiif_test_distribution_id" {
   value = module.iiif-test.distribution_id
 }
+
+output "iiif_stage_new_distribution_id" {
+  value = module.iiif-stage-new.distribution_id
+}

--- a/cloudfront/iiif.wellcomecollection.org/tests/rewrite_tests.py
+++ b/cloudfront/iiif.wellcomecollection.org/tests/rewrite_tests.py
@@ -118,33 +118,33 @@ def validate_cors_headers(uri, origin):
     click.echo(click.style(f"Request to '{uri}' has expected CORS.", fg="green"))
 
 
-def run_checks(env_suffix=""):
+def run_checks(env_suffix="", dlcs_hostname="dlcs.io"):
     space = 5 if env_suffix == "" else 6
     id_checks = {
         # miro
         # wellcome_images_dlcs_behaviours
         f"https://iiif{env_suffix}.wellcomecollection.org/image/V0022459": f"https://iiif{env_suffix}.wellcomecollection.org/image/V0022459",  # miro root, wc.org
         f"https://iiif{env_suffix}.wellcomecollection.org/image/V0022459/info.json": f"https://iiif{env_suffix}.wellcomecollection.org/image/V0022459",  # miro info.json, wc.org
-        f"https://dlcs.io/iiif-img/2/8/V0022459": f"https://dlcs.io/iiif-img/2/8/V0022459",  # miro root, dlcs.io
-        f"https://dlcs.io/iiif-img/2/8/V0022459/info.json": f"https://dlcs.io/iiif-img/2/8/V0022459",  # miro info.json, dlcs.io
+        f"https:/{dlcs_hostname}/iiif-img/2/8/V0022459": f"https:/{dlcs_hostname}/iiif-img/2/8/V0022459",  # miro root, dlcs.io
+        f"https:/{dlcs_hostname}/iiif-img/2/8/V0022459/info.json": f"https:/{dlcs_hostname}/iiif-img/2/8/V0022459",  # miro info.json, dlcs.io
         # non-miro images
         # dlcs_images_behaviours
         f"https://iiif{env_suffix}.wellcomecollection.org/image/b31905560_0006.jp2": f"https://iiif{env_suffix}.wellcomecollection.org/image/b31905560_0006.jp2",  # non-miro root, wc.org
         f"https://iiif{env_suffix}.wellcomecollection.org/image/b31905560_0006.jp2/info.json": f"https://iiif{env_suffix}.wellcomecollection.org/image/b31905560_0006.jp2",  # non-miro info.json, wc.org
-        f"https://dlcs.io/iiif-img/2/{space}/b31905560_0006.jp2": f"https://dlcs.io/iiif-img/2/{space}/b31905560_0006.jp2",  # non-miro root, dlcs.io
-        f"https://dlcs.io/iiif-img/2/{space}/b31905560_0006.jp2/info.json": f"https://dlcs.io/iiif-img/2/{space}/b31905560_0006.jp2",  # non-miro info.json, dlcs.io
+        f"https:/{dlcs_hostname}/iiif-img/2/{space}/b31905560_0006.jp2": f"https:/{dlcs_hostname}/iiif-img/2/{space}/b31905560_0006.jp2",  # non-miro root, dlcs.io
+        f"https:/{dlcs_hostname}/iiif-img/2/{space}/b31905560_0006.jp2/info.json": f"https:/{dlcs_hostname}/iiif-img/2/{space}/b31905560_0006.jp2",  # non-miro info.json, dlcs.io
         # video
         # av_behaviours
         f"https://iiif{env_suffix}.wellcomecollection.org/av/b16756654_0055-0000-4202-0000-0-0000-0000-0.mpg": f"https://iiif{env_suffix}.wellcomecollection.org/av/b16756654_0055-0000-4202-0000-0-0000-0000-0.mpg",  # root, wc.org
         f"https://iiif{env_suffix}.wellcomecollection.org/av/b16756654_0055-0000-4202-0000-0-0000-0000-0.mpg/info.json": f"https://iiif{env_suffix}.wellcomecollection.org/av/b16756654_0055-0000-4202-0000-0-0000-0000-0.mpg",  # info.json, wc.org
-        f"https://dlcs.io/iiif-av/2/{space}/b16756654_0055-0000-4202-0000-0-0000-0000-0.mpg": f"https://dlcs.io/iiif-av/2/{space}/b16756654_0055-0000-4202-0000-0-0000-0000-0.mpg",  # root, dlcs.io
-        f"https://dlcs.io/iiif-av/2/{space}/b16756654_0055-0000-4202-0000-0-0000-0000-0.mpg/info.json": f"https://dlcs.io/iiif-av/2/{space}/b16756654_0055-0000-4202-0000-0-0000-0000-0.mpg",  # info.json, dlcs.io
+        f"https:/{dlcs_hostname}/iiif-av/2/{space}/b16756654_0055-0000-4202-0000-0-0000-0000-0.mpg": f"https:/{dlcs_hostname}/iiif-av/2/{space}/b16756654_0055-0000-4202-0000-0-0000-0000-0.mpg",  # root, dlcs.io
+        f"https:/{dlcs_hostname}/iiif-av/2/{space}/b16756654_0055-0000-4202-0000-0-0000-0000-0.mpg/info.json": f"https:/{dlcs_hostname}/iiif-av/2/{space}/b16756654_0055-0000-4202-0000-0-0000-0000-0.mpg",  # info.json, dlcs.io
         # audio
         # av_behaviours
         f"https://iiif{env_suffix}.wellcomecollection.org/av/b32496485_0001_0001.mp3": f"https://iiif{env_suffix}.wellcomecollection.org/av/b32496485_0001_0001.mp3",  # root, wc.org
         f"https://iiif{env_suffix}.wellcomecollection.org/av/b32496485_0001_0001.mp3/info.json": f"https://iiif{env_suffix}.wellcomecollection.org/av/b32496485_0001_0001.mp3",  # info.json, wc.org
-        f"https://dlcs.io/iiif-av/2/{space}/b32496485_0001_0001.mp3": f"https://dlcs.io/iiif-av/2/{space}/b32496485_0001_0001.mp3",  # root, dlcs.io
-        f"https://dlcs.io/iiif-av/2/{space}/b32496485_0001_0001.mp3/info.json": f"https://dlcs.io/iiif-av/2/{space}/b32496485_0001_0001.mp3",  # info.json, dlcs.io
+        f"https:/{dlcs_hostname}/iiif-av/2/{space}/b32496485_0001_0001.mp3": f"https:/{dlcs_hostname}/iiif-av/2/{space}/b32496485_0001_0001.mp3",  # root, dlcs.io
+        f"https:/{dlcs_hostname}/iiif-av/2/{space}/b32496485_0001_0001.mp3/info.json": f"https:/{dlcs_hostname}/iiif-av/2/{space}/b32496485_0001_0001.mp3",  # info.json, dlcs.io
     }
 
     # validate info.json @id correct
@@ -232,6 +232,8 @@ def check_iiif(env):
         run_checks("-stage")
     elif env == "test":
         run_checks("-test")
+    elif env == "stage-new":
+        run_checks("-stage-new", "neworchestrator.dlcs.io")
     else:
         run_checks()
 

--- a/cloudfront/invalidation/terraform/iam.tf
+++ b/cloudfront/invalidation/terraform/iam.tf
@@ -138,3 +138,31 @@ resource "aws_sns_topic_policy" "iiif_test" {
   arn    = module.iiif_test.sns_topic_arn
   policy = data.aws_iam_policy_document.iiif_test.json
 }
+
+data "aws_iam_policy_document" "iiif_stage_new" {
+  statement {
+    actions = [
+      "sns:Publish",
+    ]
+
+    resources = [module.iiif_stage_new.sns_topic_arn, ]
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:userId"
+      values = [
+        "${local.dds_workflow_stage_new}:*"
+      ]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+}
+
+resource "aws_sns_topic_policy" "iiif_stage_new" {
+  arn    = module.iiif_stage_new.sns_topic_arn
+  policy = data.aws_iam_policy_document.iiif_stage_new.json
+}

--- a/cloudfront/invalidation/terraform/locals.tf
+++ b/cloudfront/invalidation/terraform/locals.tf
@@ -2,5 +2,5 @@ locals {
   dds_workflow_prod      = "AROAZQI22QHW5L3AA6HGE"
   dds_workflow_stage     = "AROAZQI22QHWVEECG3UI3"
   dds_workflow_test      = "AROAZQI22QHWWHVPVKOM3"
-  dds_workflow_stage_new = "TBC"
+  dds_workflow_stage_new = "AROAZQI22QHWQWE3OVT34"
 }

--- a/cloudfront/invalidation/terraform/locals.tf
+++ b/cloudfront/invalidation/terraform/locals.tf
@@ -1,5 +1,6 @@
 locals {
-  dds_workflow_prod  = "AROAZQI22QHW5L3AA6HGE"
-  dds_workflow_stage = "AROAZQI22QHWVEECG3UI3"
-  dds_workflow_test  = "AROAZQI22QHWWHVPVKOM3"
+  dds_workflow_prod      = "AROAZQI22QHW5L3AA6HGE"
+  dds_workflow_stage     = "AROAZQI22QHWVEECG3UI3"
+  dds_workflow_test      = "AROAZQI22QHWWHVPVKOM3"
+  dds_workflow_stage_new = "TBC"
 }

--- a/cloudfront/invalidation/terraform/main.tf
+++ b/cloudfront/invalidation/terraform/main.tf
@@ -22,6 +22,14 @@ module "iiif_test" {
   distribution_id = data.terraform_remote_state.iiif_wc_cloudfront.outputs.iiif_test_distribution_id
 }
 
+# topic and handler for invalidating iiif-stage-new.wc.org paths
+module "iiif_stage_new" {
+  source = "./sns_lambda"
+
+  friendly_name   = "iiif-stage-new"
+  distribution_id = data.terraform_remote_state.iiif_wc_cloudfront.outputs.iiif_stage_new_distribution_id
+}
+
 # topic and handler for invalidating api.wc.org paths
 module "api_prod" {
   source = "./sns_lambda"


### PR DESCRIPTION
## What's changing and why?

(WIP)

This adds Cloudfront configuration for routing to an additional complete DDS environment, `iiif-stage-new.wellcomecollection.org`, alongside `iiif`, `iiif-stage` and `iiif-test`, as well as routing asset (image service, AV, born digital) DLCS requests to `neworchestrator.dlcs.io` rather than `dlcs.io`.

## `terraform plan` diff

TBC

Questions:

 - Does the Edge Lambda need anything extra?
 - What needs to go in [cf_behaviours.tf](https://github.com/wellcomecollection/platform-infrastructure/blob/main/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf) ? It currently has `prod` and `stage` configuration but NOT `test`.
 - Similarly [locals.tf](https://github.com/wellcomecollection/platform-infrastructure/blob/main/cloudfront/iiif.wellcomecollection.org/terraform/locals.tf) doesn't have `test` but we're going to need something here
 - Should we bother handling auth paths?
 - Need an ARN here: https://github.com/wellcomecollection/platform-infrastructure/pull/349/files#diff-158119a93634df2b0cde4fe993db46ba19122c5f8a1e3f99602b678b5aa73dfbR5



