### PR TITLE
Configure the Kinesis stream with a cross-account log destination

### DIFF
--- a/critical/elastic_logging_cluster.tf
+++ b/critical/elastic_logging_cluster.tf
@@ -126,7 +126,7 @@ locals {
   logging_apm_server_url = ec_deployment.logging.apm[0].https_endpoint
   logging_apm_secret     = ec_deployment.logging.apm_secret_token
 
-  logging_esf_api_key = elasticstack_elasticsearch_security_api_key.esf.api_key
+  logging_esf_api_key = elasticstack_elasticsearch_security_api_key.esf.encoded
 }
 
 module "host_secrets" {
@@ -190,11 +190,14 @@ resource "elasticstack_elasticsearch_security_api_key" "esf" {
   name = "Elastic Serverless Forwarder"
 
   role_descriptors = jsonencode({
+    cluster-health = {
+      cluster = ["monitor"]
+    }
     write-to-stream = {
       indices = [
         {
           names      = [module.esf_data_stream.name],
-          privileges = ["create_index", "index", "create"]
+          privileges = ["create_index", "index", "create", "auto_configure"]
         }
       ]
     }

--- a/critical/lambda_logging.tf
+++ b/critical/lambda_logging.tf
@@ -1,19 +1,22 @@
-resource "aws_kinesis_stream" "logs_for_esf" {
-  name = "logs-for-elastic-serverless-forwarder"
-
-  enforce_consumer_deletion = true
-  encryption_type           = "NONE"
-  retention_period          = 3 * 24 // Give us 3 days to deal with issues ingesting logs
-
-  stream_mode_details {
-    stream_mode = "ON_DEMAND"
-  }
-}
-
 module "elastic_log_forwarder" {
   source = "./modules/elastic_log_forwarder"
 
-  kinesis_log_stream_arn = aws_kinesis_stream.logs_for_esf.arn
+  kinesis_log_stream_arn = module.kinesis_log_destination.kinesis_stream.arn
   es_data_stream         = module.esf_data_stream.name
   es_api_key_secret      = "elasticsearch/logging/esf/api_key"
+}
+
+module "kinesis_log_destination" {
+  source = "./modules/kinesis_log_destination"
+
+  name = "esf-logs"
+  source_account_ids = values(local.account_ids)
+}
+
+// Put this in parameter store rather than as an output
+// so that our Lambdas don't need access to the whole critical stack state
+resource "aws_ssm_parameter" "log_destination_arn" {
+  name = "/logging/esf/destination_arn"
+  type = "String"
+  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
 }

--- a/critical/lambda_logging.tf
+++ b/critical/lambda_logging.tf
@@ -25,6 +25,7 @@ resource "aws_ssm_parameter" "log_destination_arn_platform" {
   name = local.esf_destination_parameter_name
   type = "String"
   value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  overwrite = true
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_catalogue" {
@@ -33,6 +34,7 @@ resource "aws_ssm_parameter" "log_destination_arn_catalogue" {
   name = local.esf_destination_parameter_name
   type = "String"
   value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  overwrite = true
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_digirati" {
@@ -41,6 +43,7 @@ resource "aws_ssm_parameter" "log_destination_arn_digirati" {
   name = local.esf_destination_parameter_name
   type = "String"
   value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  overwrite = true
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_experience" {
@@ -49,6 +52,7 @@ resource "aws_ssm_parameter" "log_destination_arn_experience" {
   name = local.esf_destination_parameter_name
   type = "String"
   value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  overwrite = true
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_identity" {
@@ -57,6 +61,7 @@ resource "aws_ssm_parameter" "log_destination_arn_identity" {
   name = local.esf_destination_parameter_name
   type = "String"
   value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  overwrite = true
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_reporting" {
@@ -65,6 +70,7 @@ resource "aws_ssm_parameter" "log_destination_arn_reporting" {
   name = local.esf_destination_parameter_name
   type = "String"
   value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  overwrite = true
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_storage" {
@@ -73,6 +79,7 @@ resource "aws_ssm_parameter" "log_destination_arn_storage" {
   name = local.esf_destination_parameter_name
   type = "String"
   value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  overwrite = true
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_workflow" {
@@ -81,4 +88,5 @@ resource "aws_ssm_parameter" "log_destination_arn_workflow" {
   name = local.esf_destination_parameter_name
   type = "String"
   value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  overwrite = true
 }

--- a/critical/lambda_logging.tf
+++ b/critical/lambda_logging.tf
@@ -15,8 +15,70 @@ module "kinesis_log_destination" {
 
 // Put this in parameter store rather than as an output
 // so that our Lambdas don't need access to the whole critical stack state
-resource "aws_ssm_parameter" "log_destination_arn" {
-  name = "/logging/esf/destination_arn"
+locals {
+  esf_destination_parameter_name = "/logging/esf/destination_arn"
+}
+
+resource "aws_ssm_parameter" "log_destination_arn_platform" {
+  provider = aws.platform
+
+  name = local.esf_destination_parameter_name
+  type = "String"
+  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+}
+
+resource "aws_ssm_parameter" "log_destination_arn_catalogue" {
+  provider = aws.catalogue
+
+  name = local.esf_destination_parameter_name
+  type = "String"
+  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+}
+
+resource "aws_ssm_parameter" "log_destination_arn_digirati" {
+  provider = aws.digirati
+
+  name = local.esf_destination_parameter_name
+  type = "String"
+  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+}
+
+resource "aws_ssm_parameter" "log_destination_arn_experience" {
+  provider = aws.experience
+
+  name = local.esf_destination_parameter_name
+  type = "String"
+  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+}
+
+resource "aws_ssm_parameter" "log_destination_arn_identity" {
+  provider = aws.identity
+
+  name = local.esf_destination_parameter_name
+  type = "String"
+  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+}
+
+resource "aws_ssm_parameter" "log_destination_arn_reporting" {
+  provider = aws.reporting
+
+  name = local.esf_destination_parameter_name
+  type = "String"
+  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+}
+
+resource "aws_ssm_parameter" "log_destination_arn_storage" {
+  provider = aws.storage
+
+  name = local.esf_destination_parameter_name
+  type = "String"
+  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+}
+
+resource "aws_ssm_parameter" "log_destination_arn_workflow" {
+  provider = aws.workflow
+
+  name = local.esf_destination_parameter_name
   type = "String"
   value = module.kinesis_log_destination.cloudwatch_log_destination.arn
 }

--- a/critical/lambda_logging.tf
+++ b/critical/lambda_logging.tf
@@ -9,7 +9,7 @@ module "elastic_log_forwarder" {
 module "kinesis_log_destination" {
   source = "./modules/kinesis_log_destination"
 
-  name = "esf-logs"
+  name               = "esf-logs"
   source_account_ids = values(local.account_ids)
 }
 
@@ -22,71 +22,71 @@ locals {
 resource "aws_ssm_parameter" "log_destination_arn_platform" {
   provider = aws.platform
 
-  name = local.esf_destination_parameter_name
-  type = "String"
-  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  name      = local.esf_destination_parameter_name
+  type      = "String"
+  value     = module.kinesis_log_destination.cloudwatch_log_destination.arn
   overwrite = true
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_catalogue" {
   provider = aws.catalogue
 
-  name = local.esf_destination_parameter_name
-  type = "String"
-  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  name      = local.esf_destination_parameter_name
+  type      = "String"
+  value     = module.kinesis_log_destination.cloudwatch_log_destination.arn
   overwrite = true
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_digirati" {
   provider = aws.digirati
 
-  name = local.esf_destination_parameter_name
-  type = "String"
-  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  name      = local.esf_destination_parameter_name
+  type      = "String"
+  value     = module.kinesis_log_destination.cloudwatch_log_destination.arn
   overwrite = true
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_experience" {
   provider = aws.experience
 
-  name = local.esf_destination_parameter_name
-  type = "String"
-  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  name      = local.esf_destination_parameter_name
+  type      = "String"
+  value     = module.kinesis_log_destination.cloudwatch_log_destination.arn
   overwrite = true
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_identity" {
   provider = aws.identity
 
-  name = local.esf_destination_parameter_name
-  type = "String"
-  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  name      = local.esf_destination_parameter_name
+  type      = "String"
+  value     = module.kinesis_log_destination.cloudwatch_log_destination.arn
   overwrite = true
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_reporting" {
   provider = aws.reporting
 
-  name = local.esf_destination_parameter_name
-  type = "String"
-  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  name      = local.esf_destination_parameter_name
+  type      = "String"
+  value     = module.kinesis_log_destination.cloudwatch_log_destination.arn
   overwrite = true
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_storage" {
   provider = aws.storage
 
-  name = local.esf_destination_parameter_name
-  type = "String"
-  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  name      = local.esf_destination_parameter_name
+  type      = "String"
+  value     = module.kinesis_log_destination.cloudwatch_log_destination.arn
   overwrite = true
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_workflow" {
   provider = aws.workflow
 
-  name = local.esf_destination_parameter_name
-  type = "String"
-  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  name      = local.esf_destination_parameter_name
+  type      = "String"
+  value     = module.kinesis_log_destination.cloudwatch_log_destination.arn
   overwrite = true
 }

--- a/critical/locals.tf
+++ b/critical/locals.tf
@@ -17,12 +17,38 @@ locals {
   aws_region = "eu-west-1"
 
   account_ids = {
-    catalogue  = "756629837203"
-    reporting  = "269807742353"
-    experience = "130871440101"
+    catalogue  = data.aws_caller_identity.catalogue.account_id
+    digirati  = data.aws_caller_identity.digirati.account_id
+    experience = data.aws_caller_identity.experience.account_id
+    identity = data.aws_caller_identity.identity.account_id
+    reporting = data.aws_caller_identity.reporting.account_id
+    storage = data.aws_caller_identity.storage.account_id
+    workflow = data.aws_caller_identity.workflow.account_id
   }
 
   default_tags = {
     TerraformConfigurationURL = "https://github.com/wellcomecollection/platform-infrastructure/tree/main/critical"
   }
+}
+
+data "aws_caller_identity" "catalogue" {
+  provider = aws.catalogue
+}
+data "aws_caller_identity" "digirati" {
+  provider = aws.digirati
+}
+data "aws_caller_identity" "experience" {
+  provider = aws.experience
+}
+data "aws_caller_identity" "identity" {
+  provider = aws.identity
+}
+data "aws_caller_identity" "reporting" {
+  provider = aws.reporting
+}
+data "aws_caller_identity" "storage" {
+  provider = aws.storage
+}
+data "aws_caller_identity" "workflow" {
+  provider = aws.workflow
 }

--- a/critical/locals.tf
+++ b/critical/locals.tf
@@ -18,12 +18,12 @@ locals {
 
   account_ids = {
     catalogue  = data.aws_caller_identity.catalogue.account_id
-    digirati  = data.aws_caller_identity.digirati.account_id
+    digirati   = data.aws_caller_identity.digirati.account_id
     experience = data.aws_caller_identity.experience.account_id
-    identity = data.aws_caller_identity.identity.account_id
-    reporting = data.aws_caller_identity.reporting.account_id
-    storage = data.aws_caller_identity.storage.account_id
-    workflow = data.aws_caller_identity.workflow.account_id
+    identity   = data.aws_caller_identity.identity.account_id
+    reporting  = data.aws_caller_identity.reporting.account_id
+    storage    = data.aws_caller_identity.storage.account_id
+    workflow   = data.aws_caller_identity.workflow.account_id
   }
 
   default_tags = {

--- a/critical/modules/elastic_log_forwarder/config.yml.tftpl
+++ b/critical/modules/elastic_log_forwarder/config.yml.tftpl
@@ -4,6 +4,6 @@ inputs:
     outputs:
       - type: "elasticsearch"
         args:
-          elasticsearch_url: "${es_url_secret_arn}"
+          elasticsearch_url: "https://${es_host_secret_arn}"
           api_key: "${api_key_secret_arn}"
           es_datastream_name: "${es_data_stream_name}"

--- a/critical/modules/elastic_log_forwarder/config.yml.tftpl
+++ b/critical/modules/elastic_log_forwarder/config.yml.tftpl
@@ -1,6 +1,7 @@
 inputs:
   - type: "kinesis-data-stream"
     id: "${kinesis_stream_arn}"
+    expand_event_list_from_field: "logEvents"
     outputs:
       - type: "elasticsearch"
         args:

--- a/critical/modules/elastic_log_forwarder/main.tf
+++ b/critical/modules/elastic_log_forwarder/main.tf
@@ -26,7 +26,7 @@ resource "aws_s3_object" "esf_config" {
     {
       kinesis_stream_arn  = var.kinesis_log_stream_arn
       es_data_stream_name = var.es_data_stream
-      es_url_secret_arn   = local.host_secret_arn
+      es_host_secret_arn  = local.host_secret_arn
       api_key_secret_arn  = local.api_key_secret_arn
     }
   )

--- a/critical/modules/kinesis_log_destination/README.md
+++ b/critical/modules/kinesis_log_destination/README.md
@@ -1,0 +1,3 @@
+# kinesis_log_destination
+
+This module implements the architecture specified here: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CrossAccountSubscriptions-Kinesis.html

--- a/critical/modules/kinesis_log_destination/kinesis.tf
+++ b/critical/modules/kinesis_log_destination/kinesis.tf
@@ -1,0 +1,55 @@
+resource "aws_kinesis_stream" "destination" {
+  name = var.name
+
+  enforce_consumer_deletion = true
+  encryption_type           = "NONE"
+  retention_period          = 3 * 24 // Give us 3 days to deal with issues ingesting logs
+
+  stream_mode_details {
+    stream_mode = "ON_DEMAND"
+  }
+}
+
+resource "aws_iam_role" "cloudwatch_to_kinesis_role" {
+  name = "${var.name}-role"
+  assume_role_policy = data.aws_iam_policy_document.cloudwatch_assume_role.json
+}
+
+resource "aws_iam_role_policy" "kinesis_put_record" {
+  name = "kinesis-put-record-${var.name}"
+  role = aws_iam_role.cloudwatch_to_kinesis_role.name
+  policy = data.aws_iam_policy_document.kinesis_put_record.json
+}
+
+data "aws_iam_policy_document" "cloudwatch_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:SourceArn"
+      values   = [for id in local.all_account_ids : "arn:aws:logs:${data.aws_region.current.name}:${id}:*"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "kinesis_put_record" {
+  statement {
+    effect = "Allow"
+    actions = ["kinesis:PutRecord"]
+    resources = [aws_kinesis_stream.destination.arn]
+  }
+}
+
+locals {
+  all_account_ids = setunion(var.source_account_ids, [data.aws_caller_identity.current.account_id])
+}
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}

--- a/critical/modules/kinesis_log_destination/kinesis.tf
+++ b/critical/modules/kinesis_log_destination/kinesis.tf
@@ -11,13 +11,13 @@ resource "aws_kinesis_stream" "destination" {
 }
 
 resource "aws_iam_role" "cloudwatch_to_kinesis_role" {
-  name = "${var.name}-role"
+  name               = "${var.name}-role"
   assume_role_policy = data.aws_iam_policy_document.cloudwatch_assume_role.json
 }
 
 resource "aws_iam_role_policy" "kinesis_put_record" {
-  name = "kinesis-put-record-${var.name}"
-  role = aws_iam_role.cloudwatch_to_kinesis_role.name
+  name   = "kinesis-put-record-${var.name}"
+  role   = aws_iam_role.cloudwatch_to_kinesis_role.name
   policy = data.aws_iam_policy_document.kinesis_put_record.json
 }
 
@@ -41,8 +41,8 @@ data "aws_iam_policy_document" "cloudwatch_assume_role" {
 
 data "aws_iam_policy_document" "kinesis_put_record" {
   statement {
-    effect = "Allow"
-    actions = ["kinesis:PutRecord"]
+    effect    = "Allow"
+    actions   = ["kinesis:PutRecord"]
     resources = [aws_kinesis_stream.destination.arn]
   }
 }

--- a/critical/modules/kinesis_log_destination/log_destination.tf
+++ b/critical/modules/kinesis_log_destination/log_destination.tf
@@ -1,0 +1,23 @@
+resource "aws_cloudwatch_log_destination" "kinesis" {
+  name = var.name
+  role_arn = aws_iam_role.cloudwatch_to_kinesis_role.arn
+  target_arn = aws_kinesis_stream.destination.arn
+}
+
+resource "aws_cloudwatch_log_destination_policy" "cross_account_subscriptions" {
+  destination_name = aws_cloudwatch_log_destination.kinesis.name
+  access_policy = data.aws_iam_policy_document.cross_account_subscriptions.json
+}
+
+data "aws_iam_policy_document" "cross_account_subscriptions" {
+  statement {
+    effect = "Allow"
+    actions = ["logs:PutSubscriptionFilter"]
+    resources = [aws_cloudwatch_log_destination.kinesis.arn]
+
+    principals {
+      identifiers = local.all_account_ids
+      type        = "AWS"
+    }
+  }
+}

--- a/critical/modules/kinesis_log_destination/log_destination.tf
+++ b/critical/modules/kinesis_log_destination/log_destination.tf
@@ -1,18 +1,18 @@
 resource "aws_cloudwatch_log_destination" "kinesis" {
-  name = var.name
-  role_arn = aws_iam_role.cloudwatch_to_kinesis_role.arn
+  name       = var.name
+  role_arn   = aws_iam_role.cloudwatch_to_kinesis_role.arn
   target_arn = aws_kinesis_stream.destination.arn
 }
 
 resource "aws_cloudwatch_log_destination_policy" "cross_account_subscriptions" {
   destination_name = aws_cloudwatch_log_destination.kinesis.name
-  access_policy = data.aws_iam_policy_document.cross_account_subscriptions.json
+  access_policy    = data.aws_iam_policy_document.cross_account_subscriptions.json
 }
 
 data "aws_iam_policy_document" "cross_account_subscriptions" {
   statement {
-    effect = "Allow"
-    actions = ["logs:PutSubscriptionFilter"]
+    effect    = "Allow"
+    actions   = ["logs:PutSubscriptionFilter"]
     resources = [aws_cloudwatch_log_destination.kinesis.arn]
 
     principals {

--- a/critical/modules/kinesis_log_destination/outputs.tf
+++ b/critical/modules/kinesis_log_destination/outputs.tf
@@ -1,0 +1,7 @@
+output "cloudwatch_log_destination" {
+  value = aws_cloudwatch_log_destination.kinesis
+}
+
+output "kinesis_stream" {
+  value = aws_kinesis_stream.destination
+}

--- a/critical/modules/kinesis_log_destination/variables.tf
+++ b/critical/modules/kinesis_log_destination/variables.tf
@@ -1,0 +1,7 @@
+variable "name" {
+  type = string
+}
+
+variable "source_account_ids" {
+  type = set(string)
+}

--- a/critical/provider.tf
+++ b/critical/provider.tf
@@ -112,3 +112,16 @@ provider "aws" {
     role_arn = "arn:aws:iam::653428163053:role/digirati-admin"
   }
 }
+
+provider "aws" {
+  alias  = "reporting"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = local.default_tags
+  }
+
+  assume_role {
+    role_arn = "arn:aws:iam::269807742353:role/reporting-read_only"
+  }
+}

--- a/critical/provider.tf
+++ b/critical/provider.tf
@@ -122,6 +122,6 @@ provider "aws" {
   }
 
   assume_role {
-    role_arn = "arn:aws:iam::269807742353:role/reporting-read_only"
+    role_arn = "arn:aws:iam::269807742353:role/reporting-developer"
   }
 }


### PR DESCRIPTION
This makes it possible to send logs to Kinesis from any account, and also fixes the ESF configuration.