### PR TITLE
Stop unexpected error in IIIF redirect tests

### DIFF
--- a/cloudfront/iiif.wellcomecollection.org/tests/rewrite_tests.py
+++ b/cloudfront/iiif.wellcomecollection.org/tests/rewrite_tests.py
@@ -48,8 +48,9 @@ def validate_auth(info_json, regex):
             service_description = [service_description]
 
         for service in service_description:
-            info_id = service.get("@id", None)
-            if not p.match(info_id):
+            # Get both @id and id for different IIIF versions
+            info_id = service.get("@id", service.get("id", None))
+            if not info_id or not p.match(info_id):
                 click.echo(
                     click.style(
                         f"Id fail - expected '{regex}' but found '{info_id}'", fg="red"


### PR DESCRIPTION
This makes the tests stop exploding, but perhaps they should be removed altogether