### PR TITLE
add threshold to slack alerter

### DIFF
--- a/cloudfront/api.wellcomecollection.org/.terraform.lock.hcl
+++ b/cloudfront/api.wellcomecollection.org/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/archive" {
   version = "2.6.0"
   hashes = [
+    "h1:Ou6XKWvpo7IYgZnrFJs5MKzMqQMEYv8Z2iHSJ2mmnFw=",
     "h1:upAbF0KeKLAs3UImwwp5veC7jRcLnpKWVjkbd4ziWhM=",
     "zh:29273484f7423b7c5b3f5df34ccfc53e52bb5e3d7f46a81b65908e7a8fd69072",
     "zh:3cba58ec3aea5f301caf2acc31e184c55d994cc648126cac39c63ae509a14179",
@@ -23,6 +24,7 @@ provider "registry.terraform.io/hashicorp/archive" {
 provider "registry.terraform.io/hashicorp/aws" {
   version = "5.79.0"
   hashes = [
+    "h1:VIIcae7BNc1eYKWb5WsZ+QKpFHbDN1kBdfgRRRtiIIY=",
     "h1:tWd63H8jMJHdsuwg3hkviz/b8OyL/gBogmXRA5kYb9A=",
     "zh:008b605b7b6dcde4eb86759f54a36db731f94649f780738c6918ef3826eb064f",
     "zh:08c1dd9a2b4b0d45356fc2124ac292aa549aab9053e33e240dd322700082c132",

--- a/cloudfront/api.wellcomecollection.org/Dockerfile.rie-5xx-reporter
+++ b/cloudfront/api.wellcomecollection.org/Dockerfile.rie-5xx-reporter
@@ -1,0 +1,17 @@
+FROM public.ecr.aws/lambda/nodejs:20
+
+# Install aws-lambda-rie for local testing
+ADD https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie /usr/local/bin/aws-lambda-rie
+RUN chmod +x /usr/local/bin/aws-lambda-rie
+
+# Copy the handler file
+COPY send_slack_alert_for_5xx_errors.js ./
+
+# Set the Lambda handler (filename.handlerFunction)
+# Replace 'handler' with the actual exported function name if different
+ENV _HANDLER=send_slack_alert_for_5xx_errors.handler
+
+# Set entrypoint for local testing with RIE
+ENTRYPOINT ["/usr/local/bin/aws-lambda-rie", "/var/runtime/bootstrap"]
+
+# Command is not needed; Lambda runtime will use _HANDLER

--- a/cloudfront/api.wellcomecollection.org/README.md
+++ b/cloudfront/api.wellcomecollection.org/README.md
@@ -1,0 +1,26 @@
+# Slack alerter for CloudFront logs from the API
+
+The Slack alerter monitors CloudFront logs for 5xx responses from the API distribution
+and sends a Slack alert if the percentage of _interesting_ 5xx responses exceeds a given threshold.
+
+Interesting 5xx responses are defined as those that are not from known bots or health checks.
+## Testing the slack alerter for CloudFront
+
+You can run a local version of the slack alerter by running the following command from this directory:
+
+```bash
+docker build . -f Dockerfile.rie-5xx-reporter -t send-slack-test
+docker run -p 9000:8080 -v ~/.aws:/root/.aws -e AWS_PROFILE=platform-developer -e THRESHOLD_PERCENT=0.1 -e WEBHOOK_URL=example.com send-slack-test 
+```
+
+You will need to be logged in to AWS with a profile that has permission to read the logs from s3.
+You can then send a test request to the local server thus:
+
+```bash
+sh post-to-rie.sh api.wellcomecollection.org/EIF11EK4Z5JS8.2026-01-08-12.9690b66d.gz
+```
+
+The argument is the path to a CloudFront log file in s3. You can find recent log files in the `wellcomecollection-api-logs` bucket.
+
+
+This allows you to try out any changes to filtering or thresholds against real data before deploying them to Lambda.

--- a/cloudfront/api.wellcomecollection.org/README.md
+++ b/cloudfront/api.wellcomecollection.org/README.md
@@ -20,7 +20,7 @@ You can then send a test request to the local server thus:
 sh post-to-rie.sh api.wellcomecollection.org/EIF11EK4Z5JS8.2026-01-08-12.9690b66d.gz
 ```
 
-The argument is the path to a CloudFront log file in s3. You can find recent log files in the `wellcomecollection-api-logs` bucket.
+The argument is the path to a CloudFront log file in s3. You can find recent log files in the `wellcomecollection-api-cloudfront-logs` bucket.
 
 
 This allows you to try out any changes to filtering or thresholds against real data before deploying them to Lambda.

--- a/cloudfront/api.wellcomecollection.org/post-to-rie.sh
+++ b/cloudfront/api.wellcomecollection.org/post-to-rie.sh
@@ -1,0 +1,20 @@
+curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" \
+  -d '{
+  "Records": [
+    {
+      "eventVersion": "2.1",
+      "eventSource": "aws:s3",
+      "awsRegion": "eu-west-1",
+      "eventTime": "2024-06-01T12:00:00.000Z",
+      "eventName": "ObjectCreated:Put",
+      "s3": {
+        "bucket": {
+          "name": "wellcomecollection-api-cloudfront-logs"
+        },
+        "object": {
+          "key": "'${1}'"
+        }
+      }
+    }
+  ]
+}'

--- a/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.js
+++ b/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.js
@@ -187,18 +187,16 @@ async function sendSlackMessage(bucket, key, region, serverErrors, hits, lines) 
 
   const webhookUrl = process.env.WEBHOOK_URL;
   if (webhookUrl === "example.com") {
-  	// If it's example.com, the caller has explicitly indicated they don't
- 	// want to send a Slack message (e.g. in a test environment).
-  	console.info("dummy WEBHOOK_URL set, skipping Slack message");
-  	console.info(JSON.stringify(slackPayload));
-  }
-  else {
- 	// Any other URL, including an empty one, is treated as a real webhook.
- 	// If it's empty or invalid, the post() function will fail noisily.
-	  await post(webhookUrl, slackPayload);
+    // If it's example.com, the caller has explicitly indicated they don't
+    // want to send a Slack message (e.g. in a test environment).
+    console.info("dummy WEBHOOK_URL set, skipping Slack message");
+    console.info(JSON.stringify(slackPayload));
+  } else {
+    // Any other URL, including an empty one, is treated as a real webhook.
+    // If it's empty or invalid, the post() function will fail noisily.
+    await post(webhookUrl, slackPayload);
   }
 }
-
 function createDisplayUrl(protocol, host, path, query) {
   if (query === null) {
     return `${protocol}://${host}${path}`;

--- a/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.js
+++ b/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.js
@@ -329,8 +329,10 @@ exports.handler = async event => {
     console.info(
       `Inspecting CloudFront logs for s3://${s3Object.bucket}/${s3Object.key}`
     );
-    const thresholdPercent = process.env.THRESHOLD_PERCENT;
-
+    const thresholdPercent = parseFloat(process.env.THRESHOLD_PERCENT);
+	if (isNaN(thresholdPercent)){
+	  throw new Error(`Invalid THRESHOLD_PERCENT: ${process.env.THRESHOLD_PERCENT}`);
+	}
     const hits = await findCloudFrontHitsFromLog(s3Object.bucket, s3Object.key, s3Object.region);
     const serverErrors = hits.filter(isError);
     const interestingErrors = serverErrors.filter(isInterestingError);

--- a/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.js
+++ b/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.js
@@ -353,17 +353,17 @@ exports.handler = async event => {
         `Detected ${serverErrors.length} error(s) in this log file, but nothing interesting, nothing to do`
       );
     } else if (interestingErrorsPercent < threshold_percent) {
-		// The percentage of interesting errors is below the threshold,
-		// we log them so we don't have to filter the source logs to find them
-		// later, but we don't send a Slack message.
-	    // The occasional ephemeral error is inevitable, so we don't alert if there are only a few in
-	    // relation to total requests.
+      // The percentage of interesting errors is below the threshold,
+      // we log them so we don't have to filter the source logs to find them
+      // later, but we don't send a Slack message.
+      // The occasional ephemeral error is inevitable, so we don't alert if there are only a few in
+      // relation to total requests.
       console.info(
-		`Detected ${serverErrors.length} error(s) (${total_interestingErrors} of which may be interesting) (${interestingErrorsPercent}% < ${threshold_percent}% of ${total_hits} requests), nothing to do`
-	  );
+        `Detected ${serverErrors.length} error(s) (${total_interestingErrors} of which may be interesting) (${interestingErrorsPercent}% < ${threshold_percent}% of ${total_hits} requests), nothing to do`
+      );
       console.info(
-		`Potentially interesting errors: ` + lines.join(' ')
-	  );
+        `Potentially interesting errors: ` + lines.join(' ')
+      );
     }
      else {
       // Errors are becoming more common now, this is indicative of something we should investigate immediately.

--- a/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.js
+++ b/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.js
@@ -187,10 +187,14 @@ async function sendSlackMessage(bucket, key, region, serverErrors, hits, lines) 
 
   const webhookUrl = process.env.WEBHOOK_URL;
   if (webhookUrl == "example.com") {
+  	// If it's example.com, the caller has explicitly indicated they don't
+ 	// want to send a Slack message (e.g. in a test environment).
   	console.info("dummy WEBHOOK_URL set, skipping Slack message");
   	console.info(JSON.stringify(slackPayload));
   }
   else {
+ 	// Any other URL, including an empty one, is treated as a real webhook.
+ 	// If it's empty or invalid, the post() function will fail noisily.
 	  await post(webhookUrl, slackPayload);
   }
 }
@@ -349,7 +353,11 @@ exports.handler = async event => {
         `Detected ${serverErrors.length} error(s) in this log file, but nothing interesting, nothing to do`
       );
     } else if (interestingErrorsPercent < threshold_percent) {
-
+		// The percentage of interesting errors is below the threshold,
+		// we log them so we don't have to filter the source logs to find them
+		// later, but we don't send a Slack message.
+	    // The occasional ephemeral error is inevitable, so we don't alert if there are only a few in
+	    // relation to total requests.
       console.info(
 		`Detected ${serverErrors.length} error(s) (${total_interestingErrors} of which may be interesting) (${interestingErrorsPercent}% < ${threshold_percent}% of ${total_hits} requests), nothing to do`
 	  );
@@ -358,6 +366,8 @@ exports.handler = async event => {
 	  );
     }
      else {
+      // Errors are becoming more common now, this is indicative of something we should investigate immediately.
+      // so send a Slack message.
       console.info(
         `Detected ${serverErrors.length} error(s) (${total_interestingErrors} of which may be interesting) (${interestingErrorsPercent}% > ${threshold_percent}% of ${total_hits} requests), sending message to Slack`
       );

--- a/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.js
+++ b/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.js
@@ -338,7 +338,9 @@ exports.handler = async event => {
     const interestingErrors = serverErrors.filter(isInterestingError);
 	const total_hits = hits.length;
 	const total_interestingErrors = interestingErrors.length;
-	const interestingErrorsPercent = ((total_interestingErrors/total_hits)*100).toFixed(2);
+	const interestingErrorsPercent = total_hits === 0
+      ? '0.00'
+      : ((total_interestingErrors / total_hits) * 100).toFixed(2);
     const lines = interestingErrors.map(function (e) {
 	  const url = createDisplayUrl(e.protocol, e.host, e.path, e.query);
 

--- a/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.js
+++ b/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.js
@@ -186,7 +186,7 @@ async function sendSlackMessage(bucket, key, region, serverErrors, hits, lines) 
   };
 
   const webhookUrl = process.env.WEBHOOK_URL;
-  if (webhookUrl == "example.com") {
+  if (webhookUrl === "example.com") {
   	// If it's example.com, the caller has explicitly indicated they don't
  	// want to send a Slack message (e.g. in a test environment).
   	console.info("dummy WEBHOOK_URL set, skipping Slack message");

--- a/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.tf
+++ b/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.tf
@@ -9,8 +9,8 @@ module "slack_alerts_for_5xx" {
   name        = "send_slack_alert_for_5xx_errors"
 
   environment_variables = {
-    WEBHOOK_URL = data.aws_secretsmanager_secret_version.slack_webhook.secret_string
-    THRESHOLD_PERCENT   = "0.1"  # Alert if more than 0.1% of requests are 5xx
+    WEBHOOK_URL       = data.aws_secretsmanager_secret_version.slack_webhook.secret_string
+    THRESHOLD_PERCENT = "0.1" # Alert if more than 0.1% of requests are 5xx
   }
 
   # TODO: We should be able to pull this from the monitoring remote state,

--- a/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.tf
+++ b/cloudfront/api.wellcomecollection.org/send_slack_alert_for_5xx_errors.tf
@@ -10,6 +10,7 @@ module "slack_alerts_for_5xx" {
 
   environment_variables = {
     WEBHOOK_URL = data.aws_secretsmanager_secret_version.slack_webhook.secret_string
+    THRESHOLD_PERCENT   = "0.1"  # Alert if more than 0.1% of requests are 5xx
   }
 
   # TODO: We should be able to pull this from the monitoring remote state,


### PR DESCRIPTION
## What does this change?

Resolves https://github.com/wellcomecollection/platform/issues/6244

This adds a configurable percentage based threshold (set at 0.1% of the total number of hits) for the number of 5xx errors encountered in a single log file before sending a slack alert.

The list of "interesting" failed URLs is logged by the alerter when under the threshold, in case we need to examine them anyway.

This also adds a mechanism for local testing against real data

This has already been deployed and has successfully suppressed a Slack alert overnight (slightly different wording in the log text, as I changed it this morning):

> 2026-01-09T07:40:13.154Z
> 2026-01-09T07:40:13.154Z 584c8fd7-5df7-405b-bdc9-7f0caf535d30 INFO Detected 9 error(s) but only 9 interesting error(s) (<0.1% of 19628 requests), nothing to do
> 2026-01-09T07:40:13.155Z
> 2026-01-09T07:40:13.155Z 584c8fd7-5df7-405b-bdc9-7f0caf535d30 INFO interesting errors:https://api.wellcomecollection.org/catalogue/v2/works/ywnubs2c/items https://api.wellcomecollection.org/catalogue/v2/works/ft5qpg42/items https://api.wellcomecollection.org/catalogue/v2/works/ybtd283g/items https://api.wellcomecollection.org/catalogue/v2/works/q6xvutgv/items https://api.wellcomecollection.org/catalogue/v2/works/gmxbj2ht/items https://api.wellcomecollection.org/catalogue/v2/works/qsf5uxjn/items https://api.wellcomecollection.org/catalogue/v2/works/ywnubs2c/items https://api.wellcomecollection.org/catalogue/v2/works/pm64s43t/items https://api.wellcomecollection.org/catalogue/v2/works/sa7r5zjq/items


## How to test

### Locally:
Follow the instructions in the new README. `api.wellcomecollection.org/EIF11EK4Z5JS8.2026-01-08-12.9690b66d.gz` is an example of a log file with some errors (~0.05%). Look at the console output in the Docker, try out a different % threshold.

### As Lambda:
Create a test event through the Lambda console, using the JSON from post-to-rie as a template and inserting an actual log file key.

## How can we measure success?

Fewer slack alerts caused by ephemeral errors means that the bug nurse is not distracted by things that have already sorted themselves out before the alert is even posted.

Alerts will still be seen promptly when something actually starts to go wrong.

## Have we considered potential risks?

Because this hides occasional errors, we might miss out on the opportunity to modify spam filters or api behaviour to reject or sanitise dodgy requests before they become a problem.  By setting the threshold only slightly above the numbers we tend to see when there is no real problem to address, I hope that this will still allow us to catch deliberate nefarious requests promptly enough.
