### PR TITLE
Remove references to the build_test_python image

### DIFF
--- a/images/publish_mirrored_images.py
+++ b/images/publish_mirrored_images.py
@@ -44,7 +44,6 @@ IMAGE_TAGS = [
     "localstack/localstack:0.10.5",
     "localstack/localstack:0.14.2",
     "scality/s3server:mem-latest",
-    "wellcome/build_test_python",
     "wellcome/flake8:latest",
     "wellcome/format_python:112",
     "wellcome/format_python:latest",

--- a/images/terraform/ecr.tf
+++ b/images/terraform/ecr.tf
@@ -134,7 +134,6 @@ locals {
     "localstack/localstack",
     "nginx",
     "scality/s3server",
-    "wellcome/build_test_python",
     "wellcome/flake8",
     "wellcome/format_python",
     "wellcome/format_python",


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5370

We don't use this image anywhere any more, so we can get rid of it; see https://github.com/search?type=Code&q=org:wellcomecollection+build_test_python