### PR TITLE
Filter out more "change password" alerts when it's the user fault

### DIFF
--- a/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
+++ b/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
@@ -121,6 +121,7 @@ def should_alert_for_event(log_event):
         # fcp = Failed Change Password
         "fcp": [
             "You may have pressed the back button",
+            "Password contains user information",
             "PIN is not valid : PIN is trivial",
         ],
 


### PR DESCRIPTION
Already applied.