### PR TITLE
Add Sectigo CNAME record for wellcomecollection.org

### DIFF
--- a/cloudfront/wellcomecollection.org/terraform/main.tf
+++ b/cloudfront/wellcomecollection.org/terraform/main.tf
@@ -18,6 +18,10 @@ locals {
 
     # Atlassion Statuspage (https://wellcomecollection.statuspage.io/)
     "status.wellcomecollection.org" = "qyhn8w55666p.stspg-customer.com"
+
+    # Sectigo domain name validation records
+    # Sent by Flavio V 29 October 2024
+    "_0dc4e7168ed7814510307bb24b6f7418.wellcomecollection.org" = "699a0e70174c47ab5faaf2993303e2ad.962cb5fa70ca907c6d976adbedfe809a.sectigo.com"
   }
 
   # Subdomains that should be redirected to wellcomecollection.org


### PR DESCRIPTION
> [!Note]
> This terraform change change is applied.

## What does this change?

For https://github.com/wellcomecollection/platform/issues/5814

Adds a DNS record used for validation for Sectigo a certificate validation platform used by NCW (Cloud Team).

### `terraform plan`

```
Terraform will perform the following actions:

  # aws_route53_record.subdomains["_0dc4e7168ed7814510307bb24b6f7418.wellcomecollection.org"] will be created
  + resource "aws_route53_record" "subdomains" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "_0dc4e7168ed7814510307bb24b6f7418.wellcomecollection.org"
      + records         = [
          + "699a0e70174c47ab5faaf2993303e2ad.962cb5fa70ca907c6d976adbedfe809a.sectigo.com",
        ]
      + ttl             = 300
      + type            = "CNAME"
      + zone_id         = "Z0902614YH73JBCZG1MA"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

## How to test

- [ ] Run the terraform, does the CNAME record get created?

## How can we measure success?

Happy NCW team with no red lights on their dashboard.

## Have we considered potential risks?

Minimal, we are adding a new CNAME record, not making any modifications.
