### PR TITLE
Stop mirroring the scality/s3server image

### DIFF
--- a/images/publish_mirrored_images.py
+++ b/images/publish_mirrored_images.py
@@ -43,7 +43,6 @@ IMAGE_TAGS = [
     "localstack/localstack",
     "localstack/localstack:0.10.5",
     "localstack/localstack:0.14.2",
-    "scality/s3server:mem-latest",
     "wellcome/flake8:latest",
     "wellcome/format_python:112",
     "wellcome/format_python:latest",

--- a/images/terraform/ecr.tf
+++ b/images/terraform/ecr.tf
@@ -133,7 +133,6 @@ locals {
   mirrored_images = [
     "localstack/localstack",
     "nginx",
-    "scality/s3server",
     "wellcome/flake8",
     "wellcome/format_python",
     "wellcome/format_python",


### PR DESCRIPTION
We no longer use it anywhere in our repos.

For https://github.com/wellcomecollection/platform/issues/5547