### PR TITLE
Update Cloudfront to point iiif-test.wc.org at new DLCS

### DIFF
--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
@@ -62,7 +62,7 @@ module "dlcs_origin_set" {
     origin_path : null
   }
   test = {
-    domain_name : "dlcs.io"
+    domain_name : "neworchestrator.dlcs.io"
     origin_path : null
   }
   stage_new = {
@@ -89,7 +89,7 @@ module "dlcs_wellcome_images_origin_set" {
     origin_path : "/iiif-img/wellcome/8"
   }
   test = {
-    domain_name : "dlcs.io"
+    domain_name : "neworchestrator.dlcs.io"
     origin_path : "/iiif-img/wellcome/8"
   }
   stage_new = {
@@ -116,8 +116,8 @@ module "dlcs_images_origin_set" {
     origin_path : "/iiif-img/wellcome/6"
   }
   test = {
-    domain_name : "dlcs.io"
-    origin_path : "/iiif-img/wellcome/6"
+    domain_name : "neworchestrator.dlcs.io"
+    origin_path : "/iiif-img/wellcome/9"
   }
   stage_new = {
     domain_name : "neworchestrator.dlcs.io"
@@ -141,7 +141,7 @@ module "dlcs_wellcome_thumbs_origin_set" {
     origin_path : "/thumbs/wellcome/8"
   }
   test = {
-    domain_name : "dlcs.io"
+    domain_name : "neworchestrator.dlcs.io"
     origin_path : "/thumbs/wellcome/8"
   }
   stage_new = {
@@ -165,8 +165,8 @@ module "dlcs_thumbs_origin_set" {
     origin_path : "/thumbs/wellcome/6"
   }
   test = {
-    domain_name : "dlcs.io"
-    origin_path : "/thumbs/wellcome/6"
+    domain_name : "neworchestrator.dlcs.io"
+    origin_path : "/thumbs/wellcome/9"
   }
   stage_new = {
     domain_name : "neworchestrator.dlcs.io"
@@ -189,8 +189,8 @@ module "dlcs_av_origin_set" {
     origin_path : "/iiif-av/wellcome/6"
   }
   test = {
-    domain_name : "dlcs.io"
-    origin_path : "/iiif-av/wellcome/6"
+    domain_name : "neworchestrator.dlcs.io"
+    origin_path : "/iiif-av/wellcome/9"
   }
   stage_new = {
     domain_name : "neworchestrator.dlcs.io"
@@ -211,8 +211,8 @@ module "dlcs_pdf_origin_set" {
     origin_path : "/pdf/wellcome/pdf/6"
   }
   test = {
-    domain_name : "dlcs.io"
-    origin_path : "/pdf/wellcome/pdf/6"
+    domain_name : "neworchestrator.dlcs.io"
+    origin_path : "/pdf/wellcome/pdf/9"
   }
   stage_new = {
     domain_name : "neworchestrator.dlcs.io"
@@ -233,8 +233,8 @@ module "dlcs_file_origin_set" {
     origin_path : "/file/wellcome/6"
   }
   test = {
-    domain_name : "dlcs.io"
-    origin_path : "/file/wellcome/6"
+    domain_name : "neworchestrator.dlcs.io"
+    origin_path : "/file/wellcome/9"
   }
   stage_new = {
     domain_name : "neworchestrator.dlcs.io"
@@ -279,7 +279,7 @@ module "dlcs_auth_origin_set" {
     origin_path : "/auth/2"
   }
   test = {
-    domain_name : "dlcs.io"
+    domain_name : "neworchestrator.dlcs.io"
     origin_path : "/auth/2"
   }
   stage_new = {


### PR DESCRIPTION
## What's changing and why?

We have a prod configuration of new DDS and new DLCS, and we want to point the public iiif-test.wellcomecollection.org at it.

But it needs origins updating.

## `terraform plan` diff
<!-- Please make sure you don't paste anything secure that shouldn't be shared here -->
