### PR TITLE
Add iiif-auth-2 paths to prod + update lambda@edge version

### DIFF
--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_behaviours.tf
@@ -313,6 +313,44 @@ locals {
     },
   ]
 
+  auth2_probe_behaviours_prod = [
+    {
+      path_pattern     = "auth/v2/probe/*"
+      target_origin_id = "dlcs_auth_v2_probe"
+      headers          = ["Authorization"]
+      cookies          = "all"
+      lambdas = [
+        {
+          event_type = "origin-request"
+          lambda_arn = local.dlcs_path_rewrite_arn_prod
+        }
+      ]
+
+      min_ttl     = 0
+      default_ttl = 0
+      max_ttl     = 0
+    },
+  ]
+
+  auth2_behaviours_prod = [
+    {
+      path_pattern     = "auth/v2/*"
+      target_origin_id = "dlcs_auth_v2"
+      headers          = ["Authorization"]
+      cookies          = "all"
+      lambdas = [
+        {
+          event_type = "origin-request"
+          lambda_arn = local.dlcs_path_rewrite_arn_prod
+        }
+      ]
+
+      min_ttl     = 0
+      default_ttl = 0
+      max_ttl     = 0
+    },
+  ]
+
   auth_behaviours_stage = [
     {
       path_pattern     = "auth/*"
@@ -407,6 +445,8 @@ locals {
     local.av_behaviours_prod,
     local.pdf_behaviours_prod,
     local.file_behaviours_prod,
+    local.auth2_probe_behaviours_prod,
+    local.auth2_behaviours_prod,
     local.auth_behaviours_prod,
     local.dash_behaviours,
     local.pdf_cover_behaviours,

--- a/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/cf_origins.tf
@@ -294,7 +294,9 @@ locals {
     module.dlcs_pdf_origin_set.origins["prod"],
     module.dlcs_file_origin_set.origins["prod"],
     module.dlcs_pdf_cover_origin_set.origins["prod"],
-    module.dlcs_auth_origin_set.origins["prod"]
+    module.dlcs_auth_origin_set.origins["prod"],
+    module.dlcs_auth2_origin_set.origins["prod"],
+    module.dlcs_auth2_probe_origin_set.origins["prod"]
   ]
 
   stage_origins = [

--- a/cloudfront/iiif.wellcomecollection.org/terraform/locals.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/locals.tf
@@ -3,7 +3,7 @@ locals {
   dlcs_path_rewrite_latest     = aws_lambda_function.dlcs_path_rewrite.version
   dlcs_path_rewrite_arn_latest = "${local.dlcs_path_rewrite_arn}:${local.dlcs_path_rewrite_latest}"
   dlcs_path_rewrite_arn_stage  = local.dlcs_path_rewrite_arn_latest
-  dlcs_path_rewrite_arn_prod   = "${local.dlcs_path_rewrite_arn}:14"
+  dlcs_path_rewrite_arn_prod   = local.dlcs_path_rewrite_arn_latest
 
   edge_lambdas_bucket = data.terraform_remote_state.cloudfront_core.outputs.edge_lambdas_bucket
 }


### PR DESCRIPTION
## What's changing and why?

#402, #404 and #406 updated Cloudfront and associated lambda@edge for handling iiif auth v2 paths. This PR makes the same changes for production environment. Summary:

* Update lambda@edge used in prod environment to latest version
* Add 2 new behaviours, mimicking those added to test + stage
* Add 2 new origins, again mimicking those added in test + stage (initially added in #402 then updated in #404).

## `terraform plan` diff
<!-- Please make sure you don't paste anything secure that shouldn't be shared here -->

> Generated diff too large
