### PR TITLE
Add origin and behaviour for the Content API

### DIFF
--- a/cloudfront/api.wellcomecollection.org/cloudfront_distro/main.tf
+++ b/cloudfront/api.wellcomecollection.org/cloudfront_distro/main.tf
@@ -21,6 +21,25 @@ resource "aws_cloudfront_distribution" "wellcomecollection" {
   }
 
   origin {
+    domain_name = var.origin_domains.content
+    origin_id   = "content_api"
+    origin_path = "" // https://github.com/hashicorp/terraform-provider-aws/issues/12065#issuecomment-587518720
+
+    custom_origin_config {
+      http_port                = 80
+      https_port               = 443
+      origin_keepalive_timeout = 5
+      origin_read_timeout      = 30
+      origin_protocol_policy   = "https-only"
+      origin_ssl_protocols = [
+        "TLSv1",
+        "TLSv1.1",
+        "TLSv1.2",
+      ]
+    }
+  }
+
+  origin {
     domain_name = var.origin_domains.storage
     origin_id   = "storage_api"
     origin_path = "" // https://github.com/hashicorp/terraform-provider-aws/issues/12065#issuecomment-587518720
@@ -97,6 +116,33 @@ resource "aws_cloudfront_distribution" "wellcomecollection" {
     forwarded_values {
       query_string = true
       headers      = ["Authorization"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    # We don't want to cache these results for too long, because that
+    # means we'd be serving stale data -- but nor does this data need to
+    # be so fresh that we need to go back to the API every single time.
+    #
+    # A little bit of caching here should mitigate the effect of somebody
+    # sending a flood of requests to /works.
+    min_ttl     = 0
+    default_ttl = 10
+    max_ttl     = 10
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "/content/*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "content_api"
+
+    forwarded_values {
+      query_string = true
 
       cookies {
         forward = "all"

--- a/cloudfront/api.wellcomecollection.org/cloudfront_distro/main.tf
+++ b/cloudfront/api.wellcomecollection.org/cloudfront_distro/main.tf
@@ -154,7 +154,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection" {
     # be so fresh that we need to go back to the API every single time.
     #
     # A little bit of caching here should mitigate the effect of somebody
-    # sending a flood of requests to /works.
+    # sending a flood of requests.
     min_ttl     = 0
     default_ttl = 10
     max_ttl     = 10

--- a/cloudfront/api.wellcomecollection.org/cloudfront_distro/variables.tf
+++ b/cloudfront/api.wellcomecollection.org/cloudfront_distro/variables.tf
@@ -17,6 +17,7 @@ variable "tags" {
 variable "origin_domains" {
   type = object({
     catalogue = string
+    content   = string
     storage   = string
     text      = string
   })

--- a/cloudfront/api.wellcomecollection.org/main.tf
+++ b/cloudfront/api.wellcomecollection.org/main.tf
@@ -14,6 +14,7 @@ module "wellcomecollection_prod" {
   aliases = [local.prod_domain]
   origin_domains = {
     catalogue = "catalogue.api-prod.wellcomecollection.org"
+    content   = "content.api-prod.wellcomecollection.org"
     storage   = "storage.${local.prod_domain}"
     text      = "dds.wellcomecollection.digirati.io"
   }
@@ -32,6 +33,7 @@ module "wellcomecollection_stage" {
   aliases = [local.stage_domain]
   origin_domains = {
     catalogue = "catalogue.api-stage.wellcomecollection.org"
+    content   = "content.api-stage.wellcomecollection.org"
     storage   = "storage.${local.stage_domain}"
     text      = "dds-stage.wellcomecollection.digirati.io"
   }


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/content-api/issues/2

This is already applied for stage, and the config is pre-emptively there for prod. It's pretty much a copy/paste of the existing config that's there for the catalogue API.