### PR TITLE
Lifecycle management for APM traces

### DIFF
--- a/critical/.terraform.lock.hcl
+++ b/critical/.terraform.lock.hcl
@@ -6,7 +6,6 @@ provider "registry.terraform.io/elastic/ec" {
   constraints = "0.5.0"
   hashes = [
     "h1:4BiRazUuyKHramn/5a7QwhXK5lbVxEQ1FzC2fZN8FYA=",
-    "h1:A93bvjVkPuRuRgG68pMAB5kTzD1JdqZe6I0XKctz4xE=",
     "zh:1b0bf155960e1aaccf59359080ca30bf5ae44d5d46c47d9834fc343971edd798",
     "zh:24ae7fc6becf3a6f5dedf0871223a4dd3c46ab4166dc0c2148cb05cff2157786",
     "zh:4091ad8ed4c6dfaa28cc0f5c1187ab17320f1b55966e2aa25cb832fe09b52eec",
@@ -28,7 +27,6 @@ provider "registry.terraform.io/elastic/elasticstack" {
   version     = "0.5.0"
   constraints = "0.5.0"
   hashes = [
-    "h1:Nct0wXq7GL2YzXI4elB7nsauBhlkSUtMi9BKLl9wKU0=",
     "h1:jmMnCZXvaxPl779fSnekUODXHPMwqXKTNPC98kfoudk=",
     "zh:0d28448ed2332977eaeb782f66c55c5ed35b50b171bd61d576e0232647bcd75a",
     "zh:1af52279ca0213873f2d5f30cbdabf131b6a07257c015e8fcaf8900dd7b302ea",
@@ -48,9 +46,24 @@ provider "registry.terraform.io/elastic/elasticstack" {
 }
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "5.17.0"
+  version = "5.30.0"
   hashes = [
-    "h1:+riTtJ8Tqjd6js1SGim+926BtDuxy8Jn4F+xV8LXvvg=",
+    "h1:ZsaqSoi0hx+GXUK1AaCwoHx+XYgiZY2JZX2UZ6kVvH4=",
+    "zh:0ac576f2278c6d3fead05fbb136df87e399ec065edeef56c054fa2f3ac465390",
+    "zh:1ef592d293cac2f35c37c4d23cb5f9e8b34713e24585cedaf5874d024712d9fd",
+    "zh:21d8412d5cec5e7e9a2199089d95287c5882f4db0e3b820e4f7760242bfa83b2",
+    "zh:29bcc5616d579cd389b9c43a1922e7eafe68c8ca1b0f13e91b9e0a38d59c8b89",
+    "zh:3afed6c066524eccabab25ba83af5d2b5b46e6187968284da0cb49a01002e0e8",
+    "zh:4745d71ca72a6dcf819afe8065fcd8883c8434cdcfcfdc9ab3a4722fd611b437",
+    "zh:486701b188b4a6a656a3f23b704dc53f4766164c23368542de36622f28b3248d",
+    "zh:56cd5846b35cd405f63cf33b1fdfe6e99ff19f893aaacedc6e9245c563397173",
+    "zh:5d1d4806c15c49755c8e73dd590471c43ae84a3ded8c54b0e397ad6336fba6e5",
+    "zh:7df03941001c14ce255a6f4f5c2edd275fb45a9d7cd316229eef6558f79c0149",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b0c1732d3a32630bc17d8da29662b16e346b1739ff72273e6169f9f5a968cb82",
+    "zh:ce9888a63f6a6a8786499fa3e2350b13f6b87410561122799871d50a3cf07604",
+    "zh:d336271de465e9ed48bce89ce97a874e3d9e2916712e3359d419c811365d75ee",
+    "zh:e528275339aea59021ec810ee74220ce328181ee38f4ce6c7b1efb2db9dca56f",
   ]
 }
 
@@ -59,7 +72,6 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = "3.4.3"
   hashes = [
     "h1:saZR+mhthL0OZl4SyHXZraxyaBNVMxiZzks78nWcZ2o=",
-    "h1:tL3katm68lX+4lAncjQA9AXL4GR/VM+RPwqYf4D2X8Q=",
     "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
     "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
     "zh:686ad1ee40b812b9e016317e7f34c0d63ef837e084dea4a1f578f64a6314ad53",

--- a/critical/elastic_logging_cluster.tf
+++ b/critical/elastic_logging_cluster.tf
@@ -179,7 +179,8 @@ resource "elasticstack_elasticsearch_security_role_mapping" "logging" {
 // The rollover/deletion values are chosen with the intention of avoiding the cluster storage filling up
 // and may need modifying in future.
 resource "elasticstack_elasticsearch_index_lifecycle" "apm_traces" {
-  name = "weco-traces-apm"
+  provider = elasticstack.logging
+  name     = "weco-traces-apm"
 
   hot {
     rollover {
@@ -194,7 +195,8 @@ resource "elasticstack_elasticsearch_index_lifecycle" "apm_traces" {
 }
 
 resource "elasticstack_elasticsearch_index_lifecycle" "apm_traces_rum" {
-  name = "weco-traces-apm-rum"
+  provider = elasticstack.logging
+  name     = "weco-traces-apm-rum"
 
   hot {
     rollover {
@@ -209,7 +211,8 @@ resource "elasticstack_elasticsearch_index_lifecycle" "apm_traces_rum" {
 }
 
 resource "elasticstack_elasticsearch_component_template" "apm_traces_managed_custom" {
-  name = "traces-apm@custom"
+  provider = elasticstack.logging
+  name     = "traces-apm@custom"
 
   template {
     settings = jsonencode({
@@ -221,7 +224,8 @@ resource "elasticstack_elasticsearch_component_template" "apm_traces_managed_cus
 }
 
 resource "elasticstack_elasticsearch_component_template" "apm_traces_rum_managed_custom" {
-  name = "traces-apm.rum@custom"
+  provider = elasticstack.logging
+  name     = "traces-apm.rum@custom"
 
   template {
     settings = jsonencode({

--- a/critical/elastic_logging_cluster.tf
+++ b/critical/elastic_logging_cluster.tf
@@ -221,6 +221,16 @@ resource "elasticstack_elasticsearch_component_template" "apm_traces_managed_cus
       }
     })
   }
+
+  metadata = jsonencode(
+    {
+      managed    = true
+      managed_by = "fleet"
+      package = {
+        name = "apm"
+      }
+    }
+  )
 }
 
 resource "elasticstack_elasticsearch_component_template" "apm_traces_rum_managed_custom" {
@@ -234,4 +244,14 @@ resource "elasticstack_elasticsearch_component_template" "apm_traces_rum_managed
       }
     })
   }
+
+  metadata = jsonencode(
+    {
+      managed    = true
+      managed_by = "fleet"
+      package = {
+        name = "apm"
+      }
+    }
+  )
 }

--- a/critical/elastic_logging_cluster.tf
+++ b/critical/elastic_logging_cluster.tf
@@ -173,3 +173,61 @@ resource "elasticstack_elasticsearch_security_role_mapping" "logging" {
   })
   metadata = jsonencode({ version = 1 })
 }
+
+// These are custom ILM policies which we attach to the @custom component templates as documented at
+// https://www.elastic.co/guide/en/apm/guide/current/ilm-how-to.html
+// The rollover/deletion values are chosen with the intention of avoiding the cluster storage filling up
+// and may need modifying in future.
+resource "elasticstack_elasticsearch_index_lifecycle" "apm_traces" {
+  name = "weco-traces-apm"
+
+  hot {
+    rollover {
+      max_size = "50gb"
+      max_age  = "30d"
+    }
+  }
+
+  delete {
+    min_age = "10d"
+  }
+}
+
+resource "elasticstack_elasticsearch_index_lifecycle" "apm_traces_rum" {
+  name = "weco-traces-apm-rum"
+
+  hot {
+    rollover {
+      max_size = "50gb"
+      max_age  = "30d"
+    }
+  }
+
+  delete {
+    min_age = "10d"
+  }
+}
+
+resource "elasticstack_elasticsearch_component_template" "apm_traces_managed_custom" {
+  name = "traces-apm@custom"
+
+  template {
+    settings = jsonencode({
+      lifecycle = {
+        name = elasticstack_elasticsearch_index_lifecycle.apm_traces.name
+      }
+    })
+  }
+}
+
+resource "elasticstack_elasticsearch_component_template" "apm_traces_rum_managed_custom" {
+  name = "traces-apm.rum@custom"
+
+  template {
+    settings = jsonencode({
+      lifecycle = {
+        name = elasticstack_elasticsearch_index_lifecycle.apm_traces_rum.name
+      }
+    })
+  }
+}

--- a/critical/lambda_logging.tf
+++ b/critical/lambda_logging.tf
@@ -74,6 +74,14 @@ resource "aws_ssm_parameter" "log_destination_arn_experience" {
   value = module.kinesis_log_destination.cloudwatch_log_destination.arn
 }
 
+resource "aws_ssm_parameter" "log_destination_arn_experience_cloudfront" {
+  provider = aws.experience_cloudfront
+
+  name  = local.log_destination_parameter_name
+  type  = "String"
+  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+}
+
 resource "aws_ssm_parameter" "log_destination_arn_identity" {
   provider = aws.identity
 

--- a/critical/provider.tf
+++ b/critical/provider.tf
@@ -75,6 +75,19 @@ provider "aws" {
 }
 
 provider "aws" {
+  alias  = "experience_cloudfront"
+  region = "us-east-1"
+
+  default_tags {
+    tags = local.default_tags
+  }
+
+  assume_role {
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+  }
+}
+
+provider "aws" {
   alias  = "workflow"
   region = local.aws_region
 


### PR DESCRIPTION
## What's changing and why?
We see out-of-storage warnings for the logging cluster sometimes, and usually I go and delete some old APM trace indices to fix them. This is a bad idea.

This PR makes the computer delete the indices for us - the exact configuration will probably require tweaking in future; I've been quite conservative at first so as not to throw away too much potentially useful data. It's done as documented here https://www.elastic.co/guide/en/apm/guide/current/ilm-how-to.html

The component template things already exist (they're managed by Fleet) and I think I will have to import them when I come to apply this.

## `terraform plan` diff
```
  # elasticstack_elasticsearch_component_template.apm_traces_managed_custom will be created
  + resource "elasticstack_elasticsearch_component_template" "apm_traces_managed_custom" {
      + id   = (known after apply)
      + name = "traces-apm@custom"

      + template {
          + settings = jsonencode(
                {
                  + lifecycle = {
                      + name = "weco-traces-apm"
                    }
                }
            )
        }
    }

  # elasticstack_elasticsearch_component_template.apm_traces_rum_managed_custom will be created
  + resource "elasticstack_elasticsearch_component_template" "apm_traces_rum_managed_custom" {
      + id   = (known after apply)
      + name = "traces-apm.rum@custom"

      + template {
          + settings = jsonencode(
                {
                  + lifecycle = {
                      + name = "weco-traces-apm-rum"
                    }
                }
            )
        }
    }

  # elasticstack_elasticsearch_index_lifecycle.apm_traces will be created
  + resource "elasticstack_elasticsearch_index_lifecycle" "apm_traces" {
      + id            = (known after apply)
      + modified_date = (known after apply)
      + name          = "weco-traces-apm"

      + delete {
          + min_age = "10d"
        }

      + hot {
          + min_age = (known after apply)

          + rollover {
              + max_age  = "30d"
              + max_size = "50gb"
            }
        }
    }

  # elasticstack_elasticsearch_index_lifecycle.apm_traces_rum will be created
  + resource "elasticstack_elasticsearch_index_lifecycle" "apm_traces_rum" {
      + id            = (known after apply)
      + modified_date = (known after apply)
      + name          = "weco-traces-apm-rum"

      + delete {
          + min_age = "10d"
        }

      + hot {
          + min_age = (known after apply)

          + rollover {
              + max_age  = "30d"
              + max_size = "50gb"
            }
        }
    }
```
