### PR TITLE
DDS dashboard task-role can publish to SNS invalidation topic

### DIFF
--- a/cloudfront/invalidation/terraform/iam.tf
+++ b/cloudfront/invalidation/terraform/iam.tf
@@ -10,7 +10,8 @@ data "aws_iam_policy_document" "iiif_prod" {
       test     = "StringLike"
       variable = "aws:userId"
       values = [
-        "${local.dds_workflow_prod}:*"
+        "${local.dds_workflow_prod}:*",
+        "${local.dash_workflow_prod}:*"
       ]
     }
 
@@ -38,7 +39,8 @@ data "aws_iam_policy_document" "api_prod" {
       test     = "StringLike"
       variable = "aws:userId"
       values = [
-        "${local.dds_workflow_prod}:*"
+        "${local.dds_workflow_prod}:*",
+        "${local.dash_workflow_prod}:*"
       ]
     }
 
@@ -66,7 +68,8 @@ data "aws_iam_policy_document" "iiif_stage" {
       test     = "StringLike"
       variable = "aws:userId"
       values = [
-        "${local.dds_workflow_stage}:*"
+        "${local.dds_workflow_stage}:*",
+        "${local.dash_workflow_stage}:*"
       ]
     }
 
@@ -96,6 +99,8 @@ data "aws_iam_policy_document" "api_stage" {
       values = [
         "${local.dds_workflow_stage}:*",
         "${local.dds_workflow_test}:*",
+        "${local.dash_workflow_stage}:*",
+        "${local.dash_workflow_test}:*",
       ]
     }
 
@@ -123,7 +128,8 @@ data "aws_iam_policy_document" "iiif_test" {
       test     = "StringLike"
       variable = "aws:userId"
       values = [
-        "${local.dds_workflow_test}:*"
+        "${local.dds_workflow_test}:*",
+        "${local.dash_workflow_test}:*"
       ]
     }
 
@@ -151,7 +157,8 @@ data "aws_iam_policy_document" "iiif_stage_new" {
       test     = "StringLike"
       variable = "aws:userId"
       values = [
-        "${local.dds_workflow_stage_new}:*"
+        "${local.dds_workflow_stage_new}:*",
+        "${local.dash_workflow_stage_new}:*"
       ]
     }
 

--- a/cloudfront/invalidation/terraform/locals.tf
+++ b/cloudfront/invalidation/terraform/locals.tf
@@ -3,4 +3,9 @@ locals {
   dds_workflow_stage     = "AROAZQI22QHWVEECG3UI3"
   dds_workflow_test      = "AROAZQI22QHWWHVPVKOM3"
   dds_workflow_stage_new = "AROAZQI22QHWQWE3OVT34"
+
+  dash_workflow_prod      = "AROAZQI22QHWZ755Z5O5K"
+  dash_workflow_stage     = "AROAZQI22QHW3RRRIYDN3"
+  dash_workflow_test      = "AROAZQI22QHWQI2FAIMQ5"
+  dash_workflow_stage_new = "AROAZQI22QHW6X2IDCXSZ"
 }


### PR DESCRIPTION
## What's changing and why?

Currently the DDS WorkflowProcessor can publish to an SNS topic to trigger a CloudFront invalidation Lambda. This happens as a post-processing step after a work has been handled. 

We want to allow an invalidation to be triggered via the DDS Dashboard without needing to process the work first. This PR adds the dashboard task-role Id to the relevant `aws_sns_topic_policy` to enable this.

See ticket: https://github.com/wellcomecollection/platform/issues/5627

## `terraform plan` diff

I wasn't expecting the `aws_lambda_function` changes to appear in the following change list but they are there when I run a plan on `main` without any changes.

<details>
<summary>output of <code>terraform plan -no-color</code></summary>

```hcl
Terraform will perform the following actions:

  # aws_sns_topic_policy.api_prod will be updated in-place
  ~ resource "aws_sns_topic_policy" "api_prod" {
        id     = "arn:aws:sns:eu-west-1:760097843905:api-prod-cloudfront-invalidate"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Condition = {
                          ~ StringLike = {
                              ~ "aws:userId" = "AROAZQI22QHW5L3AA6HGE:*" -> [
                                  + "AROAZQI22QHW5L3AA6HGE:*",
                                  + "AROAZQI22QHWZ755Z5O5K:*",
                                ]
                            }
                        }
                        # (5 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (2 unchanged attributes hidden)
    }

  # aws_sns_topic_policy.api_stage will be updated in-place
  ~ resource "aws_sns_topic_policy" "api_stage" {
        id     = "arn:aws:sns:eu-west-1:760097843905:api-stage-cloudfront-invalidate"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Condition = {
                          ~ StringLike = {
                              ~ "aws:userId" = [
                                    # (1 unchanged element hidden)
                                    "AROAZQI22QHWWHVPVKOM3:*",
                                  + "AROAZQI22QHW3RRRIYDN3:*",
                                  + "AROAZQI22QHWQI2FAIMQ5:*",
                                ]
                            }
                        }
                        # (5 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (2 unchanged attributes hidden)
    }

  # aws_sns_topic_policy.iiif_prod will be updated in-place
  ~ resource "aws_sns_topic_policy" "iiif_prod" {
        id     = "arn:aws:sns:eu-west-1:760097843905:iiif-prod-cloudfront-invalidate"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Condition = {
                          ~ StringLike = {
                              ~ "aws:userId" = "AROAZQI22QHW5L3AA6HGE:*" -> [
                                  + "AROAZQI22QHW5L3AA6HGE:*",
                                  + "AROAZQI22QHWZ755Z5O5K:*",
                                ]
                            }
                        }
                        # (5 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (2 unchanged attributes hidden)
    }

  # aws_sns_topic_policy.iiif_stage will be updated in-place
  ~ resource "aws_sns_topic_policy" "iiif_stage" {
        id     = "arn:aws:sns:eu-west-1:760097843905:iiif-stage-cloudfront-invalidate"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Condition = {
                          ~ StringLike = {
                              ~ "aws:userId" = "AROAZQI22QHWVEECG3UI3:*" -> [
                                  + "AROAZQI22QHWVEECG3UI3:*",
                                  + "AROAZQI22QHW3RRRIYDN3:*",
                                ]
                            }
                        }
                        # (5 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (2 unchanged attributes hidden)
    }

  # aws_sns_topic_policy.iiif_stage_new will be updated in-place
  ~ resource "aws_sns_topic_policy" "iiif_stage_new" {
        id     = "arn:aws:sns:eu-west-1:760097843905:iiif-stage-new-cloudfront-invalidate"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Condition = {
                          ~ StringLike = {
                              ~ "aws:userId" = "AROAZQI22QHWQWE3OVT34:*" -> [
                                  + "AROAZQI22QHWQWE3OVT34:*",
                                  + "AROAZQI22QHW6X2IDCXSZ:*",
                                ]
                            }
                        }
                        # (5 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (2 unchanged attributes hidden)
    }

  # aws_sns_topic_policy.iiif_test will be updated in-place
  ~ resource "aws_sns_topic_policy" "iiif_test" {
        id     = "arn:aws:sns:eu-west-1:760097843905:iiif-test-cloudfront-invalidate"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Condition = {
                          ~ StringLike = {
                              ~ "aws:userId" = "AROAZQI22QHWWHVPVKOM3:*" -> [
                                  + "AROAZQI22QHWWHVPVKOM3:*",
                                  + "AROAZQI22QHWQI2FAIMQ5:*",
                                ]
                            }
                        }
                        # (5 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (2 unchanged attributes hidden)
    }

  # module.api_prod.aws_lambda_function.cloudfront_invalidation will be updated in-place
  ~ resource "aws_lambda_function" "cloudfront_invalidation" {
        id                             = "api-prod-cloudfront_invalidation"
      ~ last_modified                  = "2023-01-19T09:16:31.000+0000" -> (known after apply)
      ~ qualified_arn                  = "arn:aws:lambda:eu-west-1:760097843905:function:api-prod-cloudfront_invalidation:3" -> (known after apply)
      ~ qualified_invoke_arn           = "arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:760097843905:function:api-prod-cloudfront_invalidation:3/invocations" -> (known after apply)
      ~ s3_object_version              = "aQ2vXr9KEwCemgXSxNUCIPYJXViRkUcq" -> "uRaHFpGwUQII7w2TLchScZaUVmyMw8wN"
        tags                           = {}
      ~ version                        = "3" -> (known after apply)
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.api_stage.aws_lambda_function.cloudfront_invalidation will be updated in-place
  ~ resource "aws_lambda_function" "cloudfront_invalidation" {
        id                             = "api-stage-cloudfront_invalidation"
      ~ last_modified                  = "2023-01-19T09:16:31.000+0000" -> (known after apply)
      ~ qualified_arn                  = "arn:aws:lambda:eu-west-1:760097843905:function:api-stage-cloudfront_invalidation:3" -> (known after apply)
      ~ qualified_invoke_arn           = "arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:760097843905:function:api-stage-cloudfront_invalidation:3/invocations" -> (known after apply)
      ~ s3_object_version              = "aQ2vXr9KEwCemgXSxNUCIPYJXViRkUcq" -> "uRaHFpGwUQII7w2TLchScZaUVmyMw8wN"
        tags                           = {}
      ~ version                        = "3" -> (known after apply)
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.iiif_prod.aws_lambda_function.cloudfront_invalidation will be updated in-place
  ~ resource "aws_lambda_function" "cloudfront_invalidation" {
        id                             = "iiif-prod-cloudfront_invalidation"
      ~ last_modified                  = "2023-01-19T09:16:31.000+0000" -> (known after apply)
      ~ qualified_arn                  = "arn:aws:lambda:eu-west-1:760097843905:function:iiif-prod-cloudfront_invalidation:3" -> (known after apply)
      ~ qualified_invoke_arn           = "arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:760097843905:function:iiif-prod-cloudfront_invalidation:3/invocations" -> (known after apply)
      ~ s3_object_version              = "aQ2vXr9KEwCemgXSxNUCIPYJXViRkUcq" -> "uRaHFpGwUQII7w2TLchScZaUVmyMw8wN"
        tags                           = {}
      ~ version                        = "3" -> (known after apply)
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.iiif_stage.aws_lambda_function.cloudfront_invalidation will be updated in-place
  ~ resource "aws_lambda_function" "cloudfront_invalidation" {
        id                             = "iiif-stage-cloudfront_invalidation"
      ~ last_modified                  = "2023-01-19T09:16:31.000+0000" -> (known after apply)
      ~ qualified_arn                  = "arn:aws:lambda:eu-west-1:760097843905:function:iiif-stage-cloudfront_invalidation:3" -> (known after apply)
      ~ qualified_invoke_arn           = "arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:760097843905:function:iiif-stage-cloudfront_invalidation:3/invocations" -> (known after apply)
      ~ s3_object_version              = "aQ2vXr9KEwCemgXSxNUCIPYJXViRkUcq" -> "uRaHFpGwUQII7w2TLchScZaUVmyMw8wN"
        tags                           = {}
      ~ version                        = "3" -> (known after apply)
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.iiif_stage_new.aws_lambda_function.cloudfront_invalidation will be updated in-place
  ~ resource "aws_lambda_function" "cloudfront_invalidation" {
        id                             = "iiif-stage-new-cloudfront_invalidation"
      ~ last_modified                  = "2023-01-19T09:16:54.811+0000" -> (known after apply)
      ~ qualified_arn                  = "arn:aws:lambda:eu-west-1:760097843905:function:iiif-stage-new-cloudfront_invalidation:1" -> (known after apply)
      ~ qualified_invoke_arn           = "arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:760097843905:function:iiif-stage-new-cloudfront_invalidation:1/invocations" -> (known after apply)
      ~ s3_object_version              = "aQ2vXr9KEwCemgXSxNUCIPYJXViRkUcq" -> "uRaHFpGwUQII7w2TLchScZaUVmyMw8wN"
        tags                           = {}
      ~ version                        = "1" -> (known after apply)
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.iiif_test.aws_lambda_function.cloudfront_invalidation will be updated in-place
  ~ resource "aws_lambda_function" "cloudfront_invalidation" {
        id                             = "iiif-test-cloudfront_invalidation"
      ~ last_modified                  = "2023-01-19T09:16:31.000+0000" -> (known after apply)
      ~ qualified_arn                  = "arn:aws:lambda:eu-west-1:760097843905:function:iiif-test-cloudfront_invalidation:3" -> (known after apply)
      ~ qualified_invoke_arn           = "arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:760097843905:function:iiif-test-cloudfront_invalidation:3/invocations" -> (known after apply)
      ~ s3_object_version              = "aQ2vXr9KEwCemgXSxNUCIPYJXViRkUcq" -> "uRaHFpGwUQII7w2TLchScZaUVmyMw8wN"
        tags                           = {}
      ~ version                        = "3" -> (known after apply)
        # (18 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 12 to change, 0 to destroy.
```
</summary>