### PR TITLE
Add the Qualys EC2 scanning role for D&T

### DIFF
--- a/accounts/modules/account/aws/qualys.tf
+++ b/accounts/modules/account/aws/qualys.tf
@@ -1,0 +1,3 @@
+module "qualys" {
+  source = "../../qualys"
+}

--- a/accounts/modules/qualys/main.tf
+++ b/accounts/modules/qualys/main.tf
@@ -1,0 +1,24 @@
+# These IAM roles are used by the Infosec team in D&T, who use
+# vulnerability scanning software from Qualys to gather data about
+# EC2 instances.
+#
+# It's based on https://github.com/wellcometrust/ncw-terraform-modules/blob/a5447056fd50175b47a1243dcb4c3228b9570751/AWS/iam-instance-roles/qualys-iam-role/main.tf
+
+resource "aws_iam_role" "wt-qualys-role" {
+  assume_role_policy   = data.aws_iam_policy_document.allow_assume_instance_role.json
+  description          = "Allow Qualys vulnerability scanning software in D&T to scan our EC2 instances"
+  max_session_duration = 2 * 60 * 60  # 2 hours
+  name                 = "wt-qualys-role"
+}
+
+# IAM Policy for Qualys Connector - CHG0034045
+resource "aws_iam_policy" "wt-qualys-policy" {
+  policy      = data.aws_iam_policy_document.allow_read_ec2_details.json
+  description = "Allow Qualys vulnerability scanning software in D&T to scan our EC2 instances"
+  name        = "wt-qualys-policy"
+}
+
+resource "aws_iam_role_policy_attachment" "wt-qualys-policy-attachment" {
+  policy_arn = aws_iam_policy.wt-qualys-policy.arn
+  role       = aws_iam_role.wt-qualys-role.name
+}

--- a/accounts/modules/qualys/main.tf
+++ b/accounts/modules/qualys/main.tf
@@ -7,7 +7,7 @@
 resource "aws_iam_role" "wt-qualys-role" {
   assume_role_policy   = data.aws_iam_policy_document.allow_assume_instance_role.json
   description          = "Allow Qualys vulnerability scanning software in D&T to scan our EC2 instances"
-  max_session_duration = 2 * 60 * 60  # 2 hours
+  max_session_duration = 2 * 60 * 60 # 2 hours
   name                 = "wt-qualys-role"
 }
 

--- a/accounts/modules/qualys/policies.tf
+++ b/accounts/modules/qualys/policies.tf
@@ -1,0 +1,34 @@
+data "aws_iam_policy_document" "allow_assume_instance_role" {
+  statement {
+    sid = "AllowsQualysToAssumeTheRole"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::805950163170:root"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values   = ["UK-332144-3928933756001"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "allow_read_ec2_details" {
+  statement {
+    sid = "AllowsToReadEC2Details"
+
+    actions = [
+      "ec2:DescribeAddresses",
+      "ec2:DescribeImages",
+      "ec2:DescribeInstances",
+      "ec2:DescribeRegions",
+      "organizations:list*",
+    ]
+
+    resources = ["*"]
+  }
+}

--- a/accounts/platform/.terraform.lock.hcl
+++ b/accounts/platform/.terraform.lock.hcl
@@ -2,8 +2,23 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "4.58.0"
+  version = "4.65.0"
   hashes = [
-    "h1:znLROwEAINbYzAG5X7Ep04whM7KxkQGrvhFdhSvNKEk=",
+    "h1:ZEdurVGkjkOZzhJijFTF+3djXZ9N4Js8Ss6tM43n3HA=",
+    "zh:0461b8dfc14e94971bfd12783cbd5a5574b9fcfc3694b6afaa8836f90b61c1f9",
+    "zh:24a27e7b1f6eb33e9da6f2ffaaa6bc48e933a24224c6572d6e588994e5c7130b",
+    "zh:2ca189d04573414bef4876c17ccb2b76f6e721e0450f6ab3700d94d7c04bec64",
+    "zh:3fb0654a527677231dab2140e9a55df3b90dba478b3db50001e21a045437a47a",
+    "zh:4918173d9c7d2735908622c17efd01746a046f0a571690afa7dd0866f22045f7",
+    "zh:491d259b15166f751076d2bdc443928ca63f6c0a83b02ea75fff8b4224662207",
+    "zh:4ff8e178f0656f04f88558c295a1d246b1bdcf5ad81d8b3b9ccceaeca2eb7fa8",
+    "zh:5e4eaf2855a740124f4bbe34ac4bd22c7f320aa3e91d9cef64396ad0a1571544",
+    "zh:65762c60c4bac2e0d55ed8c2877e455e84465cb12f0c885363a1b561cd4f5f07",
+    "zh:7c5e4f85eb5f70e6da2d64701dd5551f2bc334dbb9add76bfc6a2bea6acf4483",
+    "zh:90d32b238113528319d7a5fade97bd8ac9a8b654482fc9056478a43d2e297886",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:e6ed3299516a8fb2292af7e7e123d09817dfd8e039aaf35ad5a276f739668e88",
+    "zh:eb84fa96c63d836b3b4689835cb7c4487808dfd1ba7ddacf4d8c4c6ff65cdbef",
+    "zh:ff97d1498193c99c9c35afd9bfcdce011abf460ec041721727d6e542f7a3bedd",
   ]
 }


### PR DESCRIPTION
This is adding a standard IAM role to all our accounts, which allows the Qualys vulnerability scanning tool being used by the InfoSec team to scan EC2 instances in our accounts.

(I suspect they won't find much as we run very little vanilla EC2, but this role is pretty innocuous and it seems fine to me.)