### PR TITLE
Tidy iiif lower environments

### DIFF
--- a/cloudfront/iiif.wellcomecollection.org/terraform/cert.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cert.tf
@@ -17,21 +17,6 @@ module "cert" {
   }
 }
 
-# rather than alter the current, prod cert create a new one
-# for temporary environment
-module "cert_stagenew" {
-  source = "github.com/wellcomecollection/terraform-aws-acm-certificate?ref=v1.0.0"
-
-  domain_name = "iiif-stage-new.wellcomecollection.org"
-
-  zone_id = data.aws_route53_zone.zone.id
-
-  providers = {
-    aws     = aws.us_east_1
-    aws.dns = aws.dns
-  }
-}
-
 data "aws_route53_zone" "zone" {
   provider = aws.dns
 

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
@@ -54,7 +54,7 @@ module "dlcs_origin_set" {
     origin_path : null
   }
   test = {
-    domain_name : "neworchestrator.dlcs.io"
+    domain_name : "dlcs.io"
     origin_path : null
   }
 }
@@ -77,7 +77,7 @@ module "dlcs_wellcome_images_origin_set" {
     origin_path : "/iiif-img/wellcome/8"
   }
   test = {
-    domain_name : "neworchestrator.dlcs.io"
+    domain_name : "dlcs.io"
     origin_path : "/iiif-img/wellcome/8"
   }
 }
@@ -100,8 +100,8 @@ module "dlcs_images_origin_set" {
     origin_path : "/iiif-img/wellcome/6"
   }
   test = {
-    domain_name : "neworchestrator.dlcs.io"
-    origin_path : "/iiif-img/wellcome/5"
+    domain_name : "dlcs.io"
+    origin_path : "/iiif-img/wellcome/9"
   }
 }
 
@@ -121,7 +121,7 @@ module "dlcs_wellcome_thumbs_origin_set" {
     origin_path : "/thumbs/wellcome/8"
   }
   test = {
-    domain_name : "neworchestrator.dlcs.io"
+    domain_name : "dlcs.io"
     origin_path : "/thumbs/wellcome/8"
   }
 }
@@ -141,8 +141,8 @@ module "dlcs_thumbs_origin_set" {
     origin_path : "/thumbs/wellcome/6"
   }
   test = {
-    domain_name : "neworchestrator.dlcs.io"
-    origin_path : "/thumbs/wellcome/5"
+    domain_name : "dlcs.io"
+    origin_path : "/thumbs/wellcome/9"
   }
 }
 
@@ -161,8 +161,8 @@ module "dlcs_av_origin_set" {
     origin_path : "/iiif-av/wellcome/6"
   }
   test = {
-    domain_name : "neworchestrator.dlcs.io"
-    origin_path : "/iiif-av/wellcome/5"
+    domain_name : "dlcs.io"
+    origin_path : "/iiif-av/wellcome/9"
   }
 }
 
@@ -179,8 +179,8 @@ module "dlcs_pdf_origin_set" {
     origin_path : "/pdf/wellcome/pdf/6"
   }
   test = {
-    domain_name : "neworchestrator.dlcs.io"
-    origin_path : "/pdf/wellcome/pdf/5"
+    domain_name : "dlcs.io"
+    origin_path : "/pdf/wellcome/pdf/9"
   }
 }
 
@@ -197,8 +197,8 @@ module "dlcs_file_origin_set" {
     origin_path : "/file/wellcome/6"
   }
   test = {
-    domain_name : "neworchestrator.dlcs.io"
-    origin_path : "/file/wellcome/5"
+    domain_name : "dlcs.io"
+    origin_path : "/file/wellcome/9"
   }
 }
 
@@ -235,7 +235,7 @@ module "dlcs_auth_origin_set" {
     origin_path : "/auth/2"
   }
   test = {
-    domain_name : "neworchestrator.dlcs.io"
+    domain_name : "dlcs.io"
     origin_path : "/auth/2"
   }
 }

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
@@ -21,10 +21,6 @@ module "dashboard_origin_set" {
     domain_name : "dash-test.wellcomecollection.digirati.io"
     origin_path : null
   }
-  stage_new = {
-    domain_name : "dash-stage-new.wellcomecollection.digirati.io"
-    origin_path : null
-  }
 }
 
 module "iiif_origin_set" {
@@ -43,10 +39,6 @@ module "iiif_origin_set" {
     domain_name : "dds-test.wellcomecollection.digirati.io"
     origin_path : null
   }
-  stage_new = {
-    domain_name : "dds-stage-new.wellcomecollection.digirati.io"
-    origin_path : null
-  }
 }
 
 module "dlcs_origin_set" {
@@ -62,10 +54,6 @@ module "dlcs_origin_set" {
     origin_path : null
   }
   test = {
-    domain_name : "neworchestrator.dlcs.io"
-    origin_path : null
-  }
-  stage_new = {
     domain_name : "neworchestrator.dlcs.io"
     origin_path : null
   }
@@ -92,10 +80,6 @@ module "dlcs_wellcome_images_origin_set" {
     domain_name : "neworchestrator.dlcs.io"
     origin_path : "/iiif-img/wellcome/8"
   }
-  stage_new = {
-    domain_name : "neworchestrator.dlcs.io"
-    origin_path : "/iiif-img/wellcome/8"
-  }
 }
 
 // These are the set of all other images served by DLCS
@@ -119,10 +103,6 @@ module "dlcs_images_origin_set" {
     domain_name : "neworchestrator.dlcs.io"
     origin_path : "/iiif-img/wellcome/5"
   }
-  stage_new = {
-    domain_name : "neworchestrator.dlcs.io"
-    origin_path : "/iiif-img/wellcome/6"
-  }
 }
 
 // Corresponding to DLCS "Space 8"
@@ -141,10 +121,6 @@ module "dlcs_wellcome_thumbs_origin_set" {
     origin_path : "/thumbs/wellcome/8"
   }
   test = {
-    domain_name : "neworchestrator.dlcs.io"
-    origin_path : "/thumbs/wellcome/8"
-  }
-  stage_new = {
     domain_name : "neworchestrator.dlcs.io"
     origin_path : "/thumbs/wellcome/8"
   }
@@ -168,10 +144,6 @@ module "dlcs_thumbs_origin_set" {
     domain_name : "neworchestrator.dlcs.io"
     origin_path : "/thumbs/wellcome/5"
   }
-  stage_new = {
-    domain_name : "neworchestrator.dlcs.io"
-    origin_path : "/thumbs/wellcome/6"
-  }
 }
 
 module "dlcs_av_origin_set" {
@@ -192,10 +164,6 @@ module "dlcs_av_origin_set" {
     domain_name : "neworchestrator.dlcs.io"
     origin_path : "/iiif-av/wellcome/5"
   }
-  stage_new = {
-    domain_name : "neworchestrator.dlcs.io"
-    origin_path : "/iiif-av/wellcome/6"
-  }
 }
 
 module "dlcs_pdf_origin_set" {
@@ -213,10 +181,6 @@ module "dlcs_pdf_origin_set" {
   test = {
     domain_name : "neworchestrator.dlcs.io"
     origin_path : "/pdf/wellcome/pdf/5"
-  }
-  stage_new = {
-    domain_name : "neworchestrator.dlcs.io"
-    origin_path : "/pdf/wellcome/pdf/6"
   }
 }
 
@@ -236,10 +200,6 @@ module "dlcs_file_origin_set" {
     domain_name : "neworchestrator.dlcs.io"
     origin_path : "/file/wellcome/5"
   }
-  stage_new = {
-    domain_name : "neworchestrator.dlcs.io"
-    origin_path : "/file/wellcome/6"
-  }
 }
 
 module "dlcs_pdf_cover_origin_set" {
@@ -256,10 +216,6 @@ module "dlcs_pdf_cover_origin_set" {
   }
   test = {
     domain_name : "pdf-stage.wellcomecollection.digirati.io"
-    origin_path : null
-  }
-  stage_new = {
-    domain_name : "pdf-stage-new.wellcomecollection.digirati.io"
     origin_path : null
   }
 }
@@ -279,10 +235,6 @@ module "dlcs_auth_origin_set" {
     origin_path : "/auth/2"
   }
   test = {
-    domain_name : "neworchestrator.dlcs.io"
-    origin_path : "/auth/2"
-  }
-  stage_new = {
     domain_name : "neworchestrator.dlcs.io"
     origin_path : "/auth/2"
   }
@@ -333,20 +285,5 @@ locals {
     module.dlcs_file_origin_set.origins["test"],
     module.dlcs_pdf_cover_origin_set.origins["test"],
     module.dlcs_auth_origin_set.origins["test"]
-  ]
-
-  stage_new_origins = [
-    module.dashboard_origin_set.origins["stage_new"],
-    module.iiif_origin_set.origins["stage_new"],
-    module.dlcs_origin_set.origins["stage_new"],
-    module.dlcs_wellcome_images_origin_set.origins["stage_new"],
-    module.dlcs_wellcome_thumbs_origin_set.origins["stage_new"],
-    module.dlcs_images_origin_set.origins["stage_new"],
-    module.dlcs_thumbs_origin_set.origins["stage_new"],
-    module.dlcs_av_origin_set.origins["stage_new"],
-    module.dlcs_pdf_origin_set.origins["stage_new"],
-    module.dlcs_file_origin_set.origins["stage_new"],
-    module.dlcs_pdf_cover_origin_set.origins["stage_new"],
-    module.dlcs_auth_origin_set.origins["stage_new"]
   ]
 }

--- a/cloudfront/iiif.wellcomecollection.org/terraform/main.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/main.tf
@@ -45,19 +45,3 @@ module "iiif-test" {
     aws.dns = aws.dns
   }
 }
-
-module "iiif-stage-new" {
-  source = "./cloudfront_distro"
-
-  environment         = "stage-new"
-  acm_certificate_arn = module.cert_stagenew.arn
-
-  origins    = local.stage_new_origins
-  behaviours = local.test_behaviours
-
-  default_target_origin_id = "iiif"
-
-  providers = {
-    aws.dns = aws.dns
-  }
-}

--- a/cloudfront/iiif.wellcomecollection.org/terraform/origin_sets/origin_set.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/origin_sets/origin_set.tf
@@ -25,12 +25,6 @@ variable "test" {
     origin_path : string
   })
 }
-variable "stage_new" {
-  type = object({
-    domain_name : string
-    origin_path : string
-  })
-}
 
 output "origins" {
   value = {
@@ -50,12 +44,6 @@ output "origins" {
       origin_id    = var.id
       domain_name  = var.test.domain_name
       origin_path  = var.test.origin_path
-      forward_host = var.forward_host
-    },
-    stage_new : {
-      origin_id    = var.id
-      domain_name  = var.stage_new.domain_name
-      origin_path  = var.stage_new.origin_path
       forward_host = var.forward_host
     }
   }

--- a/cloudfront/iiif.wellcomecollection.org/terraform/outputs.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/outputs.tf
@@ -18,7 +18,3 @@ output "iiif_stage_distribution_id" {
 output "iiif_test_distribution_id" {
   value = module.iiif-test.distribution_id
 }
-
-output "iiif_stage_new_distribution_id" {
-  value = module.iiif-stage-new.distribution_id
-}

--- a/cloudfront/iiif.wellcomecollection.org/tests/rewrite_tests.py
+++ b/cloudfront/iiif.wellcomecollection.org/tests/rewrite_tests.py
@@ -232,8 +232,6 @@ def check_iiif(env):
         run_checks("-stage")
     elif env == "test":
         run_checks("-test")
-    elif env == "stage-new":
-        run_checks("-stage-new", "neworchestrator.dlcs.io")
     else:
         run_checks()
 

--- a/cloudfront/invalidation/terraform/iam.tf
+++ b/cloudfront/invalidation/terraform/iam.tf
@@ -144,32 +144,3 @@ resource "aws_sns_topic_policy" "iiif_test" {
   arn    = module.iiif_test.sns_topic_arn
   policy = data.aws_iam_policy_document.iiif_test.json
 }
-
-data "aws_iam_policy_document" "iiif_stage_new" {
-  statement {
-    actions = [
-      "sns:Publish",
-    ]
-
-    resources = [module.iiif_stage_new.sns_topic_arn, ]
-
-    condition {
-      test     = "StringLike"
-      variable = "aws:userId"
-      values = [
-        "${local.dds_workflow_stage_new}:*",
-        "${local.dash_workflow_stage_new}:*"
-      ]
-    }
-
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-  }
-}
-
-resource "aws_sns_topic_policy" "iiif_stage_new" {
-  arn    = module.iiif_stage_new.sns_topic_arn
-  policy = data.aws_iam_policy_document.iiif_stage_new.json
-}

--- a/cloudfront/invalidation/terraform/locals.tf
+++ b/cloudfront/invalidation/terraform/locals.tf
@@ -2,10 +2,8 @@ locals {
   dds_workflow_prod      = "AROAZQI22QHW5L3AA6HGE"
   dds_workflow_stage     = "AROAZQI22QHWVEECG3UI3"
   dds_workflow_test      = "AROAZQI22QHWWHVPVKOM3"
-  dds_workflow_stage_new = "AROAZQI22QHWQWE3OVT34"
 
   dash_workflow_prod      = "AROAZQI22QHWZ755Z5O5K"
   dash_workflow_stage     = "AROAZQI22QHW3RRRIYDN3"
   dash_workflow_test      = "AROAZQI22QHWQI2FAIMQ5"
-  dash_workflow_stage_new = "AROAZQI22QHW6X2IDCXSZ"
 }

--- a/cloudfront/invalidation/terraform/locals.tf
+++ b/cloudfront/invalidation/terraform/locals.tf
@@ -1,9 +1,9 @@
 locals {
-  dds_workflow_prod      = "AROAZQI22QHW5L3AA6HGE"
-  dds_workflow_stage     = "AROAZQI22QHWVEECG3UI3"
-  dds_workflow_test      = "AROAZQI22QHWWHVPVKOM3"
+  dds_workflow_prod  = "AROAZQI22QHW5L3AA6HGE"
+  dds_workflow_stage = "AROAZQI22QHWVEECG3UI3"
+  dds_workflow_test  = "AROAZQI22QHWWHVPVKOM3"
 
-  dash_workflow_prod      = "AROAZQI22QHWZ755Z5O5K"
-  dash_workflow_stage     = "AROAZQI22QHW3RRRIYDN3"
-  dash_workflow_test      = "AROAZQI22QHWQI2FAIMQ5"
+  dash_workflow_prod  = "AROAZQI22QHWZ755Z5O5K"
+  dash_workflow_stage = "AROAZQI22QHW3RRRIYDN3"
+  dash_workflow_test  = "AROAZQI22QHWQI2FAIMQ5"
 }

--- a/cloudfront/invalidation/terraform/main.tf
+++ b/cloudfront/invalidation/terraform/main.tf
@@ -22,14 +22,6 @@ module "iiif_test" {
   distribution_id = data.terraform_remote_state.iiif_wc_cloudfront.outputs.iiif_test_distribution_id
 }
 
-# topic and handler for invalidating iiif-stage-new.wc.org paths
-module "iiif_stage_new" {
-  source = "./sns_lambda"
-
-  friendly_name   = "iiif-stage-new"
-  distribution_id = data.terraform_remote_state.iiif_wc_cloudfront.outputs.iiif_stage_new_distribution_id
-}
-
 # topic and handler for invalidating api.wc.org paths
 module "api_prod" {
   source = "./sns_lambda"


### PR DESCRIPTION
## What's changing and why?

We have now released new versions of iiif-builder/dds and DLCS. This change rollsback some temporary changes that were made to lower environments to facilitate testing. Changes:

* Remove iiif-stage-new.weco.org CF distro. This was a temporary environment that has been deleted.
* Remove resources related to invalidating above CF distro.
* Update iiif-test.weco.org origins:
  * Use `dlcs.io` rather than `neworchestrator.dlcs.io`. Latter was an alias for Protagonist before it was deployed to production.
  * Use space 9, rather than 5. Space 5 is "production", space 9 is "test"

## `terraform plan` diff

Unable to plan changes to CF distro as I do not have appropriate permissions.

Changes for invalidation lambda include other environment but I suspect that is due to s3 object changing.

<details>
<summary>output of <code>terraform plan</code> for CF invalidation </summary>

```hcl
Terraform will perform the following actions:

  # aws_sns_topic_policy.iiif_stage_new will be destroyed
  # (because aws_sns_topic_policy.iiif_stage_new is not in configuration)
  - resource "aws_sns_topic_policy" "iiif_stage_new" {
    }

  # module.api_prod.aws_lambda_function.cloudfront_invalidation will be updated in-place
  ~ resource "aws_lambda_function" "cloudfront_invalidation" {
        id                             = "api-prod-cloudfront_invalidation"
      ~ last_modified                  = "2023-02-23T09:09:41.000+0000" -> (known after apply)
      ~ qualified_arn                  = "arn:aws:lambda:eu-west-1:760097843905:function:api-prod-cloudfront_invalidation:4" -> (known after apply)
      ~ qualified_invoke_arn           = "arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:760097843905:function:api-prod-cloudfront_invalidation:4/invocations" -> (known after apply)
      ~ s3_object_version              = "uRaHFpGwUQII7w2TLchScZaUVmyMw8wN" -> "9ttBHo3Yk6pWw7alYF_lCFY1G.VdJWOw"
        tags                           = {}
      ~ version                        = "4" -> (known after apply)
        # (19 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.api_stage.aws_lambda_function.cloudfront_invalidation will be updated in-place
  ~ resource "aws_lambda_function" "cloudfront_invalidation" {
        id                             = "api-stage-cloudfront_invalidation"
      ~ last_modified                  = "2023-02-23T09:09:41.000+0000" -> (known after apply)
      ~ qualified_arn                  = "arn:aws:lambda:eu-west-1:760097843905:function:api-stage-cloudfront_invalidation:4" -> (known after apply)
      ~ qualified_invoke_arn           = "arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:760097843905:function:api-stage-cloudfront_invalidation:4/invocations" -> (known after apply)
      ~ s3_object_version              = "uRaHFpGwUQII7w2TLchScZaUVmyMw8wN" -> "9ttBHo3Yk6pWw7alYF_lCFY1G.VdJWOw"
        tags                           = {}
      ~ version                        = "4" -> (known after apply)
        # (19 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.iiif_prod.aws_lambda_function.cloudfront_invalidation will be updated in-place
  ~ resource "aws_lambda_function" "cloudfront_invalidation" {
        id                             = "iiif-prod-cloudfront_invalidation"
      ~ last_modified                  = "2023-02-23T09:09:41.000+0000" -> (known after apply)
      ~ qualified_arn                  = "arn:aws:lambda:eu-west-1:760097843905:function:iiif-prod-cloudfront_invalidation:4" -> (known after apply)
      ~ qualified_invoke_arn           = "arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:760097843905:function:iiif-prod-cloudfront_invalidation:4/invocations" -> (known after apply)
      ~ s3_object_version              = "uRaHFpGwUQII7w2TLchScZaUVmyMw8wN" -> "9ttBHo3Yk6pWw7alYF_lCFY1G.VdJWOw"
        tags                           = {}
      ~ version                        = "4" -> (known after apply)
        # (19 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.iiif_stage.aws_lambda_function.cloudfront_invalidation will be updated in-place
  ~ resource "aws_lambda_function" "cloudfront_invalidation" {
        id                             = "iiif-stage-cloudfront_invalidation"
      ~ last_modified                  = "2023-02-23T09:09:41.000+0000" -> (known after apply)
      ~ qualified_arn                  = "arn:aws:lambda:eu-west-1:760097843905:function:iiif-stage-cloudfront_invalidation:4" -> (known after apply)
      ~ qualified_invoke_arn           = "arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:760097843905:function:iiif-stage-cloudfront_invalidation:4/invocations" -> (known after apply)
      ~ s3_object_version              = "uRaHFpGwUQII7w2TLchScZaUVmyMw8wN" -> "9ttBHo3Yk6pWw7alYF_lCFY1G.VdJWOw"
        tags                           = {}
      ~ version                        = "4" -> (known after apply)
        # (19 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.iiif_stage_new.aws_iam_role.cloudfront_invalidation_exec_role will be destroyed
  # (because aws_iam_role.cloudfront_invalidation_exec_role is not in configuration)
  - resource "aws_iam_role" "cloudfront_invalidation_exec_role" {
    }

  # module.iiif_stage_new.aws_iam_role_policy.lambda_invalidate_cloudfront_distro will be destroyed
  # (because aws_iam_role_policy.lambda_invalidate_cloudfront_distro is not in configuration)
  - resource "aws_iam_role_policy" "lambda_invalidate_cloudfront_distro" {
    }

  # module.iiif_stage_new.aws_iam_role_policy_attachment.basic_execution_role will be destroyed
  # (because aws_iam_role_policy_attachment.basic_execution_role is not in configuration)
  - resource "aws_iam_role_policy_attachment" "basic_execution_role" {
    }

  # module.iiif_stage_new.aws_lambda_function.cloudfront_invalidation will be destroyed
  # (because aws_lambda_function.cloudfront_invalidation is not in configuration)
  - resource "aws_lambda_function" "cloudfront_invalidation" {
    }

  # module.iiif_stage_new.aws_lambda_permission.execute_from_sns will be destroyed
  # (because aws_lambda_permission.execute_from_sns is not in configuration)
  - resource "aws_lambda_permission" "execute_from_sns" {
    }

  # module.iiif_stage_new.aws_sns_topic.sns_invalidation_topic will be destroyed
  # (because aws_sns_topic.sns_invalidation_topic is not in configuration)
  - resource "aws_sns_topic" "sns_invalidation_topic" {
    }

  # module.iiif_stage_new.aws_sns_topic_subscription.invalidation_lambda_target will be destroyed
  # (because aws_sns_topic_subscription.invalidation_lambda_target is not in configuration)
  - resource "aws_sns_topic_subscription" "invalidation_lambda_target" {
    }

  # module.iiif_test.aws_lambda_function.cloudfront_invalidation will be updated in-place
  ~ resource "aws_lambda_function" "cloudfront_invalidation" {
    }

Plan: 0 to add, 5 to change, 8 to destroy.
```
</details>