### PR TITLE
Update test/staging IIIF Cloudfront for IIIF Auth2

### DIFF
--- a/cloudfront/iiif.wellcomecollection.org/terraform/.terraform.lock.hcl
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "5.3.0"
   hashes = [
     "h1:HKlxtbkaT/YKPtzJLGm8np5JiaPSys/aG6Lbj8QB/5c=",
+    "h1:ZcDshfcHs+j9fxRsjteavgJ/yCb+TSSqmw/VOB6tLD0=",
     "zh:001814dcf6b2329de5e2c9223c4f1e95a0f60d6670046015419053b03b3c0712",
     "zh:3c511a91f53076c3a1117526bee0880b339261f1eb3feecd7854771bfef7890d",
     "zh:3e6c19e048f06051c9296c7a3236946f37431ce0d84f843585c5f3e8504759d3",

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
@@ -332,6 +332,25 @@ locals {
     },
   ]
 
+  auth2_behaviours_stage = [
+    {
+      path_pattern     = "auth/v2/*"
+      target_origin_id = "dlcs_auth_v2"
+      headers          = ["Authorization"]
+      cookies          = "all"
+      lambdas = [
+        {
+          event_type = "origin-request"
+          lambda_arn = local.dlcs_path_rewrite_arn_stage
+        }
+      ]
+
+      min_ttl     = 0
+      default_ttl = 24 * 60 * 60
+      max_ttl     = 365 * 24 * 60 * 60
+    },
+  ]
+
   dash_behaviours = [
     {
       path_pattern     = "dash/*"
@@ -383,6 +402,7 @@ locals {
     local.av_behaviours_stage,
     local.pdf_behaviours_stage,
     local.file_behaviours_stage,
+    local.auth2_behaviours_stage,
     local.auth_behaviours_stage,
     local.dash_behaviours,
     local.pdf_cover_behaviours,
@@ -397,6 +417,7 @@ locals {
     local.av_behaviours_stage,
     local.pdf_behaviours_stage,
     local.file_behaviours_stage,
+    local.auth2_behaviours_stage,
     local.auth_behaviours_stage,
     local.dash_behaviours,
     local.pdf_cover_behaviours,

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
@@ -332,6 +332,25 @@ locals {
     },
   ]
 
+  auth2_probe_behaviours_stage = [
+    {
+      path_pattern     = "auth/v2/probe/*"
+      target_origin_id = "dlcs_auth_v2_probe"
+      headers          = ["Authorization"]
+      cookies          = "all"
+      lambdas = [
+        {
+          event_type = "origin-request"
+          lambda_arn = local.dlcs_path_rewrite_arn_stage
+        }
+      ]
+
+      min_ttl     = 0
+      default_ttl = 24 * 60 * 60
+      max_ttl     = 365 * 24 * 60 * 60
+    },
+  ]
+
   auth2_behaviours_stage = [
     {
       path_pattern     = "auth/v2/*"
@@ -402,6 +421,7 @@ locals {
     local.av_behaviours_stage,
     local.pdf_behaviours_stage,
     local.file_behaviours_stage,
+    local.auth2_probe_behaviours_stage,
     local.auth2_behaviours_stage,
     local.auth_behaviours_stage,
     local.dash_behaviours,
@@ -417,6 +437,7 @@ locals {
     local.av_behaviours_stage,
     local.pdf_behaviours_stage,
     local.file_behaviours_stage,
+    local.auth2_probe_behaviours_stage,
     local.auth2_behaviours_stage,
     local.auth_behaviours_stage,
     local.dash_behaviours,

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
@@ -240,6 +240,26 @@ module "dlcs_auth_origin_set" {
   }
 }
 
+module "dlcs_auth2_origin_set" {
+  source = "./origin_sets"
+  id     = "dlcs_auth_v2"
+
+  forward_host = true
+
+  prod = {
+    domain_name : "dlcs.io"
+    origin_path : "/auth/v2/2"
+  }
+  stage = {
+    domain_name : "dlcs.io"
+    origin_path : "/auth/v2/2"
+  }
+  test = {
+    domain_name : "dlcs.io"
+    origin_path : "/auth/v2/2"
+  }
+}
+
 locals {
 
   prod_origins = [
@@ -269,7 +289,8 @@ locals {
     module.dlcs_pdf_origin_set.origins["stage"],
     module.dlcs_file_origin_set.origins["stage"],
     module.dlcs_pdf_cover_origin_set.origins["stage"],
-    module.dlcs_auth_origin_set.origins["stage"]
+    module.dlcs_auth_origin_set.origins["stage"],
+    module.dlcs_auth2_origin_set.origins["stage"]
   ]
 
   test_origins = [
@@ -284,6 +305,7 @@ locals {
     module.dlcs_pdf_origin_set.origins["test"],
     module.dlcs_file_origin_set.origins["test"],
     module.dlcs_pdf_cover_origin_set.origins["test"],
-    module.dlcs_auth_origin_set.origins["test"]
+    module.dlcs_auth_origin_set.origins["test"],
+    module.dlcs_auth2_origin_set.origins["test"]
   ]
 }

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
@@ -260,6 +260,26 @@ module "dlcs_auth2_origin_set" {
   }
 }
 
+module "dlcs_auth2_probe_origin_set" {
+  source = "./origin_sets"
+  id     = "dlcs_auth_v2_probe"
+
+  forward_host = true
+
+  prod = {
+    domain_name : "dlcs.io"
+    origin_path : "/auth/v2/probe/2"
+  }
+  stage = {
+    domain_name : "dlcs.io"
+    origin_path : "/auth/v2/probe/2"
+  }
+  test = {
+    domain_name : "dlcs.io"
+    origin_path : "/auth/v2/probe/2"
+  }
+}
+
 locals {
 
   prod_origins = [
@@ -290,7 +310,8 @@ locals {
     module.dlcs_file_origin_set.origins["stage"],
     module.dlcs_pdf_cover_origin_set.origins["stage"],
     module.dlcs_auth_origin_set.origins["stage"],
-    module.dlcs_auth2_origin_set.origins["stage"]
+    module.dlcs_auth2_origin_set.origins["stage"],
+    module.dlcs_auth2_probe_origin_set.origins["stage"]
   ]
 
   test_origins = [
@@ -306,6 +327,7 @@ locals {
     module.dlcs_file_origin_set.origins["test"],
     module.dlcs_pdf_cover_origin_set.origins["test"],
     module.dlcs_auth_origin_set.origins["test"],
-    module.dlcs_auth2_origin_set.origins["test"]
+    module.dlcs_auth2_origin_set.origins["test"],
+    module.dlcs_auth2_probe_origin_set.origins["test"]
   ]
 }

--- a/cloudfront/iiif.wellcomecollection.org/terraform/s3.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/s3.tf
@@ -75,7 +75,7 @@ data "aws_iam_policy_document" "allow_manage_bucket_acl" {
     ]
 
     resources = [
-      aws_s3_bucket.cloudfront_logs.id,
+      aws_s3_bucket.cloudfront_logs.arn,
     ]
   }
 }

--- a/critical/lambda_logging.tf
+++ b/critical/lambda_logging.tf
@@ -45,63 +45,63 @@ locals {
 resource "aws_ssm_parameter" "log_destination_arn_platform" {
   provider = aws.platform
 
-  name      = local.log_destination_parameter_name
-  type      = "String"
-  value     = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  name  = local.log_destination_parameter_name
+  type  = "String"
+  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_catalogue" {
   provider = aws.catalogue
 
-  name      = local.log_destination_parameter_name
-  type      = "String"
-  value     = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  name  = local.log_destination_parameter_name
+  type  = "String"
+  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_digirati" {
   provider = aws.digirati
 
-  name      = local.log_destination_parameter_name
-  type      = "String"
-  value     = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  name  = local.log_destination_parameter_name
+  type  = "String"
+  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_experience" {
   provider = aws.experience
 
-  name      = local.log_destination_parameter_name
-  type      = "String"
-  value     = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  name  = local.log_destination_parameter_name
+  type  = "String"
+  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_identity" {
   provider = aws.identity
 
-  name      = local.log_destination_parameter_name
-  type      = "String"
-  value     = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  name  = local.log_destination_parameter_name
+  type  = "String"
+  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_reporting" {
   provider = aws.reporting
 
-  name      = local.log_destination_parameter_name
-  type      = "String"
-  value     = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  name  = local.log_destination_parameter_name
+  type  = "String"
+  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_storage" {
   provider = aws.storage
 
-  name      = local.log_destination_parameter_name
-  type      = "String"
-  value     = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  name  = local.log_destination_parameter_name
+  type  = "String"
+  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
 }
 
 resource "aws_ssm_parameter" "log_destination_arn_workflow" {
   provider = aws.workflow
 
-  name      = local.log_destination_parameter_name
-  type      = "String"
-  value     = module.kinesis_log_destination.cloudwatch_log_destination.arn
+  name  = local.log_destination_parameter_name
+  type  = "String"
+  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
 }


### PR DESCRIPTION
## What's changing and why?

Added a new behaviour/origin for IIIF Auth v2 (test + staging env only to verify setup).

New origins are `dlcs.io/auth/v2/probe/*` and `dlcs.io/auth/v2/*`.

There was already a `dlcs_auth` behaviour which handled `/auth/*` paths (for IIIF auth v1). 

I added the new `dlcs_auth_2` / `/auth/v2/*` behaviour as a lower precedence to ensure it is evaluated before ^. This has resulted in some behaviours being re-ordered and the `terraform plan` being pretty large.

## `terraform plan` diff

I initially included `terraform plan` output but it was too large and I received an error: 

> Pull request creation failed. Validation failed: Body is too long (maximum is 65536 characters) 