### PR TITLE
Provision large accession backup S3 bucket

### DIFF
--- a/assets/.terraform.lock.hcl
+++ b/assets/.terraform.lock.hcl
@@ -2,8 +2,23 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "2.70.0"
+  version = "5.99.0"
   hashes = [
-    "h1:mM6eIaG1Gcrk47TveViXBO9YjY6nDaGukbED2bdo8Mk=",
+    "h1:NvZWIp27M05/XvHX7/XTwnrfa83f9HgMWb/HhXq67qM=",
+    "zh:05b7ceebcddeca5e90d8e24c4469d39dddc41033297f6207569ea0b01a998df4",
+    "zh:0810e63b51fdce6063abd1050f673db244d5875d53fc9cf6434458547b2121d3",
+    "zh:236f55ba27d22a0a6bf812f0a46948d0f684200aec668cdc033a3756972a70e1",
+    "zh:3c21641e0a0abc6f095db494df7376cdc9379e7de80bb4d0d4be21dfcc364e0c",
+    "zh:4639560578e89ba9bef8495f5c16811db000f13a250feaef60ec406056bbe270",
+    "zh:7a4d6be98994cd397184a20709af8b8fca76300b3ca3438a1f44a9196e44fb19",
+    "zh:8173d2e11420e64c0bba1cc1a6a6d1bfb439c1d28cdee18f5c1749b54230691b",
+    "zh:95986c0d0ecd4cd9056407f76f0b74d8f96edec3cfb6fa93c426aeade624aff9",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:aaf9d1bc1ce8d4fd21fca92881503c4c179196b0e72688df1881e4a4db4e76c7",
+    "zh:ac8e1fb974569f0c5fdc09f5991fb8b0e79ccf4086799bf64715317f3a27a7fd",
+    "zh:baf2d4248143b1e05224db724e8f538cdf3683d280b783768a616c7db72499ba",
+    "zh:d1a6a78dd00023e81f144d244a35b66a275518c4fcdf66e748927a47500a3b34",
+    "zh:d77fc7e17730eb40cde656e67fc206e9d7ca2a346d9e1819e6f3bd71289207e2",
+    "zh:ee0abbe85346250d849ad8c0eca4e4392c7945b05ccb97af452f4aa3742e017f",
   ]
 }

--- a/assets/s3_largeaccession_temp.tf
+++ b/assets/s3_largeaccession_temp.tf
@@ -1,0 +1,94 @@
+resource "aws_s3_bucket" "large_accession_temp" {
+  bucket = "wellcomecollection-assets-largeaccessiontemp"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = local.default_tags
+}
+
+# Enable versioning on the bucket
+resource "aws_s3_bucket_versioning" "large_accession_temp" {
+  bucket = aws_s3_bucket.large_accession_temp.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "large_accession_temp" {
+  bucket = aws_s3_bucket.large_accession_temp.id
+
+  # Transition all objects to Glacier Instant Retrieval storage class immediately
+  rule {
+    id = "transition_all_to_glacier_instant"
+
+    transition {
+      days          = 0
+      storage_class = "GLACIER_IR"
+    }
+
+    status = "Enabled"
+  }
+
+  # Delete non-current versions after 30 days
+  rule {
+    id = "delete_non_current_versions_after_30_days"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+
+    status = "Enabled"
+  }
+}
+
+# Provision an IAM user for cataloguers to access the large accession temp bucket
+resource "aws_iam_user" "cataloguers_large_accession_temp" {
+  name = "cataloguers_large_accession_temp"
+
+  tags = local.default_tags
+}
+
+# Allow access for sync, but prevent deletion of non-current versions
+data "aws_iam_policy_document" "allow_large_accession_temp_access" {
+  statement {
+    sid    = "AllowAllS3ActionsInsideBucket"
+    effect = "Allow"
+    actions = [
+      "s3:*",
+    ]
+    resources = [
+      "arn:aws:s3:::wellcomecollection-assets-largeaccessiontemp/*", # For object-level actions
+    ]
+  }
+
+  statement {
+    sid    = "DenyPermanentDeletionOfObjectVersions"
+    effect = "Deny"
+    actions = [
+      "s3:DeleteObjectVersion",
+    ]
+    resources = [
+      "arn:aws:s3:::wellcomecollection-assets-largeaccessiontemp/*", # This action applies to objects
+    ]
+  }
+
+  statement {
+    sid    = "AllowGetS3ActionsOnBucket"
+    effect = "Allow"
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+    resources = [
+      "arn:aws:s3:::wellcomecollection-assets-largeaccessiontemp", # For bucket-level actions
+    ]
+  }
+}
+
+resource "aws_iam_user_policy" "cataloguers_large_accession_temp" {
+  user   = aws_iam_user.cataloguers_large_accession_temp.name
+  policy = data.aws_iam_policy_document.allow_large_accession_temp_access.json
+}

--- a/assets/s3_workingstorage.tf
+++ b/assets/s3_workingstorage.tf
@@ -140,3 +140,11 @@ data "aws_iam_policy_document" "working_storage" {
     ]
   }
 }
+
+resource "aws_s3_bucket_ownership_controls" "working_storage" {
+  bucket = "wellcomecollection-assets-workingstorage"
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}


### PR DESCRIPTION
## What does this change?

This change provisions an S3 bucket to assist in an ongoing accession of a large volume of digital assets for a recently acquired accession. The volume of data is too large to reasonably go via the usual "born digital accession" route where data pre-cataloguing is held in the storage service and processed via Archivematica while it awaits re-ingestion with cataloguing information.

The volume of data expected is ~10TB.

This S3 bucket serves as a temporary backup for on-premise data while cataloguing proceeds using a locally held copy.

The lifecycle rules here will transition all data meeting the 128KB size requirement to Glacier Instant Access immediately (or within a single day, accounting for rule evaluation intervals), to reduce costs. The bucket is versioned and non-current objects are kept for 30 days as an extra means of protecting against deletion.

To prevent accidental deletions no access for cataloguers will be provisioned unless required in the future, and a temporary IAM user has been created to facilitate on-premise uploads.

## How to test

- [ ] Apply the terraform, is the bucket created as expected?
- [ ] Create an access key for the provisioned user, can those credentials perform `s3 sync`, but not other destructive actions?

## How can we measure success?

Accession data is backed up with relatively low cost for a medium term period (6 months to a year) while cataloguing proceeds. If there is an issue with accidental deletion or modification of data it can be restored quickly from this bucket.

## Have we considered potential risks?

Potential misconfiguration could lead to data-loss or unexpected cost, we should ensure that any sync operations proceed to completion and that objects are transitioned to the expected Glacier tier.
