### PR TITLE
Add our standard role permissions to the microsites account

### DIFF
--- a/accounts/platform/locals.tf
+++ b/accounts/platform/locals.tf
@@ -15,7 +15,7 @@ locals {
   workflow_account_roles      = data.terraform_remote_state.accounts_workflow.outputs
   identity_account_roles      = data.terraform_remote_state.accounts_identity.outputs
   dam_prototype_account_roles = data.terraform_remote_state.accounts_dam_prototype.outputs
-  microsites_account_roles = data.terraform_remote_state.accounts_microsites.outputs
+  microsites_account_roles    = data.terraform_remote_state.accounts_microsites.outputs
 
   account_ids = {
     platform = local.account_id

--- a/accounts/platform/rolesets.tf
+++ b/accounts/platform/rolesets.tf
@@ -66,7 +66,7 @@ module "super_dev_roleset" {
     local.dam_prototype_account_roles["developer_role_arn"],
     local.dam_prototype_account_roles["read_only_role_arn"],
     local.dam_prototype_account_roles["admin_role_arn"],
-    
+
     # Microsites account
     local.microsites_account_roles["developer_role_arn"],
     local.microsites_account_roles["read_only_role_arn"],


### PR DESCRIPTION
This adds the legacy 'microsite' account to our standard roleset, so any platform dev can log in and do maintenance as necessary. We don't do much in here, but I just had to add the CloudHealth role for D&T, and it was easier to make it like everything else than carve out a special exception.