### PR TITLE
Update the alert description filter

### DIFF
--- a/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
+++ b/monitoring/slack_alerts/auth0_log_stream_alert/src/auth0_log_stream_alert.py
@@ -167,7 +167,7 @@ def should_alert_for_event(log_event):
         "f": [
             "You may have pressed the back button",
             "PIN is not valid : PIN is trivial",
-            "Missing required parameter: response type",
+            "Missing required parameter: response_type",
             "Unauthorized",
         ],
 


### PR DESCRIPTION

## What's changing and why?

The alert description filter for "Missing required parameter: response_type" was missing the underscore, this adds it.

See the description being output in Slack:
<img width="387" alt="Screenshot 2024-03-04 at 16 35 27" src="https://github.com/wellcomecollection/platform-infrastructure/assets/953792/a915b6ad-81d0-4b09-9538-8ac07dc87893">

## `terraform plan` diff

```console
module.auth0_log_stream_alerts.module.auth0_log_stream_alerts.module.lambda.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "identity_auth0_log_stream_alerts"
      ~ last_modified                  = "2024-02-19T09:47:52.000+0000" -> (known after apply)
      ~ source_code_hash               = "MXCUFp/ZwKdgUMRnlvR0oQheEaFzTpJfyRiAunJX7cw=" -> "dBIBz3ywIXiFJhxefEB++XIV7XOXTTRif4I+Je4Bu5A="
        tags                           = {}
        # (21 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
> [!NOTE]
> This change is applied.
