### PR TITLE
Logging updates for ECS services

### DIFF
--- a/critical/.terraform.lock.hcl
+++ b/critical/.terraform.lock.hcl
@@ -66,3 +66,23 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f6d355a2fb3bcebb597f68bbca4fa2aaa364efd29240236c582375e219d77656",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.4.3"
+  constraints = "3.4.3"
+  hashes = [
+    "h1:tL3katm68lX+4lAncjQA9AXL4GR/VM+RPwqYf4D2X8Q=",
+    "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
+    "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
+    "zh:686ad1ee40b812b9e016317e7f34c0d63ef837e084dea4a1f578f64a6314ad53",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:84103eae7251384c0d995f5a257c72b0096605048f757b749b7b62107a5dccb3",
+    "zh:8ee974b110adb78c7cd18aae82b2729e5124d8f115d484215fd5199451053de5",
+    "zh:9dd4561e3c847e45de603f17fa0c01ae14cae8c4b7b4e6423c9ef3904b308dda",
+    "zh:bb07bb3c2c0296beba0beec629ebc6474c70732387477a65966483b5efabdbc6",
+    "zh:e891339e96c9e5a888727b45b2e1bb3fcbdfe0fd7c5b4396e4695459b38c8cb1",
+    "zh:ea4739860c24dfeaac6c100b2a2e357106a89d18751f7693f3c31ecf6a996f8d",
+    "zh:f0c76ac303fd0ab59146c39bc121c5d7d86f878e9a69294e29444d4c653786f8",
+    "zh:f143a9a5af42b38fed328a161279906759ff39ac428ebcfe55606e05e1518b93",
+  ]
+}

--- a/critical/elastic_logging_cluster.tf
+++ b/critical/elastic_logging_cluster.tf
@@ -172,34 +172,3 @@ resource "elasticstack_elasticsearch_security_role_mapping" "logging" {
   })
   metadata = jsonencode({ version = 1 })
 }
-
-module "log_data_stream" {
-  source = "./modules/elasticsearch_data_stream"
-  providers = {
-    elasticstack = elasticstack.logging
-  }
-
-  stream_name            = "service-logs-forwarded"
-  index_rollover_max_age = "1d"
-  index_delete_after     = "30d"
-}
-
-resource "elasticstack_elasticsearch_security_api_key" "log_forwarder" {
-  provider = elasticstack.logging
-
-  name = "Elasticsearch log forwarder"
-
-  role_descriptors = jsonencode({
-    cluster-health = {
-      cluster = ["monitor"]
-    }
-    write-to-stream = {
-      indices = [
-        {
-          names      = [module.log_data_stream.name],
-          privileges = ["create_index", "index", "create", "auto_configure"]
-        }
-      ]
-    }
-  })
-}

--- a/critical/firelens_logging.tf
+++ b/critical/firelens_logging.tf
@@ -3,19 +3,19 @@ resource "elasticstack_elasticsearch_security_user" "firelens_client" {
 
   username = "firelens_client"
   password = random_password.firelens_client_password.result
-  roles = [elasticstack_elasticsearch_security_role.firelens_client.name]
+  roles    = [elasticstack_elasticsearch_security_role.firelens_client.name]
 }
 
 resource "elasticstack_elasticsearch_security_role" "firelens_client" {
   provider = elasticstack.logging
 
-  name = "firelens_client"
+  name    = "firelens_client"
   cluster = []
 
   indices {
     # The "firelens-*" pattern is legacy, can be removed if we are sure all services
     # are using new versions of the logging sidecar that are pointed at service-logs-firelens
-    names = ["firelens-*", module.firelens_service_log_data_stream.name]
+    names      = ["firelens-*", module.firelens_service_log_data_stream.name]
     privileges = ["all"]
   }
 }
@@ -28,8 +28,8 @@ module "firelens_secrets" {
   source = "github.com/wellcomecollection/terraform-aws-secrets.git?ref=v1.3.0"
 
   key_value_map = {
-    "shared/logging/es_user" = elasticstack_elasticsearch_security_user.firelens_client.username
-    "shared/logging/es_pass" = elasticstack_elasticsearch_security_user.firelens_client.password
+    "shared/logging/es_user"                   = elasticstack_elasticsearch_security_user.firelens_client.username
+    "shared/logging/es_pass"                   = elasticstack_elasticsearch_security_user.firelens_client.password
     "shared/logging/firelens_data_stream_name" = module.firelens_service_log_data_stream.name
   }
 }
@@ -40,7 +40,7 @@ module "firelens_service_log_data_stream" {
     elasticstack = elasticstack.logging
   }
 
-  stream_name = "service-logs-firelens"
+  stream_name            = "service-logs-firelens"
   index_rollover_max_age = "1d"
-  index_delete_after = "30d"
+  index_delete_after     = "30d"
 }

--- a/critical/firelens_logging.tf
+++ b/critical/firelens_logging.tf
@@ -1,0 +1,46 @@
+resource "elasticstack_elasticsearch_security_user" "firelens_client" {
+  provider = elasticstack.logging
+
+  username = "firelens_client"
+  password = random_password.firelens_client_password.result
+  roles = [elasticstack_elasticsearch_security_role.firelens_client.name]
+}
+
+resource "elasticstack_elasticsearch_security_role" "firelens_client" {
+  provider = elasticstack.logging
+
+  name = "firelens_client"
+  cluster = []
+
+  indices {
+    # The "firelens-*" pattern is legacy, can be removed if we are sure all services
+    # are using new versions of the logging sidecar that are pointed at service-logs-firelens
+    names = ["firelens-*", module.firelens_service_log_data_stream.name]
+    privileges = ["all"]
+  }
+}
+
+resource "random_password" "firelens_client_password" {
+  length = 15
+}
+
+module "firelens_secrets" {
+  source = "github.com/wellcomecollection/terraform-aws-secrets.git?ref=v1.3.0"
+
+  key_value_map = {
+    "shared/logging/es_user" = elasticstack_elasticsearch_security_user.firelens_client.username
+    "shared/logging/es_pass" = elasticstack_elasticsearch_security_user.firelens_client.password
+    "shared/logging/firelens_data_stream_name" = module.firelens_service_log_data_stream.name
+  }
+}
+
+module "firelens_service_log_data_stream" {
+  source = "./modules/elasticsearch_data_stream"
+  providers = {
+    elasticstack = elasticstack.logging
+  }
+
+  stream_name = "service-logs-firelens"
+  index_rollover_max_age = "1d"
+  index_delete_after = "30d"
+}

--- a/critical/lambda_logging.tf
+++ b/critical/lambda_logging.tf
@@ -1,3 +1,34 @@
+module "log_data_stream" {
+  source = "./modules/elasticsearch_data_stream"
+  providers = {
+    elasticstack = elasticstack.logging
+  }
+
+  stream_name            = "service-logs-forwarded"
+  index_rollover_max_age = "1d"
+  index_delete_after     = "30d"
+}
+
+resource "elasticstack_elasticsearch_security_api_key" "log_forwarder" {
+  provider = elasticstack.logging
+
+  name = "Elasticsearch log forwarder"
+
+  role_descriptors = jsonencode({
+    cluster-health = {
+      cluster = ["monitor"]
+    }
+    write-to-stream = {
+      indices = [
+        {
+          names      = [module.log_data_stream.name],
+          privileges = ["create_index", "index", "create", "auto_configure"]
+        }
+      ]
+    }
+  })
+}
+
 module "kinesis_log_destination" {
   source = "./modules/kinesis_log_destination"
 

--- a/critical/secrets.tf
+++ b/critical/secrets.tf
@@ -5,6 +5,7 @@ locals {
     ES_HOST         = "shared/logging/es_host"
     ES_PORT         = "shared/logging/es_port"
     ES_HOST_PRIVATE = "shared/logging/es_host_private"
+    DATA_STREAM_NAME = "shared/logging/firelens_data_stream_name"
   }
 
   apm_secrets = {

--- a/critical/secrets.tf
+++ b/critical/secrets.tf
@@ -1,10 +1,10 @@
 locals {
   logging_secrets = {
-    ES_USER         = "shared/logging/es_user"
-    ES_PASS         = "shared/logging/es_pass"
-    ES_HOST         = "shared/logging/es_host"
-    ES_PORT         = "shared/logging/es_port"
-    ES_HOST_PRIVATE = "shared/logging/es_host_private"
+    ES_USER          = "shared/logging/es_user"
+    ES_PASS          = "shared/logging/es_pass"
+    ES_HOST          = "shared/logging/es_host"
+    ES_PORT          = "shared/logging/es_port"
+    ES_HOST_PRIVATE  = "shared/logging/es_host_private"
     DATA_STREAM_NAME = "shared/logging/firelens_data_stream_name"
   }
 

--- a/critical/terraform.tf
+++ b/critical/terraform.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "elastic/elasticstack"
       version = "0.5.0"
     }
+    random = {
+      source = "hashicorp/random"
+      version = "3.4.3"
+    }
   }
 
   backend "s3" {

--- a/critical/terraform.tf
+++ b/critical/terraform.tf
@@ -11,7 +11,7 @@ terraform {
       version = "0.5.0"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
       version = "3.4.3"
     }
   }

--- a/images/dockerfiles/fluentbit/Dockerfile
+++ b/images/dockerfiles/fluentbit/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazon/aws-for-fluent-bit:latest
+FROM public.ecr.aws/aws-observability/aws-for-fluent-bit:2.29.1
 
 LABEL maintainer "Wellcome Collection <wellcomedigitalplatform@wellcome.org>"
 LABEL description "Sends logs from platform applications to Elasticsearch"

--- a/images/dockerfiles/fluentbit/extra.conf
+++ b/images/dockerfiles/fluentbit/extra.conf
@@ -10,8 +10,7 @@
     Port                ${ES_PORT}
     HTTP_User           ${ES_USER}
     HTTP_Passwd         ${ES_PASS}
-    Logstash_Format     On
-    Logstash_Prefix     firelens
+    Index               ${DATA_STREAM_NAME}
     tls                 On
     # ES 8.0 does not allow specification of the document _type
     # https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch#action-metadata-contains-an-unknown-parameter-type


### PR DESCRIPTION
- Pins the fluentbit base image to a specific version in ECR Public
- Removes the fluentbit config (`Logstash_Prefix`) responsible for rotating indices daily and makes the log destination index/data stream configurable
- Creates a data stream (with ILM) in the logging cluster to use as the log destination. This has the same prefix (`service-logs`) as the Lambda logs do so they are all visible under one ~index pattern~ data view. 
- Recreates and imports the firelens user/role/secrets/etc in Terraform.