### PR TITLE
Remove redirect tests for iiif-stage-new.wc.org

### DIFF
--- a/.buildkite/pipeline.redirectsTest.yml
+++ b/.buildkite/pipeline.redirectsTest.yml
@@ -19,16 +19,6 @@ steps:
     retry:
       automatic: true
 
-  - label: "IIIF STAGE-NEW Redirects"
-    plugins:
-      - ecr#v2.1.1:
-          login: true
-      - docker-compose#v3.5.0:
-          run: iiif_tests
-          command: ["--env", "stage-new"]
-    retry:
-      automatic: true
-
   - label: "IIIF PROD Redirects"
     plugins:
       - ecr#v2.1.1:


### PR DESCRIPTION
## What's changing and why?

Remove `iiif-stage-new.wc.org` tests from buildkite config. Config added in #349 but for these tests to path a collection of known assets need to exist in the DLCS. This isn't the case for iiif-stage-new as it uses an empty DLCS instance, which is only being used for integration testing.

Tests can be reinstated at a later date when we have required assets ingested into the DLCS.

## `terraform plan` diff
<!-- Please make sure you don't paste anything secure that shouldn't be shared here -->
_No TF changed_
