### PR TITLE
expand timeframe in cloudfront kibana link

### DIFF
--- a/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.js
+++ b/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.js
@@ -122,15 +122,15 @@ function maxDate(dates) {
  * e.g. 200 OK or 404 Not Found responses.
  */
 function createKibanaLogLink(serverErrors) {
-  // Find the time of the earliest/latest error, then add a few minutes either
+  // Find the time of the earliest/latest error, then add an hour either
   // side for safety.
   const earliestError = minDate(serverErrors.map(e => e.date));
   const latestError = maxDate(serverErrors.map(e => e.date));
 
   const fromDate = new Date(
-    earliestError.setMinutes(earliestError.getMinutes() - 2)
+    earliestError.setMinutes(earliestError.getMinutes() - 60)
   );
-  const toDate = new Date(latestError.setMinutes(latestError.getMinutes() + 2));
+  const toDate = new Date(latestError.setMinutes(latestError.getMinutes() + 60));
 
   return `https://logging.wellcomecollection.org/app/discover#?_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A0)%2Ctime%3A(from%3A'${fromDate.toISOString()}'%2Cto%3A'${toDate.toISOString()}'))`;
 }


### PR DESCRIPTION
## What's changing and why?

Extending the duration in the logging link sent as part of the slack alert make it easier to see the context of an error.

## `terraform plan` diff

 # module.slack_alerts_for_5xx.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "send_slack_alert_for_5xx_errors"
      ~ last_modified                  = "2023-04-16T18:37:49.000+0000" -> (known after apply)
      ~ source_code_hash               = "L5tGrKkuQThjeB7gsceC+vX4calKT6rm2pN5xiekamI=" -> "R0JbOWqqXdQfv9GCd+siIU3ZhmlIJp3uByGwNSj5naU="
        tags                           = {}
        # (21 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
