### PR TITLE
Ignore alerts about somebody having too common a password

### DIFF
--- a/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
+++ b/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
@@ -182,6 +182,7 @@ def should_alert_for_event(log_event):
         "fcp": [
             "You may have pressed the back button",
             "Password contains user information",
+            "Password is too common",
             "PIN is not valid : PIN is trivial",
         ],
 


### PR DESCRIPTION
e.g. `Abcd1234`