### PR TITLE
Remove healthcheck endpoints from nginx configuration for frontend

### DIFF
--- a/images/dockerfiles/nginx/frontend.nginx.conf
+++ b/images/dockerfiles/nginx/frontend.nginx.conf
@@ -20,10 +20,5 @@ http {
       proxy_set_header Host $host;
       proxy_pass http://${APP_HOST}:${APP_PORT}/;
     }
-
-    location /management/healthcheck {
-      add_header Content-Type text/plain;
-      return 200 'OK';
-    }
   }
 }

--- a/images/dockerfiles/nginx/frontend_identity.nginx.conf
+++ b/images/dockerfiles/nginx/frontend_identity.nginx.conf
@@ -62,10 +62,5 @@ http {
       proxy_buffers            8 8k;
       proxy_busy_buffers_size  16k;
     }
-
-    location /management/healthcheck {
-      add_header Content-Type text/plain;
-      return 200 'OK';
-    }
   }
 }

--- a/images/dockerfiles/publish_nginx_images.sh
+++ b/images/dockerfiles/publish_nginx_images.sh
@@ -5,7 +5,6 @@ set -o errexit
 
 AWS_ACCOUNT_ID=760097843905
 AWS_PROFILE=platform-developer
-DEV_ROLE_ARN="arn:aws:iam::$AWS_ACCOUNT_ID:role/platform-developer"
 ROOT=$(git rev-parse --show-toplevel)
 CURRENT_COMMIT=$(git rev-parse HEAD)
 

--- a/images/dockerfiles/publish_nginx_images.sh
+++ b/images/dockerfiles/publish_nginx_images.sh
@@ -1,71 +1,96 @@
 #!/usr/bin/env bash
 
 set -o nounset
+set -o errexit
 
-DEV_ROLE_ARN="arn:aws:iam::760097843905:role/platform-developer"
+AWS_ACCOUNT_ID=760097843905
+AWS_PROFILE=platform-developer
+DEV_ROLE_ARN="arn:aws:iam::$AWS_ACCOUNT_ID:role/platform-developer"
 ROOT=$(git rev-parse --show-toplevel)
+CURRENT_COMMIT=$(git rev-parse HEAD)
 
-ECR_PRIVATE_PREFIX="760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome"
+ECR_PRIVATE_PREFIX="$AWS_ACCOUNT_ID.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome"
 ECR_PUBLIC_PREFIX="public.ecr.aws/l7a1d1z4"
+AWS_REGION="eu-west-1"
 
-SERVICE_IDS="frontend_identity"
+SERVICE_IDS="frontend frontend_identity"
+
+
+function ecr_login() {
+  local aws_profile=$1
+  local aws_region=$2
+  local is_public=$3
+
+  if [ "$is_public" = true ]; then
+    repo_url="public.ecr.aws"
+    aws_region="us-east-1"
+    service_name="ecr-public"
+  else
+    service_name="ecr"
+    repo_url="$AWS_ACCOUNT_ID.dkr.ecr.$aws_region.amazonaws.com"
+  fi
+
+  echo ""
+  echo "*** Logging in to ECR ($repo_url in $aws_region) ***"
+  echo ""
+
+  aws $service_name get-login-password --region $aws_region --profile $aws_profile | \
+    docker login --username AWS --password-stdin $repo_url
+}
+
+function push_to_ecr() {
+  local tag=$1
+  local ecr_prefix=$2
+  local ecr_tag="$ecr_prefix/$tag"
+
+  echo ""
+  echo "*** Pushing $ecr_tag to ECR ***"
+  echo ""
+
+  docker tag "$tag" "$ecr_tag"
+  docker push "$ecr_tag"
+  docker rmi "$ecr_tag"
+}
+
+function build_template() {
+  local service_id=$1
+  local tag=$2
+  local template_file="$service_id.nginx.conf"
+
+  echo ""
+  echo "*** Building $template_file ***"
+  echo ""
+
+  docker build \
+    --tag="$tag" \
+    --build-arg CONFIG_TEMPLATE="${template_file}" \
+    --file nginx/template.Dockerfile \
+    nginx
+}
+
+function publish_service() {
+  local service_id=$1
+  local template_file="$service_id.nginx.conf"
+  local tag="nginx_$service_id:$CURRENT_COMMIT"
+
+  build_template "$service_id" "$tag"
+  push_to_ecr "$tag" "$ECR_PRIVATE_PREFIX"
+  push_to_ecr "$tag" "$ECR_PUBLIC_PREFIX"
+}
 
 echo ""
 echo "*** WARNING! ***"
 echo "Updating these images may result in downstream updates!"
-echo "This will affect multiple public facing products (including wc.org)"
+echo "Check if consumers are using untagged images before proceeding."
+echo "See: https://github.com/search?q=org%3Awellcomecollection%20uk.ac.wellcome%2Fnginx&type=code"
 echo "*** WARNING! ***"
 echo ""
-read -p "Press enter to continue."
+read -p "Press enter to continue"
 
-
-
-echo ""
-echo "*** Logging in to ECR Private ***"
-echo ""
-AWS_PROFILE=platform-developer aws ecr get-login --no-include-email | bash
-
-echo ""
-echo "*** Logging in to ECR Public ***"
-echo ""
-
-# We have to log in with us-east-1 because that's where ECR Public lives.
-# See https://docs.aws.amazon.com/AmazonECR/latest/public/getting-started-cli.html#cli-authenticate-registry
-AWS_PROFILE=platform-developer aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+ecr_login "$AWS_PROFILE" "$AWS_REGION" false
+ecr_login "$AWS_PROFILE" "$AWS_REGION" true
 
 for SERVICE_ID in $SERVICE_IDS
 do
-
-  echo ""
-  echo "*** Publishing $SERVICE_ID ***"
-  echo ""
-
-  CURRENT_COMMIT=$(git rev-parse HEAD)
-  TEMPLATE_FILE="$SERVICE_ID.nginx.conf"
-
-  TAG="nginx_$SERVICE_ID:$CURRENT_COMMIT"
-  ECR_PRIVATE_TAG="$ECR_PRIVATE_PREFIX/$TAG"
-  ECR_PUBLIC_TAG="$ECR_PUBLIC_PREFIX/$TAG"
-
-  docker build \
-    --tag="$TAG" \
-    --build-arg CONFIG_TEMPLATE="${TEMPLATE_FILE}" \
-    --file nginx/template.Dockerfile \
-    nginx
-
-  echo ""
-  echo "*** Publishing $SERVICE_ID image to ECR Private ***"
-  echo ""
-
-  docker tag "$TAG" "$ECR_PRIVATE_TAG"
-  docker push "$ECR_PRIVATE_TAG"
-  docker rmi "$ECR_PRIVATE_TAG"
-
-  echo ""
-  echo "*** Publishing $SERVICE_ID image to ECR Public ***"
-  echo ""
-
-  docker tag "$TAG" "$ECR_PUBLIC_TAG"
-  docker push "$ECR_PUBLIC_TAG"
-  docker rmi "$ECR_PUBLIC_TAG"
+  publish_service "$SERVICE_ID"
 done

--- a/images/dockerfiles/publish_nginx_images.sh
+++ b/images/dockerfiles/publish_nginx_images.sh
@@ -65,6 +65,7 @@ function build_template() {
     --tag="$tag" \
     --build-arg CONFIG_TEMPLATE="${template_file}" \
     --file nginx/template.Dockerfile \
+    --platform linux/amd64 \
     nginx
 }
 


### PR DESCRIPTION
## What's changing and why?

This change removes the healthcheck endpoints from the frontend and frontend_identity docker images so these can now reach the app containers which serve there own healthchecks.

We also update the publish scripts to be a bit neater and use functions.

See https://github.com/wellcomecollection/wellcomecollection.org/issues/10545 for the motivation for this change.

In order to use this change, we should:

- [x] Build new versions of these container images, these will get pushed [ECR in the platform account](https://eu-west-1.console.aws.amazon.com/ecr/private-registry/repositories?region=eu-west-1).
  - `760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_frontend:b809c6ef4363ff0cbac8da7ff5e80d865cfcd008`
  - `760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_frontend_identity:b809c6ef4363ff0cbac8da7ff5e80d865cfcd008`
- [ ] Update the consuming services reference to the build images, for [the content service and identity (frontend)](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/infrastructure/modules/service/main.tf#L43), (content uses default variables for tag, identity overrides these).
- [ ] Optionally: remove the default references to the old container images from the [terraform-aws-ecs-service](https://github.com/wellcomecollection/terraform-aws-ecs-service/blob/main/modules/nginx/frontend/variables.tf#L23)
  - https://github.com/wellcomecollection/terraform-aws-ecs-service/pull/52

## How to test

- [ ] Update the staging environment for the content and identity services to use the new container image after ensuring the services serve healthcheck endpoints, needs: 
  - https://github.com/wellcomecollection/wellcomecollection.org/pull/10617
  - https://github.com/wellcomecollection/wellcomecollection.org/pull/10612

## How can we measure success?

Healthchecks that really test if the application is running protect us from broken deployments going out, and ensure the application container is really serving requests when marked as healthy.

