### PR TITLE
Bump the Node versions in the Lambdas to fix failing tests

### DIFF
--- a/cloudfront/iiif.wellcomecollection.org/edge-lambda/Dockerfile
+++ b/cloudfront/iiif.wellcomecollection.org/edge-lambda/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:12-slim
+FROM public.ecr.aws/docker/library/node:16-slim
 
 RUN apt-get update && apt-get install -yq --no-install-recommends zip
 

--- a/cloudfront/iiif.wellcomecollection.org/edge-lambda/package.json
+++ b/cloudfront/iiif.wellcomecollection.org/edge-lambda/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "engines": {
-    "node": "12.*.*"
+    "node": "16.*.*"
   },
   "license": "MIT",
   "scripts": {

--- a/cloudfront/invalidation/lambda/Dockerfile
+++ b/cloudfront/invalidation/lambda/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:12-slim
+FROM public.ecr.aws/docker/library/node:16-slim
 
 RUN apt-get update && apt-get install -yq --no-install-recommends zip
 

--- a/cloudfront/invalidation/lambda/package.json
+++ b/cloudfront/invalidation/lambda/package.json
@@ -4,7 +4,7 @@
   "description": "Lambda for handling CloudFront invalidation requests",
   "main": "index.js",
   "engines": {
-    "node": "12.*.*"
+    "node": "16.*.*"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
The tests are failing and we're running old versions of Node, I suspect these are related facts.