### PR TITLE
Fix logging cluster ILM policies

### DIFF
--- a/critical/elastic_logging_cluster.tf
+++ b/critical/elastic_logging_cluster.tf
@@ -191,6 +191,7 @@ resource "elasticstack_elasticsearch_index_lifecycle" "apm_traces" {
 
   delete {
     min_age = "1d"
+    delete {}
   }
 }
 
@@ -207,6 +208,7 @@ resource "elasticstack_elasticsearch_index_lifecycle" "apm_traces_rum" {
 
   delete {
     min_age = "1d"
+    delete {}
   }
 }
 


### PR DESCRIPTION
## What's changing and why?

This modifies the `delete` policy on APM trace indices to make sure they get deleted 1 day after rollover. See [this thread](https://wellcome.slack.com/archives/C02ANCYL90E/p1721917048277189) for more info

## `terraform plan` diff
```tf
Terraform will perform the following actions:

  # elasticstack_elasticsearch_index_lifecycle.apm_traces will be updated in-place
  ~ resource "elasticstack_elasticsearch_index_lifecycle" "apm_traces" {
        id            = "J6V5gvONTve393_OJiiJnA/weco-traces-apm"
        name          = "weco-traces-apm"
        # (1 unchanged attribute hidden)

      ~ delete {
            # (1 unchanged attribute hidden)

          + delete {
              + delete_searchable_snapshot = true
            }
        }

        # (1 unchanged block hidden)
    }

  # elasticstack_elasticsearch_index_lifecycle.apm_traces_rum will be updated in-place
  ~ resource "elasticstack_elasticsearch_index_lifecycle" "apm_traces_rum" {
        id            = "J6V5gvONTve393_OJiiJnA/weco-traces-apm-rum"
        name          = "weco-traces-apm-rum"
        # (1 unchanged attribute hidden)

      ~ delete {
            # (1 unchanged attribute hidden)

          + delete {
              + delete_searchable_snapshot = true
            }
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.

```
