### PR TITLE
Remove a couple of mirrored images that we're no longer using

### DIFF
--- a/images/publish_mirrored_images.py
+++ b/images/publish_mirrored_images.py
@@ -46,8 +46,6 @@ IMAGE_TAGS = [
     "wellcome/flake8:latest",
     "wellcome/format_python:112",
     "wellcome/format_python:latest",
-    "wellcome/image_builder:23",
-    "wellcome/publish_lambda:130",
     "wellcome/sbt_wrapper",
     "wellcome/tox:latest",
     "zenko/cloudserver:8.1.8",

--- a/images/terraform/ecr.tf
+++ b/images/terraform/ecr.tf
@@ -136,8 +136,6 @@ locals {
     "wellcome/flake8",
     "wellcome/format_python",
     "wellcome/format_python",
-    "wellcome/image_builder",
-    "wellcome/publish_lambda",
     "wellcome/sbt_wrapper",
     "wellcome/tox",
     "zenko/cloudserver",


### PR DESCRIPTION
I continue to aspire towards ditching all these mirrored images entirely; in the meantime these are two images we don't use any more, so we can delete their mirrored versions.

For https://github.com/wellcomecollection/platform/issues/5370/https://github.com/wellcomecollection/platform/issues/5545