### PR TITLE
Digitisation lambda logging

### DIFF
--- a/cloudfront/api.wellcomecollection.org/.terraform.lock.hcl
+++ b/cloudfront/api.wellcomecollection.org/.terraform.lock.hcl
@@ -5,6 +5,18 @@ provider "registry.terraform.io/hashicorp/archive" {
   version = "2.3.0"
   hashes = [
     "h1:pTPG9Kf1Qg2aPsZLXDa6OvLqsEXaMrKnp0Z4Q/TIBPA=",
+    "zh:0869128d13abe12b297b0cd13b8767f10d6bf047f5afc4215615aabc39c2eb4f",
+    "zh:481ed837d63ba3aa45dd8736da83e911e3509dee0e7961bf5c00ed2644f807b3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9f08fe2977e2166849be24fb9f394e4d2697414d463f7996fd0d7beb4e19a29c",
+    "zh:9fe566deeafd460d27999ca0bbfd85426a5fcfcb40007b23884deb76da127b6f",
+    "zh:a1bd9a60925d9769e0da322e4523330ee86af9dc2e770cba1d0247a999ef29cb",
+    "zh:bb4094c8149f74308b22a87e1ac19bcccca76e8ef021b571074d9bccf1c0c6f0",
+    "zh:c8984c9def239041ce41ec8e19bbd76a49e74ed2024ff736dad60429dee89bcc",
+    "zh:ea4bb5ae73db1de3a586e62f39106f5e56770804a55aa5e6b4f642df973e0e75",
+    "zh:f44a9d596ecc3a8c5653f56ba0cd202ad93b49f76767f4608daf7260b813289e",
+    "zh:f5c5e6cc9f7f070020ab7d95fcc9ed8e20d5cf219978295a71236e22cbb6d508",
+    "zh:fd2273f51dcc8f43403bf1e425ba9db08a57c3ddcba5ad7a51742ccde21ca611",
   ]
 }
 

--- a/critical/.terraform.lock.hcl
+++ b/critical/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/elastic/ec" {
   constraints = "0.5.0"
   hashes = [
     "h1:4BiRazUuyKHramn/5a7QwhXK5lbVxEQ1FzC2fZN8FYA=",
+    "h1:A93bvjVkPuRuRgG68pMAB5kTzD1JdqZe6I0XKctz4xE=",
     "zh:1b0bf155960e1aaccf59359080ca30bf5ae44d5d46c47d9834fc343971edd798",
     "zh:24ae7fc6becf3a6f5dedf0871223a4dd3c46ab4166dc0c2148cb05cff2157786",
     "zh:4091ad8ed4c6dfaa28cc0f5c1187ab17320f1b55966e2aa25cb832fe09b52eec",
@@ -27,6 +28,7 @@ provider "registry.terraform.io/elastic/elasticstack" {
   version     = "0.5.0"
   constraints = "0.5.0"
   hashes = [
+    "h1:Nct0wXq7GL2YzXI4elB7nsauBhlkSUtMi9BKLl9wKU0=",
     "h1:jmMnCZXvaxPl779fSnekUODXHPMwqXKTNPC98kfoudk=",
     "zh:0d28448ed2332977eaeb782f66c55c5ed35b50b171bd61d576e0232647bcd75a",
     "zh:1af52279ca0213873f2d5f30cbdabf131b6a07257c015e8fcaf8900dd7b302ea",
@@ -49,6 +51,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "5.30.0"
   hashes = [
     "h1:ZsaqSoi0hx+GXUK1AaCwoHx+XYgiZY2JZX2UZ6kVvH4=",
+    "h1:sqLVPs9SeQR+ZPMJXR+ni5zdPrXjmSbli6AZZXJw/kI=",
     "zh:0ac576f2278c6d3fead05fbb136df87e399ec065edeef56c054fa2f3ac465390",
     "zh:1ef592d293cac2f35c37c4d23cb5f9e8b34713e24585cedaf5874d024712d9fd",
     "zh:21d8412d5cec5e7e9a2199089d95287c5882f4db0e3b820e4f7760242bfa83b2",
@@ -72,6 +75,7 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = "3.4.3"
   hashes = [
     "h1:saZR+mhthL0OZl4SyHXZraxyaBNVMxiZzks78nWcZ2o=",
+    "h1:tL3katm68lX+4lAncjQA9AXL4GR/VM+RPwqYf4D2X8Q=",
     "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
     "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
     "zh:686ad1ee40b812b9e016317e7f34c0d63ef837e084dea4a1f578f64a6314ad53",

--- a/critical/lambda_logging.tf
+++ b/critical/lambda_logging.tf
@@ -113,3 +113,11 @@ resource "aws_ssm_parameter" "log_destination_arn_workflow" {
   type  = "String"
   value = module.kinesis_log_destination.cloudwatch_log_destination.arn
 }
+
+resource "aws_ssm_parameter" "log_destination_arn_digitisation" {
+  provider = aws.digitisation
+
+  name  = local.log_destination_parameter_name
+  type  = "String"
+  value = module.kinesis_log_destination.cloudwatch_log_destination.arn
+}

--- a/critical/locals.tf
+++ b/critical/locals.tf
@@ -24,6 +24,7 @@ locals {
     reporting  = data.aws_caller_identity.reporting.account_id
     storage    = data.aws_caller_identity.storage.account_id
     workflow   = data.aws_caller_identity.workflow.account_id
+    digitisation   = data.aws_caller_identity.digitisation.account_id
   }
 
   default_tags = {
@@ -36,6 +37,9 @@ data "aws_caller_identity" "catalogue" {
 }
 data "aws_caller_identity" "digirati" {
   provider = aws.digirati
+}
+data "aws_caller_identity" "digitisation" {
+  provider = aws.digitisation
 }
 data "aws_caller_identity" "experience" {
   provider = aws.experience

--- a/critical/locals.tf
+++ b/critical/locals.tf
@@ -17,14 +17,14 @@ locals {
   aws_region = "eu-west-1"
 
   account_ids = {
-    catalogue  = data.aws_caller_identity.catalogue.account_id
-    digirati   = data.aws_caller_identity.digirati.account_id
-    experience = data.aws_caller_identity.experience.account_id
-    identity   = data.aws_caller_identity.identity.account_id
-    reporting  = data.aws_caller_identity.reporting.account_id
-    storage    = data.aws_caller_identity.storage.account_id
-    workflow   = data.aws_caller_identity.workflow.account_id
-    digitisation   = data.aws_caller_identity.digitisation.account_id
+    catalogue    = data.aws_caller_identity.catalogue.account_id
+    digirati     = data.aws_caller_identity.digirati.account_id
+    experience   = data.aws_caller_identity.experience.account_id
+    identity     = data.aws_caller_identity.identity.account_id
+    reporting    = data.aws_caller_identity.reporting.account_id
+    storage      = data.aws_caller_identity.storage.account_id
+    workflow     = data.aws_caller_identity.workflow.account_id
+    digitisation = data.aws_caller_identity.digitisation.account_id
   }
 
   default_tags = {

--- a/critical/provider.tf
+++ b/critical/provider.tf
@@ -127,6 +127,19 @@ provider "aws" {
 }
 
 provider "aws" {
+  alias  = "digitisation"
+  region = "eu-west-1"
+
+  default_tags {
+    tags = local.default_tags
+  }
+
+  assume_role {
+    role_arn = "arn:aws:iam::404315009621:role/digitisation-developer"
+  }
+}
+
+provider "aws" {
   alias  = "reporting"
   region = "eu-west-1"
 


### PR DESCRIPTION
## What's changing and why?

This adds the log forwarder SSM parameter to the digitisation account and updates kinesis in the platform account so that digitisation Lambdas can forward logs to our common logging platform


## `terraform plan` diff
```
  # aws_ssm_parameter.log_destination_arn_digitisation will be created
  + resource "aws_ssm_parameter" "log_destination_arn_digitisation" {
      + arn            = (known after apply)
      + data_type      = (known after apply)
      + id             = (known after apply)
      + insecure_value = (known after apply)
      + key_id         = (known after apply)
      + name           = "/logging/forwarder/destination_arn"
      + tags_all       = {
          + "TerraformConfigurationURL" = "https://github.com/wellcomecollection/platform-infrastructure/tree/main/critical"
        }
      + tier           = (known after apply)
      + type           = "String"
      + value          = (sensitive value)
      + version        = (known after apply)
    }

  # module.kinesis_log_destination.aws_cloudwatch_log_destination_policy.cross_account_subscriptions will be updated in-place
  ~ resource "aws_cloudwatch_log_destination_policy" "cross_account_subscriptions" {
      ~ access_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Principal = {
                          ~ AWS = [
                                # (4 unchanged elements hidden)
                                "653428163053",
                              + "404315009621",
                                "299497370133",
                                # (2 unchanged elements hidden)
                            ]
                        }
                      - Sid       = ""
                        # (3 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        id               = "elasticsearch-forwarder-logs"
        # (1 unchanged attribute hidden)
    }

  # module.kinesis_log_destination.aws_iam_role.cloudwatch_to_kinesis_role will be updated in-place
  ~ resource "aws_iam_role" "cloudwatch_to_kinesis_role" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Condition = {
                          ~ StringLike = {
                              ~ "aws:SourceArn" = [
                                    # (2 unchanged elements hidden)
                                    "arn:aws:logs:eu-west-1:299497370133:*",
                                  + "arn:aws:logs:eu-west-1:404315009621:*",
                                    "arn:aws:logs:eu-west-1:653428163053:*",
                                    # (4 unchanged elements hidden)
                                ]
                            }
                        }
                      - Sid       = ""
                        # (3 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        id                    = "elasticsearch-forwarder-logs-role"
        name                  = "elasticsearch-forwarder-logs-role"
        tags                  = {}
        # (11 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

```