### PR TITLE
Add image-builder for required base images (monitoring agents)

### DIFF
--- a/images/dockerfiles/awstoe/Dockerfile
+++ b/images/dockerfiles/awstoe/Dockerfile
@@ -1,0 +1,5 @@
+FROM amazonlinux:2
+
+RUN yum install awscli -y
+ADD https://awstoe-us-east-1.s3.us-east-1.amazonaws.com/latest/linux/arm64/awstoe /usr/local/bin/awstoe
+RUN chmod +x /usr/local/bin/awstoe

--- a/images/dockerfiles/awstoe/README.md
+++ b/images/dockerfiles/awstoe/README.md
@@ -1,0 +1,16 @@
+# AWSTOE 
+
+This image allows the local testing and development of AWS Image Builder components using the [AWS Task Orchestrator and Executor component manager](https://docs.aws.amazon.com/imagebuilder/latest/userguide/toe-component-manager.html).
+
+## Development
+
+Put component YAML in the ./components directory and run `./run.sh` this will start a docker container with `awstoe` installed and give you an interactive shell on that container. Exiting gracefully should stop and clean up the created container.
+
+You can run a component like this:
+
+```console
+awstoe run --trace --documents /components/hello-world.yml --phases build
+```
+
+It will attempt to run the component within the running container image.
+

--- a/images/dockerfiles/awstoe/components/.gitkeep
+++ b/images/dockerfiles/awstoe/components/.gitkeep
@@ -1,0 +1,1 @@
+Use this folder to hold test components

--- a/images/dockerfiles/awstoe/components/hello-world.yml
+++ b/images/dockerfiles/awstoe/components/hello-world.yml
@@ -1,0 +1,10 @@
+"phases":
+- "name": "build"
+  "steps":
+  - "action": "ExecuteBash"
+    "inputs":
+      "commands":
+      - "echo 'hello world' > /tmp/hello-world.txt"
+    "name": "example"
+    "onFailure": "Continue"
+"schemaVersion": 1

--- a/images/dockerfiles/awstoe/docker-compose.yml
+++ b/images/dockerfiles/awstoe/docker-compose.yml
@@ -1,0 +1,11 @@
+# build and start the dockerfile in this folder, keeping it running and mounting a folder to /components
+services:
+  awstoe:
+    build: .
+    command: tail -f /dev/null
+    environment:
+      - AWS_PROFILE=platform-developer
+      - AWS_REGION=eu-west-1
+    volumes:
+      - ./components:/components
+      - ~/.aws:/root/.aws

--- a/images/dockerfiles/awstoe/run.sh
+++ b/images/dockerfiles/awstoe/run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# run the docker-compose file in this folder in the background,
+# then docker exec into the running container called "awstoe-1"
+# interrupting this script will stop the container
+
+export DOCKER_DEFAULT_PLATFORM=linux/x86_64
+CONTAINER_REF=$(docker-compose run --rm -d awstoe)
+
+echo "Container reference: $CONTAINER_REF"
+docker exec -it $CONTAINER_REF /bin/bash && docker-compose stop

--- a/images/terraform/.terraform.lock.hcl
+++ b/images/terraform/.terraform.lock.hcl
@@ -2,8 +2,24 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "4.58.0"
+  version     = "4.67.0"
+  constraints = ">= 4.0.0, < 5.0.0"
   hashes = [
-    "h1:znLROwEAINbYzAG5X7Ep04whM7KxkQGrvhFdhSvNKEk=",
+    "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
   ]
 }

--- a/images/terraform/image-builder.tf
+++ b/images/terraform/image-builder.tf
@@ -7,10 +7,10 @@ data "aws_vpc" "platform_ci" {
 }
 
 locals {
-  image_builder_aws_region        = "eu-west-1"
-  image_builder_vpc_id            = data.aws_vpc.platform_ci.id
-  image_builder_subnet_id         = data.terraform_remote_state.accounts_platform.outputs.ci_vpc_private_subnets[0]
-  image_builder_source_cidr       = [data.aws_vpc.platform_ci.cidr_block]
+  image_builder_aws_region  = "eu-west-1"
+  image_builder_vpc_id      = data.aws_vpc.platform_ci.id
+  image_builder_subnet_id   = data.terraform_remote_state.accounts_platform.outputs.ci_vpc_private_subnets[0]
+  image_builder_source_cidr = [data.aws_vpc.platform_ci.cidr_block]
 
   # Config for ecs-optimised-x86
   ecs-optimised-x86-image_builder_source_ami_filter = "amzn2-ami-ecs-hvm-2.0.*-x86_64-ebs"

--- a/images/terraform/image-builder.tf
+++ b/images/terraform/image-builder.tf
@@ -1,0 +1,63 @@
+resource "aws_s3_bucket" "image-builder" {
+  bucket = "wellcomecollection-imagebuilder"
+}
+
+locals {
+    image_builder_source_ami_filter = "amzn2-ami-ecs-hvm-2.0.*-x86_64-ebs"
+    image_builder_aws_region = "eu-west-1"
+    image_builder_vpc_id   = "SET_THIS_VALUE_FROM_CONFIG"
+    image_builder_subnet_id = "SET_THIS_VALUE_FROM_CONFIG"
+    image_builder_source_cidr = ["SET_THIS_VALUE_FROM_CONFIG"]
+    example_component = {
+        phases = [{
+        name = "build"
+        steps = [{
+            action = "ExecuteBash"
+            inputs = {
+            commands = ["echo 'hello world'"]
+            }
+            name      = "example"
+            onFailure = "Continue"
+        }]
+        }]
+        schemaVersion = 1.0
+  }
+}
+
+resource "aws_s3_object" "example" {
+  bucket = aws_s3_bucket.image-builder.bucket
+  key    = "components/example.yaml"
+  content = yamlencode(local.example_component)
+}
+
+resource "aws_imagebuilder_component" "example" {
+  name     = "example"
+  platform = "Linux"
+  uri      = "s3://${aws_s3_object.example.bucket}/${aws_s3_object.example.key}"
+  version  = "1.0.1"
+
+  depends_on = [ aws_s3_object.example ]
+}
+
+data "aws_ami" "source_ami" {
+  most_recent = true
+  owners      = ["amazon"]
+  filter {
+    name   = "name"
+    values = [local.image_builder_source_ami_filter]
+  }
+}
+
+module "ec2-image-builder" {
+  source              = "./image-builder"
+  name                = "amazon-linux-2-ecs-collection-x86"
+  vpc_id              = local.image_builder_vpc_id
+  subnet_id           = local.image_builder_subnet_id
+  aws_region          = local.image_builder_aws_region
+  source_cidr         = local.image_builder_source_cidr
+  source_ami_id       = data.aws_ami.source_ami.id
+  # ami_name            = "amazon-linux-2-ecs-collection-x86" 
+  # ami_description     = "Wellcome Collection Amazon Linux x86 AMI for ECS" 
+  recipe_version      = "0.0.1"
+  build_component_arn = [aws_imagebuilder_component.example.arn]
+}

--- a/images/terraform/image-builder.tf
+++ b/images/terraform/image-builder.tf
@@ -2,41 +2,48 @@ resource "aws_s3_bucket" "image-builder" {
   bucket = "wellcomecollection-imagebuilder"
 }
 
+data "aws_vpc" "platform_ci" {
+  id = data.terraform_remote_state.accounts_platform.outputs.ci_vpc_id
+}
+
 locals {
-    image_builder_source_ami_filter = "amzn2-ami-ecs-hvm-2.0.*-x86_64-ebs"
-    image_builder_aws_region = "eu-west-1"
-    image_builder_vpc_id   = "SET_THIS_VALUE_FROM_CONFIG"
-    image_builder_subnet_id = "SET_THIS_VALUE_FROM_CONFIG"
-    image_builder_source_cidr = ["SET_THIS_VALUE_FROM_CONFIG"]
-    example_component = {
-        phases = [{
-        name = "build"
-        steps = [{
-            action = "ExecuteBash"
-            inputs = {
-            commands = ["echo 'hello world'"]
-            }
-            name      = "example"
-            onFailure = "Continue"
-        }]
-        }]
-        schemaVersion = 1.0
-  }
+  image_builder_aws_region        = "eu-west-1"
+  image_builder_vpc_id            = data.aws_vpc.platform_ci.id
+  image_builder_subnet_id         = data.terraform_remote_state.accounts_platform.outputs.ci_vpc_private_subnets[0]
+  image_builder_source_cidr       = [data.aws_vpc.platform_ci.cidr_block]
+
+  # Config for ecs-optimised-x86
+  ecs-optimised-x86-image_builder_source_ami_filter = "amzn2-ami-ecs-hvm-2.0.*-x86_64-ebs"
+  ecs-optimised-x86-target_account_ids = [
+    local.account_ids_map["workflow"],
+  ]
 }
 
-resource "aws_s3_object" "example" {
-  bucket = aws_s3_bucket.image-builder.bucket
-  key    = "components/example.yaml"
-  content = yamlencode(local.example_component)
+resource "aws_secretsmanager_secret" "crowdstrike_cid" {
+  name = "image-builder/crowdstrike-cid"
 }
 
-resource "aws_imagebuilder_component" "example" {
-  name     = "example"
+resource "aws_secretsmanager_secret" "qualys_cid" {
+  name = "image-builder/qualys-cid"
+}
+
+resource "aws_secretsmanager_secret" "qualys_aid" {
+  name = "image-builder/qualys-aid"
+}
+
+resource "aws_s3_object" "crowdstrike_agent_component" {
+  bucket  = aws_s3_bucket.image-builder.bucket
+  key     = "components/crowdstrike-agent.yml"
+  content = file("${path.module}/image-builder/components/crowdstrike-agent.yml")
+}
+
+resource "aws_imagebuilder_component" "crowdstrike_agent_component" {
+  name     = "crowdstrike-agent"
   platform = "Linux"
-  uri      = "s3://${aws_s3_object.example.bucket}/${aws_s3_object.example.key}"
-  version  = "1.0.1"
+  uri      = "s3://${aws_s3_bucket.image-builder.bucket}/${aws_s3_object.crowdstrike_agent_component.key}"
+  version  = "1.0.7"
 
-  depends_on = [ aws_s3_object.example ]
+  depends_on = [aws_s3_object.crowdstrike_agent_component]
 }
 
 data "aws_ami" "source_ami" {
@@ -44,20 +51,51 @@ data "aws_ami" "source_ami" {
   owners      = ["amazon"]
   filter {
     name   = "name"
-    values = [local.image_builder_source_ami_filter]
+    values = [local.ecs-optimised-x86-image_builder_source_ami_filter]
   }
 }
 
-module "ec2-image-builder" {
-  source              = "./image-builder"
-  name                = "amazon-linux-2-ecs-collection-x86"
-  vpc_id              = local.image_builder_vpc_id
-  subnet_id           = local.image_builder_subnet_id
-  aws_region          = local.image_builder_aws_region
-  source_cidr         = local.image_builder_source_cidr
-  source_ami_id       = data.aws_ami.source_ami.id
-  # ami_name            = "amazon-linux-2-ecs-collection-x86" 
-  # ami_description     = "Wellcome Collection Amazon Linux x86 AMI for ECS" 
-  recipe_version      = "0.0.1"
-  build_component_arn = [aws_imagebuilder_component.example.arn]
+resource "aws_iam_policy" "image_builder_policy" {
+  name   = "image_builder_custom_policy"
+  policy = data.aws_iam_policy_document.image_builder_policy_document.json
+}
+
+data "aws_iam_policy_document" "image_builder_policy_document" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+    ]
+    resources = [aws_s3_bucket.image-builder.arn,
+    "${aws_s3_bucket.image-builder.arn}/*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+    resources = [
+      aws_secretsmanager_secret.crowdstrike_cid.arn,
+      aws_secretsmanager_secret.qualys_cid.arn,
+      aws_secretsmanager_secret.qualys_aid.arn
+    ]
+  }
+}
+
+module "ec2-image-builder-ecs-optimised-x86" {
+  source               = "./image-builder"
+  name                 = "amazon-linux-2-ecs-collection-x86"
+  vpc_id               = local.image_builder_vpc_id
+  subnet_id            = local.image_builder_subnet_id
+  aws_region           = local.image_builder_aws_region
+  source_cidr          = local.image_builder_source_cidr
+  source_ami_id        = data.aws_ami.source_ami.id
+  ami_name             = "amazon-linux-2-ecs-collection-x86"
+  ami_description      = "Wellcome Collection Amazon Linux x86 AMI for ECS"
+  custom_policy_arn    = aws_iam_policy.image_builder_policy.arn
+  attach_custom_policy = true
+  recipe_version       = "0.0.8"
+  build_component_arn  = [aws_imagebuilder_component.crowdstrike_agent_component.arn]
+  target_account_ids   = local.ecs-optimised-x86-target_account_ids
 }

--- a/images/terraform/image-builder.tf
+++ b/images/terraform/image-builder.tf
@@ -12,13 +12,22 @@ locals {
   image_builder_subnet_id   = data.terraform_remote_state.accounts_platform.outputs.ci_vpc_private_subnets[0]
   image_builder_source_cidr = [data.aws_vpc.platform_ci.cidr_block]
 
-  # Config for ecs-optimised-x86
-  ecs-optimised-x86-image_builder_source_ami_filter = "amzn2-ami-ecs-hvm-2.0.*-x86_64-ebs"
-  ecs-optimised-x86-target_account_ids = [
+  # Config for amzn2-ecs-optimised-hvm-x86_64-ebs
+  amzn2-ecs-optimised-hvm-x86_64-ebs-image_builder_source_ami_filter = "amzn2-ami-ecs-hvm-2.0.*-x86_64-ebs"
+  amzn2-ecs-optimised-hvm-x86_64-ebs-target_account_ids = [
     local.account_ids_map["workflow"],
+    local.account_ids_map["digirati"],
+  ]
+
+  # Config for amzn2-hvm-x86_64-gp2
+  amzn2-hvm-x86_64-gp2-image_builder_source_ami_filter = "amzn2-ami-hvm-2.0.*-x86_64-gp2"
+  amzn2-hvm-x86_64-gp2-target_account_ids = [
+    local.account_ids_map["workflow"],
+    local.account_ids_map["digirati"],
   ]
 }
 
+# secrets needed for image-builder to apply components
 resource "aws_secretsmanager_secret" "crowdstrike_cid" {
   name = "image-builder/crowdstrike-cid"
 }
@@ -31,6 +40,11 @@ resource "aws_secretsmanager_secret" "qualys_aid" {
   name = "image-builder/qualys-aid"
 }
 
+resource "aws_secretsmanager_secret" "qualys_uri" {
+  name = "image-builder/qualys-uri"
+}
+
+# crowdstrike agent
 resource "aws_s3_object" "crowdstrike_agent_component" {
   bucket  = aws_s3_bucket.image-builder.bucket
   key     = "components/crowdstrike-agent.yml"
@@ -46,15 +60,24 @@ resource "aws_imagebuilder_component" "crowdstrike_agent_component" {
   depends_on = [aws_s3_object.crowdstrike_agent_component]
 }
 
-data "aws_ami" "source_ami" {
-  most_recent = true
-  owners      = ["amazon"]
-  filter {
-    name   = "name"
-    values = [local.ecs-optimised-x86-image_builder_source_ami_filter]
-  }
+# qualys agent
+resource "aws_s3_object" "qualys_agent_component" {
+  bucket  = aws_s3_bucket.image-builder.bucket
+  key     = "components/qualys-agent.yml"
+  content = file("${path.module}/image-builder/components/qualys-agent.yml")
 }
 
+resource "aws_imagebuilder_component" "qualys_agent_component" {
+  name     = "qualys-agent"
+  platform = "Linux"
+  uri      = "s3://${aws_s3_bucket.image-builder.bucket}/${aws_s3_object.qualys_agent_component.key}"
+  version  = "1.0.1"
+
+  depends_on = [aws_s3_object.qualys_agent_component]
+}
+
+
+# iam policy for image builder instance
 resource "aws_iam_policy" "image_builder_policy" {
   name   = "image_builder_custom_policy"
   policy = data.aws_iam_policy_document.image_builder_policy_document.json
@@ -78,24 +101,69 @@ data "aws_iam_policy_document" "image_builder_policy_document" {
     resources = [
       aws_secretsmanager_secret.crowdstrike_cid.arn,
       aws_secretsmanager_secret.qualys_cid.arn,
-      aws_secretsmanager_secret.qualys_aid.arn
+      aws_secretsmanager_secret.qualys_aid.arn,
+      aws_secretsmanager_secret.qualys_uri.arn,
     ]
   }
 }
 
-module "ec2-image-builder-ecs-optimised-x86" {
+
+# amzn2-ecs-optimised-hvm-x86_64-ebs
+data "aws_ami" "amzn2-ecs-optimised-hvm-x86_64-ebs" {
+  most_recent = true
+  owners      = ["amazon"]
+  filter {
+    name   = "name"
+    values = [local.amzn2-ecs-optimised-hvm-x86_64-ebs-image_builder_source_ami_filter]
+  }
+}
+
+module "ec2-image-builder-amzn2-ecs-optimised-hvm-x86_64-ebs" {
   source               = "./image-builder"
-  name                 = "amazon-linux-2-ecs-collection-x86"
+  name                 = "weco-amzn2-ecs-optimised-hvm-x86_64"
   vpc_id               = local.image_builder_vpc_id
   subnet_id            = local.image_builder_subnet_id
   aws_region           = local.image_builder_aws_region
   source_cidr          = local.image_builder_source_cidr
-  source_ami_id        = data.aws_ami.source_ami.id
-  ami_name             = "amazon-linux-2-ecs-collection-x86"
-  ami_description      = "Wellcome Collection Amazon Linux x86 AMI for ECS"
+  source_ami_id        = data.aws_ami.amzn2-ecs-optimised-hvm-x86_64-ebs.id
+  ami_name             = "weco-amzn2-ecs-optimised-hvm-x86_64"
+  ami_description      = "Wellcome Collection: Amazon Linux 2, ECS Optimised, HVM, x86_64, GP2"
   custom_policy_arn    = aws_iam_policy.image_builder_policy.arn
   attach_custom_policy = true
-  recipe_version       = "0.0.8"
-  build_component_arn  = [aws_imagebuilder_component.crowdstrike_agent_component.arn]
-  target_account_ids   = local.ecs-optimised-x86-target_account_ids
+  recipe_version       = "1.0.1"
+  build_component_arn  = [
+    aws_imagebuilder_component.crowdstrike_agent_component.arn,
+    aws_imagebuilder_component.qualys_agent_component.arn,
+  ]
+  target_account_ids   = local.amzn2-ecs-optimised-hvm-x86_64-ebs-target_account_ids
+}
+
+# amzn2-hvm-x86_64-gp2
+data "aws_ami" "amzn2-hvm-x86_64-gp2" {
+  most_recent = true
+  owners      = ["amazon"]
+  filter {
+    name   = "name"
+    values = [local.amzn2-hvm-x86_64-gp2-image_builder_source_ami_filter]
+  }
+}
+
+module "ec2-image-builder-amzn2-hvm-x86_64-gp2" {
+  source               = "./image-builder"
+  name                 = "weco-amzn2-hvm-x86_64-gp2"
+  vpc_id               = local.image_builder_vpc_id
+  subnet_id            = local.image_builder_subnet_id
+  aws_region           = local.image_builder_aws_region
+  source_cidr          = local.image_builder_source_cidr
+  source_ami_id        = data.aws_ami.amzn2-hvm-x86_64-gp2.id
+  ami_name             = "weco-amzn2-hvm-x86_64-gp2"
+  ami_description      = "Wellcome Collection: Amazon Linux 2, HVM, x86_64, GP2"
+  custom_policy_arn    = aws_iam_policy.image_builder_policy.arn
+  attach_custom_policy = true
+  recipe_version       = "1.0.1"
+  build_component_arn  = [
+    aws_imagebuilder_component.crowdstrike_agent_component.arn,
+    aws_imagebuilder_component.qualys_agent_component.arn,
+  ]  
+  target_account_ids   = local.amzn2-hvm-x86_64-gp2-target_account_ids
 }

--- a/images/terraform/image-builder.tf
+++ b/images/terraform/image-builder.tf
@@ -131,11 +131,11 @@ module "ec2-image-builder-amzn2-ecs-optimised-hvm-x86_64-ebs" {
   custom_policy_arn    = aws_iam_policy.image_builder_policy.arn
   attach_custom_policy = true
   recipe_version       = "1.0.1"
-  build_component_arn  = [
+  build_component_arn = [
     aws_imagebuilder_component.crowdstrike_agent_component.arn,
     aws_imagebuilder_component.qualys_agent_component.arn,
   ]
-  target_account_ids   = local.amzn2-ecs-optimised-hvm-x86_64-ebs-target_account_ids
+  target_account_ids = local.amzn2-ecs-optimised-hvm-x86_64-ebs-target_account_ids
 }
 
 # amzn2-hvm-x86_64-gp2
@@ -161,9 +161,9 @@ module "ec2-image-builder-amzn2-hvm-x86_64-gp2" {
   custom_policy_arn    = aws_iam_policy.image_builder_policy.arn
   attach_custom_policy = true
   recipe_version       = "1.0.1"
-  build_component_arn  = [
+  build_component_arn = [
     aws_imagebuilder_component.crowdstrike_agent_component.arn,
     aws_imagebuilder_component.qualys_agent_component.arn,
-  ]  
-  target_account_ids   = local.amzn2-hvm-x86_64-gp2-target_account_ids
+  ]
+  target_account_ids = local.amzn2-hvm-x86_64-gp2-target_account_ids
 }

--- a/images/terraform/image-builder/components/crowdstrike-agent.yml
+++ b/images/terraform/image-builder/components/crowdstrike-agent.yml
@@ -1,0 +1,41 @@
+---
+schemaVersion: 1
+phases:
+  -
+    name: 'build'
+    steps:
+      - 
+        name: DownloadAgent
+        action: S3Download
+        timeoutSeconds: 60
+        onFailure: Abort
+        maxAttempts: 3
+        inputs:
+          -
+            source: 's3://wellcomecollection-imagebuilder/assets/falcon-agent.rpm'
+            destination: '/tmp/falcon-agent.rpm'
+  
+      - 
+        name: InstallAgentWithDeps
+        action: ExecuteBash
+        inputs:
+          commands:
+            - sudo yum install awscli libnl -y
+            - sudo yum install /tmp/falcon-agent.rpm -y
+
+      - 
+        name: ConfigureAgent
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              CID=$(aws secretsmanager get-secret-value \
+                  --secret-id image-builder/crowdstrike-cid \
+                  --region eu-west-1 \
+                  --query "SecretString" \
+                  --output=text)
+              # Setup the CrowdStrike agent
+              sudo /opt/CrowdStrike/falconctl -s --cid=$CID
+              # Start the CrowdStrike agent
+              sudo systemctl start falcon-sensor
+              

--- a/images/terraform/image-builder/components/qualys-agent.yml
+++ b/images/terraform/image-builder/components/qualys-agent.yml
@@ -1,0 +1,51 @@
+---
+schemaVersion: 1
+phases:
+  -
+    name: 'build'
+    steps:
+      - 
+        name: DownloadAgent
+        action: S3Download
+        timeoutSeconds: 60
+        onFailure: Abort
+        maxAttempts: 3
+        inputs:
+          -
+            source: 's3://wellcomecollection-imagebuilder/assets/qualys-agent.rpm'
+            destination: '/tmp/qualys-agent.rpm'
+  
+      - 
+        name: InstallAgentWithDeps
+        action: ExecuteBash
+        inputs:
+          commands:
+            - sudo yum install /tmp/qualys-agent.rpm -y
+
+      - 
+        name: ConfigureAgent
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              CID=$(aws secretsmanager get-secret-value \
+                  --secret-id image-builder/qualys-cid \
+                  --region eu-west-1 \
+                  --query "SecretString" \
+                  --output=text)
+              AID=$(aws secretsmanager get-secret-value \
+                  --secret-id image-builder/qualys-aid \
+                  --region eu-west-1 \
+                  --query "SecretString" \
+                  --output=text)
+              URI=$(aws secretsmanager get-secret-value \
+                  --secret-id image-builder/qualys-uri \
+                  --region eu-west-1 \
+                  --query "SecretString" \
+                  --output=text)
+              # Setup the Qualys agent
+              sudo /usr/local/qualys/cloud-agent/bin/qualys-cloud-agent.sh \
+                ActivationId=$AID \
+                CustomerId=$CID \
+                ServerUri=$URI
+              

--- a/images/terraform/image-builder/distribution_configuration.tf
+++ b/images/terraform/image-builder/distribution_configuration.tf
@@ -1,0 +1,18 @@
+resource "aws_imagebuilder_distribution_configuration" "imagebuilder_distribution_configuration" {
+  count = length(var.target_account_ids) > 0 ? 1 : 0
+  name  = "${var.name}-distribution"
+
+  distribution {
+    region = var.aws_region
+    ami_distribution_configuration {
+      name               = "${var.ami_name}-{{ imagebuilder:buildDate }}"
+      description        = var.ami_description
+      target_account_ids = var.target_account_ids
+      launch_permission {
+        user_ids = var.target_account_ids
+      }
+      ami_tags = var.tags
+    }
+  }
+  tags = var.tags
+}

--- a/images/terraform/image-builder/iam_role.tf
+++ b/images/terraform/image-builder/iam_role.tf
@@ -25,7 +25,7 @@ resource "aws_iam_role_policy_attachment" "ssm" {
 }
 
 resource "aws_iam_instance_profile" "iam_instance_profile" {
-  name = "EC2InstanceProfileImageBuilder"
+  name = "${var.name}-EC2InstanceProfileImageBuilder"
   role = aws_iam_role.awsserviceroleforimagebuilder.name
 }
 

--- a/images/terraform/image-builder/iam_role.tf
+++ b/images/terraform/image-builder/iam_role.tf
@@ -1,0 +1,63 @@
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "awsserviceroleforimagebuilder" {
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+  name               = "${var.name}-role"
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "imagebuilder" {
+  policy_arn = "arn:aws:iam::aws:policy/EC2InstanceProfileForImageBuilder"
+  role       = aws_iam_role.awsserviceroleforimagebuilder.name
+}
+resource "aws_iam_role_policy_attachment" "ssm" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  role       = aws_iam_role.awsserviceroleforimagebuilder.name
+}
+
+resource "aws_iam_instance_profile" "iam_instance_profile" {
+  name = "EC2InstanceProfileImageBuilder"
+  role = aws_iam_role.awsserviceroleforimagebuilder.name
+}
+
+resource "aws_iam_role_policy_attachment" "custom_policy" {
+  count      = var.attach_custom_policy ? 1 : 0
+  policy_arn = var.custom_policy_arn
+  role       = aws_iam_role.awsserviceroleforimagebuilder.name
+}
+
+resource "aws_iam_role_policy" "aws_policy" {
+  name   = "${var.name}-aws-access"
+  role   = aws_iam_role.awsserviceroleforimagebuilder.id
+  policy = data.aws_iam_policy_document.aws_policy.json
+}
+
+data "aws_iam_policy_document" "aws_policy" {
+  statement {
+    effect    = "Allow"
+    actions   = ["sts:AssumeRole"]
+    resources = ["arn:aws:iam::*:role/EC2ImageBuilderDistributionCrossAccountRole"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2messages:GetMessages",
+      "ec2:MetadataHttpEndpoint",
+      "ec2:MetadataHttpPutResponseHopLimit",
+      "ec2:MetadataHttpTokens",
+      "ssm:SendCommand"
+    ]
+    resources = ["*"]
+  }
+
+}

--- a/images/terraform/image-builder/image.tf
+++ b/images/terraform/image-builder/image.tf
@@ -1,0 +1,12 @@
+resource "aws_imagebuilder_image" "imagebuilder_image" {
+  count                            = 1
+  image_recipe_arn                 = aws_imagebuilder_image_recipe.imagebuilder_image_recipe.arn
+  infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.imagebuilder_infrastructure_configuration.arn
+  distribution_configuration_arn   = try(aws_imagebuilder_distribution_configuration.imagebuilder_distribution_configuration[count.index].arn, null)
+
+  tags = var.tags
+
+  timeouts {
+    create = var.timeout
+  }
+}

--- a/images/terraform/image-builder/image_pipeline.tf
+++ b/images/terraform/image-builder/image_pipeline.tf
@@ -1,0 +1,14 @@
+resource "aws_imagebuilder_image_pipeline" "imagebuilder_image_pipeline" {
+  image_recipe_arn                 = aws_imagebuilder_image_recipe.imagebuilder_image_recipe.arn
+  infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.imagebuilder_infrastructure_configuration.arn
+  distribution_configuration_arn   = null
+  dynamic "schedule" {
+    for_each = try(var.schedule_expression, tomap({}))
+    content {
+      schedule_expression                = schedule.key
+      pipeline_execution_start_condition = schedule.value
+    }
+  }
+  name = "${var.name}-pipeline"
+  tags = var.tags
+}

--- a/images/terraform/image-builder/image_recipe.tf
+++ b/images/terraform/image-builder/image_recipe.tf
@@ -2,18 +2,6 @@ resource "aws_imagebuilder_image_recipe" "imagebuilder_image_recipe" {
   name         = "${var.name}-image-recipe"
   parent_image = var.source_ami_id
   version      = var.recipe_version
-  
-  # it seems there is a bug on checkov for check CKV_AWS_200, even supressing it doesn't help, had to add the below block_device_mapping to pass
-#   block_device_mapping {
-#     device_name = "/dev/xvdb"
-
-#     ebs {
-#       delete_on_termination = true
-#       volume_size           = var.recipe_volume_size
-#       volume_type           = var.recipe_volume_type
-#       encrypted             = true
-#     }
-#   }
 
   lifecycle {
     create_before_destroy = true

--- a/images/terraform/image-builder/image_recipe.tf
+++ b/images/terraform/image-builder/image_recipe.tf
@@ -1,0 +1,30 @@
+resource "aws_imagebuilder_image_recipe" "imagebuilder_image_recipe" {
+  name         = "${var.name}-image-recipe"
+  parent_image = var.source_ami_id
+  version      = var.recipe_version
+  
+  # it seems there is a bug on checkov for check CKV_AWS_200, even supressing it doesn't help, had to add the below block_device_mapping to pass
+#   block_device_mapping {
+#     device_name = "/dev/xvdb"
+
+#     ebs {
+#       delete_on_termination = true
+#       volume_size           = var.recipe_volume_size
+#       volume_type           = var.recipe_volume_type
+#       encrypted             = true
+#     }
+#   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  dynamic "component" {
+    for_each = var.build_component_arn
+    content {
+      component_arn = component.value
+    }
+  }
+
+  tags = var.tags
+}

--- a/images/terraform/image-builder/infrastructure_configuration.tf
+++ b/images/terraform/image-builder/infrastructure_configuration.tf
@@ -1,0 +1,12 @@
+resource "aws_imagebuilder_infrastructure_configuration" "imagebuilder_infrastructure_configuration" {
+  instance_profile_name = aws_iam_instance_profile.iam_instance_profile.name
+  instance_types        = var.instance_types
+
+  name               = "${var.name}-infrastructure-configuration"
+  security_group_ids = [aws_security_group.security_group.id]
+  subnet_id          = var.subnet_id
+
+  terminate_instance_on_failure = var.terminate_on_failure
+  resource_tags                 = var.tags
+  tags                          = var.tags
+}

--- a/images/terraform/image-builder/security_group.tf
+++ b/images/terraform/image-builder/security_group.tf
@@ -1,0 +1,37 @@
+resource "aws_security_group" "security_group" {
+  name        = "${var.name}-sg"
+  description = "Security Group for for the EC2 Image Builder Build Instances"
+  vpc_id      = var.vpc_id
+
+  tags = var.tags
+}
+
+resource "aws_security_group_rule" "sg_https_ingress" {
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = var.source_cidr
+  security_group_id = aws_security_group.security_group.id
+  description       = "HTTPS from VPC"
+}
+
+resource "aws_security_group_rule" "sg_rdp_ingress" {
+  type              = "ingress"
+  from_port         = 3389
+  to_port           = 3389
+  protocol          = "tcp"
+  cidr_blocks       = var.source_cidr
+  security_group_id = aws_security_group.security_group.id
+  description       = "RDP from the source variable CIDR"
+}
+
+resource "aws_security_group_rule" "sg_internet_egress" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "all"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.security_group.id
+  description       = "Access to the internet"
+}

--- a/images/terraform/image-builder/variables.tf
+++ b/images/terraform/image-builder/variables.tf
@@ -76,18 +76,6 @@ variable "recipe_version" {
   default     = "0.0.1"
 }
 
-# variable "recipe_volume_size" {
-#   default     = 100
-#   description = "(Optional) Volume Size of Imagebuilder Image Recipe Block Device Mapping"
-#   type        = string
-# }
-
-# variable "recipe_volume_type" {
-#   default     = "gp3"
-#   description = "(Optional) Volume Type of Imagebuilder Image Recipe Block Device Mapping"
-#   type        = string
-# }
-
 variable "build_component_arn" {
   type        = list(string)
   description = "(Required) List of ARNs for the Build EC2 Image Builder Build Components"
@@ -97,4 +85,26 @@ variable "build_component_arn" {
 variable "source_ami_id" {
   type        = string
   description = "(Required) The ID of the source AMI"
+}
+
+variable "ami_name" {
+  type        = string
+  description = "(Required) The name of the AMI"
+}
+
+variable "ami_description" {
+  type        = string
+  description = "(Required) The description of the AMI"
+}
+
+variable "timeout" {
+  type        = string
+  description = "(Optional) Number of hours before image time out. Defaults to 2h. "
+  default     = "2h"
+}
+
+variable "target_account_ids" {
+  description = "The list of AWS accounts to share the AMI with"
+  type        = list(string)
+  default     = []
 }

--- a/images/terraform/image-builder/variables.tf
+++ b/images/terraform/image-builder/variables.tf
@@ -1,0 +1,100 @@
+variable "name" {
+  type        = string
+  description = "(Required) Name of the image-builder"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "(Required) VPC ID to deploy the EC2 Image Builder Environment."
+}
+
+variable "aws_region" {
+  type        = string
+  description = "(Required) AWS Region to deploy the resources"
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "(Required) Subnet ID to deploy the EC2 Image Builder Environment."
+}
+
+variable "source_cidr" {
+  type        = list(string)
+  description = "(Required) Source CIDR block which will be allowed to RDP or SSH to EC2 Image Builder Instances"
+}
+
+variable "tags" {
+  description = "(Optional) A map of resource tags to associate with the resource"
+  type        = map(string)
+  default     = {}
+}
+
+variable "attach_custom_policy" {
+  type        = bool
+  description = "(Required) Attach custom policy to the EC2 Instance Profile, if true, ARN of the custom policy needs to be specified on the variable custom_policy_arn"
+  default     = false
+}
+
+variable "custom_policy_arn" {
+  type        = string
+  description = "(Optional) ARN of the custom policy to be attached to the EC2 Instance Profile"
+  default     = null
+}
+
+variable "instance_types" {
+  type        = list(string)
+  description = <<-EOD
+  (Optional) Instance type for the EC2 Image Builder Instances. 
+  Will be set by default to c5.large. Please check the AWS Pricing for more information about the instance types.
+  EOD
+  default     = ["c5.large"]
+}
+
+variable "terminate_on_failure" {
+  default     = true
+  description = "(Optional) Change to false if you want to connect to a builder for debugging after failure"
+  type        = bool
+}
+
+variable "schedule_expression" {
+  type = list(object({
+    pipeline_execution_start_condition = string,
+    scheduleExpression                 = string
+  }))
+  description = <<-EOD
+  "(Optional) pipeline_execution_start_condition = The condition configures when the pipeline should trigger a new image build. 
+  Valid Values: EXPRESSION_MATCH_ONLY | EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE
+  scheduleExpression = The cron expression determines how often EC2 Image Builder evaluates your pipelineExecutionStartCondition.
+  e.g.:  "cron(0 0 * * ? *)"
+  EOD
+  default     = []
+}
+
+variable "recipe_version" {
+  type        = string
+  description = "(Required) The semantic version of the image recipe. This version follows the semantic version syntax. e.g.: 0.0.1"
+  default     = "0.0.1"
+}
+
+# variable "recipe_volume_size" {
+#   default     = 100
+#   description = "(Optional) Volume Size of Imagebuilder Image Recipe Block Device Mapping"
+#   type        = string
+# }
+
+# variable "recipe_volume_type" {
+#   default     = "gp3"
+#   description = "(Optional) Volume Type of Imagebuilder Image Recipe Block Device Mapping"
+#   type        = string
+# }
+
+variable "build_component_arn" {
+  type        = list(string)
+  description = "(Required) List of ARNs for the Build EC2 Image Builder Build Components"
+  default     = []
+}
+
+variable "source_ami_id" {
+  type        = string
+  description = "(Required) The ID of the source AMI"
+}

--- a/images/terraform/locals.tf
+++ b/images/terraform/locals.tf
@@ -1,4 +1,4 @@
-locals {  
+locals {
   account_ids_map = {
     "catalogue"    = "756629837203"
     "platform"     = "760097843905"

--- a/images/terraform/locals.tf
+++ b/images/terraform/locals.tf
@@ -1,14 +1,17 @@
-locals {
-  account_ids = [
-    "756629837203", // catalogue_account_id
-    "760097843905", // platform_account_id
-    "975596993436", // storage_account_id
-    "299497370133", // workflow_account_id
-    "130871440101", // experience_account_id
-    "653428163053", // digirati_account_id
-    "770700576653", // identity_account_id
-    "964279923020", // data science account ID
-  ]
+locals {  
+  account_ids_map = {
+    "catalogue"    = "756629837203"
+    "platform"     = "760097843905"
+    "storage"      = "975596993436"
+    "workflow"     = "299497370133"
+    "experience"   = "130871440101"
+    "digirati"     = "653428163053"
+    "identity"     = "770700576653"
+    "data_science" = "964279923020"
+  }
+
+  # list of accoubnt ids from the above map
+  account_ids = values(local.account_ids_map)
 
   namespace = "uk.ac.wellcome"
 }

--- a/images/terraform/terraform.tf
+++ b/images/terraform/terraform.tf
@@ -32,3 +32,15 @@ provider "aws" {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
   }
 }
+
+data "terraform_remote_state" "accounts_platform" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/aws-account-infrastructure/platform.tfstate"
+    region = "eu-west-1"
+  }
+}


### PR DESCRIPTION
## What's changing and why?

This change attempts to provision an AWS image-builder pipeline to install necessary agents on our EC2 instances as part of a base AMI.

See: https://github.com/wellcomecollection/platform-infrastructure/issues/410

Borrows heavily from: https://github.com/aws-ia/terraform-aws-ec2-image-builder

## How to test?

Run the image builder pipeline by doing `terraform apply`, an image should be successfully built and distributed.

## How can we measure success?

Our EC2 instances can easily and repeatably be kept up to date with security / monitoring requirements as well as ensuring we reduce our security risk by keeping our images up to date.
