### PR TITLE
Add VPCE for developer vpc to allow communication with Elastic Cloud

### DIFF
--- a/critical/elastic_logging_cluster.tf
+++ b/critical/elastic_logging_cluster.tf
@@ -63,6 +63,7 @@ resource "ec_deployment" "logging" {
   traffic_filter = [
     ec_deployment_traffic_filter.public_internet.id,
     module.platform_privatelink.traffic_filter_vpce_id,
+    module.developer_privatelink.traffic_filter_vpce_id,
     module.catalogue_privatelink.traffic_filter_vpce_id,
     module.storage_privatelink.traffic_filter_vpce_id,
     module.experience_privatelink.traffic_filter_vpce_id,

--- a/critical/elastic_privatelink.tf
+++ b/critical/elastic_privatelink.tf
@@ -36,6 +36,22 @@ module "platform_privatelink" {
   ec_vpce_domain = local.catalogue_pipeline_ec_vpce_domain
 }
 
+module "developer_privatelink" {
+  source = "./modules/elasticsearch_privatelink"
+
+  providers = {
+    aws = aws.platform
+  }
+
+  traffic_filter_name = "ec_allow_vpc_endpoint"
+
+  vpc_id     = local.platform_vpcs["developer_vpc_id"]
+  subnet_ids = local.platform_vpcs["developer_vpc_private_subnets"]
+
+  service_name   = local.ec_eu_west_1_service_name
+  ec_vpce_domain = local.catalogue_pipeline_ec_vpce_domain
+}
+
 module "monitoring_privatelink" {
   source = "./modules/elasticsearch_privatelink"
 

--- a/critical/outputs.tf
+++ b/critical/outputs.tf
@@ -117,6 +117,10 @@ output "ec_platform_privatelink_sg_id" {
   value = module.platform_privatelink.security_group_id
 }
 
+output "ec_developer_privatelink_sg_id" {
+  value = module.developer_privatelink.security_group_id
+}
+
 output "ec_catalogue_privatelink_sg_id" {
   value = module.catalogue_privatelink.security_group_id
 }
@@ -154,6 +158,10 @@ output "ec_monitoring_privatelink_sg_id" {
 }
 
 output "ec_platform_privatelink_traffic_filter_id" {
+  value = module.platform_privatelink.traffic_filter_vpce_id
+}
+
+output "ec_developer_privatelink_traffic_filter_id" {
   value = module.platform_privatelink.traffic_filter_vpce_id
 }
 


### PR DESCRIPTION
## What does this change?

For https://github.com/wellcomecollection/catalogue-graph/pull/21

This change adds a VPCE for developer vpc to allow communication with Elastic Cloud, so ECS tasks can send logs.

## How to test

- [ ] Send some logs from an ECS task in the developer VPC, do they show up?

## How can we measure success?

Log visibility!

## Have we considered potential risks?

This allows tasks running in the developer VPC to talk to elasticsearch over a privatelink endpoint, but they can at the moment also talk over the public internet, so risk is minimal.
