### PR TITLE
Remove alpine from sbt_wrapper

### DIFF
--- a/images/dockerfiles/sbt_wrapper/Dockerfile
+++ b/images/dockerfiles/sbt_wrapper/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre
 
 LABEL maintainer = "Wellcome Collection <dev@wellcomecollection.org>"
 LABEL description = "A Docker image for running SBT"
@@ -8,7 +8,8 @@ ARG SBT_VERSION=1.4.1
 ENV SBT_HOME /usr/local/sbt
 ENV PATH ${PATH}:${SBT_HOME}/bin
 
-RUN apk add --no-cache rsync bash docker-cli docker-compose
+RUN apt-get update
+RUN apt-get install -y rsync bash docker docker-compose
 
 COPY install_sbt.sh /
 RUN /install_sbt.sh

--- a/images/dockerfiles/sbt_wrapper/install_sbt.sh
+++ b/images/dockerfiles/sbt_wrapper/install_sbt.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o nounset
 
-apk add --no-cache curl
+apt-get install -y curl
 
 curl --location "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" \
   | gunzip \
@@ -35,5 +35,3 @@ echo "export COURSIER_DIR=$COURSIER_DIR" > ~/.env.sh
 # and after we've mounted the host caches.
 mv ~/.sbt ~/.sbt.image
 mv $COURSIER_DIR $COURSIER_DIR.image
-
-apk del curl


### PR DESCRIPTION
## What's changing and why?

This change moves from using an alpine os version of sbt-wrapper, to using the slightly larger dependencies included ubuntu version.

We've seen places where tests fail because there are missing dependencies. This change resolves that issue at the cost of increased data transfer in CI.

See: https://buildkite.com/wellcomecollection/storage-service/builds/1748#018ee239-8e8c-4f39-b46a-7e8009748236/183-550

The new container image reports:
```
root@61480c352c5a:/repo# uname -a
Linux 61480c352c5a 6.6.16-linuxkit #1 SMP Fri Feb 16 11:54:02 UTC 2024 aarch64 aarch64 aarch64 GNU/Linux
root@61480c352c5a:/repo# cat /etc/
Display all 107 possibilities? (y or n)
root@61480c352c5a:/repo# cat /etc/o
opt/        os-release
root@61480c352c5a:/repo# cat /etc/os-release
PRETTY_NAME="Ubuntu 22.04.4 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.4 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
root@61480c352c5a:/repo# exit
```

> [!NOTE]
> This is currently pushed with the tag `760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/sbt_wrapper:no_alpine`. We should test this in projects outside the storage service and then push it to untagged to be picked up generally by all projects that use this in CI to run scala tests.