### PR TITLE
increased memory from 128 (default) to 256

### DIFF
--- a/cloudfront/api.wellcomecollection.org/.terraform.lock.hcl
+++ b/cloudfront/api.wellcomecollection.org/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/archive" {
   version = "2.3.0"
   hashes = [
+    "h1:NaDbOqAcA9d8DiAS5/6+5smXwN3/+twJGb3QRiz6pNw=",
     "h1:pTPG9Kf1Qg2aPsZLXDa6OvLqsEXaMrKnp0Z4Q/TIBPA=",
     "zh:0869128d13abe12b297b0cd13b8767f10d6bf047f5afc4215615aabc39c2eb4f",
     "zh:481ed837d63ba3aa45dd8736da83e911e3509dee0e7961bf5c00ed2644f807b3",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "4.59.0"
   hashes = [
     "h1:irUD0Fq6r6y9l03z1rza6Vv70iTt6OdvKS9wJF4QajE=",
+    "h1:uBpb5w197ACmg0JGuouIR8Dzbtg7V9OxcsabBZ8JxgQ=",
     "zh:0341a460210463a0bebd5c12ce13dc49bd8cae2399b215418c5efa607fed84e4",
     "zh:0544e9bbdd31d3551e7273bed7326d26a28653fd9c26b5cd06ac8ed76f188798",
     "zh:3d13acd0363f0a48d2725cae9d224481df38dddb90ef4a66eb82303f0aa45a99",

--- a/cloudfront/api.wellcomecollection.org/lambda/lambda_function.tf
+++ b/cloudfront/api.wellcomecollection.org/lambda/lambda_function.tf
@@ -16,7 +16,7 @@ resource "aws_lambda_function" "lambda_function" {
   runtime = var.runtime
   timeout = var.timeout
 
-  memory_size = 256
+  memory_size = var.memory_size
 
   dead_letter_config {
     target_arn = aws_sqs_queue.lambda_dlq.arn

--- a/cloudfront/api.wellcomecollection.org/lambda/lambda_function.tf
+++ b/cloudfront/api.wellcomecollection.org/lambda/lambda_function.tf
@@ -16,7 +16,7 @@ resource "aws_lambda_function" "lambda_function" {
   runtime = var.runtime
   timeout = var.timeout
 
-  memory_size = var.memory_size
+  memory_size = 256
 
   dead_letter_config {
     target_arn = aws_sqs_queue.lambda_dlq.arn

--- a/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.tf
+++ b/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.tf
@@ -19,6 +19,8 @@ module "slack_alerts_for_5xx" {
   # Note: we used to specify a 30 second timeout here, but occasionally
   # the Lambda would error if there were lots of log events.
   timeout = 300
+
+  memory_size = 256
 }
 
 data "aws_secretsmanager_secret_version" "slack_webhook" {


### PR DESCRIPTION
## What's changing and why?

Memory increased from 128 (default var) to 256 as per #443 

## `terraform plan` diff
```
Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  ~ update in-place
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # aws_iam_role_policy.allow_s3_read must be replaced
-/+ resource "aws_iam_role_policy" "allow_s3_read" {
      ~ id          = "lambda_send_slack_alert_for_5xx_errors:terraform-20230321122311397500000001" -> (known after apply)
      ~ name        = "terraform-20230321122311397500000001" -> (known after apply)
      - name_prefix = "terraform-" -> null # forces replacement
        # (2 unchanged attributes hidden)
    }

  # module.slack_alerts_for_5xx.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "send_slack_alert_for_5xx_errors"
      ~ last_modified                  = "2024-07-19T08:22:17.000+0000" -> (known after apply)
      ~ memory_size                    = 128 -> 256
      ~ source_code_hash               = "jsduuStdqBOd39Sw6YQfq1KAsEy5OzA2f4gZUEfxUdI=" -> "Muyhd941OhW1yIHHSbtKNyrHywvymTj0LntBt9NxVsE="
        tags                           = {}
        # (25 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

Plan: 1 to add, 1 to change, 1 to destroy.
```
