### PR TITLE
Remove request body restrictions from IIIF API WAF

### DIFF
--- a/cloudfront/iiif.wellcomecollection.org/terraform/waf/main.tf
+++ b/cloudfront/iiif.wellcomecollection.org/terraform/waf/main.tf
@@ -93,6 +93,16 @@ resource "aws_wafv2_web_acl" "acl" {
             allow {}
           }
         }
+
+        rule_action_override {
+          // Overriding this rule as it the IIIF dashboard sometimes requires POSTing a request
+          // with a large body, which is blocked by this rule.
+          name = "SizeRestrictions_BODY"
+
+          action_to_use {
+            allow {}
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## What's changing and why?

This change removes the request body size rules in the IIIF WAF to allow large POST requests required for the IIIF dashboard to succeed. It is probably largely non-impactful as we don't see this as an issue via the WAF at the moment.

See: https://wellcome.slack.com/archives/CBT40CMKQ/p1723718811584909