### PR TITLE
Further updates to iiif-stage and iiif-test CloudFront config for iiif-auth2

### DIFF
--- a/cloudfront/iiif.wellcomecollection.org/edge-lambda/src/dlcs_path_rewrite.test.ts
+++ b/cloudfront/iiif.wellcomecollection.org/edge-lambda/src/dlcs_path_rewrite.test.ts
@@ -108,6 +108,23 @@ const rewrite_tests = (): Array<ExpectedRewrite> => {
       in: '/file/b21320962_National%20primary%20science%20survey.pdf',
       out: '/b21320962_National%20primary%20science%20survey.pdf'
     },
+    // DLCS iiif auth v2 paths
+    {
+      in : '/auth/v2/probe/foo?roles=api.dlcs.io/customers/2/roles/clickthrough',
+      out: '/foo?roles=api.dlcs.io/customers/2/roles/clickthrough'
+    },
+    {
+      in : '/auth/v2/access/clickthrough?origin=test.example',
+      out: '/clickthrough?origin=test.example'
+    },
+    {
+      in : '/auth/v2/access/clickthrough/logout',
+      out: '/clickthrough/logout'
+    },
+    {
+      in : '/auth/v2/access/token?origin=test.example&messageId=123',
+      out: '/token?origin=test.example&messageId=123'
+    },
     // DLCS auth paths
     {
       in: '/auth/fromcas?token=xyz',

--- a/cloudfront/iiif.wellcomecollection.org/edge-lambda/src/dlcs_path_rewrite.ts
+++ b/cloudfront/iiif.wellcomecollection.org/edge-lambda/src/dlcs_path_rewrite.ts
@@ -13,6 +13,7 @@ export const request: CloudFrontRequestHandler = (event, context, callback) => {
     const dlcsThumbsUri: RegExp = /^\/thumbs\/.+/
     const dlcsPdfUri: RegExp = /^\/pdf\/.+/
     const dlcsFileUri: RegExp = /^\/file\/.+/
+    const dlcsAuth2Uri: RegExp = /^\/auth\/v2\/.+/
     const dlcsAuthUri: RegExp = /^\/auth\/.+/
 
     const rewriteRequestUri: (uri: string) => string = (uri: string) => {
@@ -38,6 +39,10 @@ export const request: CloudFrontRequestHandler = (event, context, callback) => {
         } else if(uri.match(dlcsFileUri)) {
             return uri
                 .replace('/file', '')
+        } else if(uri.match(dlcsAuth2Uri)) {
+            return uri
+                .replace('/auth/v2/access', '')
+                .replace('/auth/v2/probe', '')
         } else if(uri.match(dlcsAuthUri)) {
             return uri
                 .replace('/auth', '')

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
@@ -248,15 +248,15 @@ module "dlcs_auth2_origin_set" {
 
   prod = {
     domain_name : "dlcs.io"
-    origin_path : "/auth/v2/2"
+    origin_path : "/auth/v2/access/2"
   }
   stage = {
     domain_name : "dlcs.io"
-    origin_path : "/auth/v2/2"
+    origin_path : "/auth/v2/access/2"
   }
   test = {
     domain_name : "dlcs.io"
-    origin_path : "/auth/v2/2"
+    origin_path : "/auth/v2/access/2"
   }
 }
 
@@ -268,15 +268,15 @@ module "dlcs_auth2_probe_origin_set" {
 
   prod = {
     domain_name : "dlcs.io"
-    origin_path : "/auth/v2/probe/2"
+    origin_path : "/auth/v2/probe/2/5"
   }
   stage = {
     domain_name : "dlcs.io"
-    origin_path : "/auth/v2/probe/2"
+    origin_path : "/auth/v2/probe/2/6"
   }
   test = {
     domain_name : "dlcs.io"
-    origin_path : "/auth/v2/probe/2"
+    origin_path : "/auth/v2/probe/2/9"
   }
 }
 


### PR DESCRIPTION
## What's changing and why?

This PR extends changes made via #402.

After testing deployed DLCS it became apparent that the CloudFront origin paths needed to be altered.

In addition to this the lambda@edge function needed some slight alterations to allow us to handle incoming paths correctly. It looks like the same lambda is used for all envs, this change should be safe to apply as there will be no prod requests that match `/^\/auth\/v2\/.+/` as this is a new path.

## `terraform plan` diff
<!-- Please make sure you don't paste anything secure that shouldn't be shared here -->
