### PR TITLE
Filter out a couple more URLs from the API alerts

### DIFF
--- a/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.js
+++ b/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.js
@@ -305,7 +305,7 @@ function isInterestingError(hit) {
   // avoid dropping errors from legitimate queries.
   if (
     hit.status === 503 &&
-    (hit.query.split('%C3').length > 80 || hit.query.split('%25C2').length > 80)
+    (hit.query.split('%C3').length > 70 || hit.query.split('%25C2').length > 80)
   ) {
     return false;
   }


### PR DESCRIPTION
The current URLs causing alerts have **73** instances of this but are still pretty obviously spam.