### PR TITLE
optional chaining in case query is not defined/null

### DIFF
--- a/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.js
+++ b/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.js
@@ -305,7 +305,7 @@ function isInterestingError(hit) {
   // avoid dropping errors from legitimate queries.
   if (
     hit.status === 503 &&
-    (hit.query.split('%C3').length > 70 || hit.query.split('%25C2').length > 80)
+    (hit.query?.split('%C3').length > 70 || hit.query?.split('%25C2').length > 80)
   ) {
     return false;
   }


### PR DESCRIPTION
## What's changing and why?

We've seen [errors](https://wellcome.slack.com/archives/CQ720BG02/p1720597318517099) in this lambda, which should be fixed by this addition of optional chaining in case `query` is `null`

## `terraform plan` diff
```
Terraform will perform the following actions:

  # module.slack_alerts_for_5xx.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "send_slack_alert_for_5xx_errors"
      ~ last_modified                  = "2024-05-03T08:25:21.000+0000" -> (known after apply)
      ~ source_code_hash               = "Oq9I+XxfJXbNIs2Af3laOK5mksm6C/gzV4zRdDFQyQ4=" -> "Muyhd941OhW1yIHHSbtKNyrHywvymTj0LntBt9NxVsE="
        tags                           = {}
        # (27 unchanged attributes hidden)

        # (5 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
